### PR TITLE
[Ralph] spec-001-shared

### DIFF
--- a/packages/shared/.gitignore
+++ b/packages/shared/.gitignore
@@ -1,0 +1,4 @@
+dist/
+coverage/
+node_modules/
+*.tsbuildinfo

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@onboarding/shared",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Shared TypeScript types and zod schemas (PRD-MVP-SLIM v0.10 §6.2 D)",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./types": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/types/index.js",
+      "default": "./dist/types/index.js"
+    },
+    "./schemas": {
+      "types": "./dist/schemas/index.d.ts",
+      "import": "./dist/schemas/index.js",
+      "default": "./dist/schemas/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "test": "vitest run --coverage",
+    "lint": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@vitest/coverage-v8": "^2.1.0",
+    "typescript": "^5.5.4",
+    "vitest": "^2.1.0"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,2 @@
+export * from './types/index.js';
+export * from './schemas/index.js';

--- a/packages/shared/src/schemas/api.ts
+++ b/packages/shared/src/schemas/api.ts
@@ -1,0 +1,251 @@
+import { z } from 'zod';
+
+import {
+  CONSENT_TYPES,
+  ITEM_STATUSES,
+  VISION_CONFIDENCES,
+  VISION_VERIFY_STATUSES,
+} from '../types/index.js';
+import { VerificationSchema } from './checklist.js';
+
+// ---------------------------------------------------------------------------
+// Domain primitives reused across endpoints
+// ---------------------------------------------------------------------------
+
+export const ItemIdSchema = z.string().min(1);
+
+export const ItemStatusSchema = z.enum(ITEM_STATUSES);
+
+export const ItemStateSchema = z
+  .object({
+    item_id: ItemIdSchema,
+    status: ItemStatusSchema,
+    current_step: z.string().min(1).nullable(),
+    started_at: z.number().int().nonnegative().nullable(),
+    completed_at: z.number().int().nonnegative().nullable(),
+    attempt_count: z.number().int().nonnegative(),
+  })
+  .strict();
+
+export const HighlightRegionSchema = z
+  .object({
+    x: z.number().positive(),
+    y: z.number().positive(),
+    width: z.number().positive(),
+    height: z.number().positive(),
+  })
+  .strict();
+
+export const VisionConfidenceSchema = z.enum(VISION_CONFIDENCES);
+
+export const VisionGuideResultSchema = z
+  .object({
+    type: z.literal('guide'),
+    message: z.string().min(1),
+    highlight_region: HighlightRegionSchema.optional(),
+    confidence: VisionConfidenceSchema,
+  })
+  .strict();
+
+export const VisionVerifyStatusSchema = z.enum(VISION_VERIFY_STATUSES);
+
+export const VisionVerifyResultSchema = z
+  .object({
+    type: z.literal('verify'),
+    status: VisionVerifyStatusSchema,
+    reasoning: z.string().min(1),
+    next_action_hint: z.string().min(1).optional(),
+  })
+  .strict();
+
+export const ConsentTypeSchema = z.enum(CONSENT_TYPES);
+
+export const ConsentRecordSchema = z
+  .object({
+    consent_type: ConsentTypeSchema,
+    granted: z.boolean(),
+    granted_at: z.number().int().nonnegative().nullable(),
+    revoked_at: z.number().int().nonnegative().nullable(),
+  })
+  .strict();
+
+// ---------------------------------------------------------------------------
+// 9.1.1 GET /api/checklist
+// ---------------------------------------------------------------------------
+
+export const GetChecklistResponseSchema = z
+  .object({
+    items: z.array(ItemStateSchema),
+  })
+  .strict();
+
+// ---------------------------------------------------------------------------
+// 9.1.2 POST /api/items/:itemId/start
+// ---------------------------------------------------------------------------
+
+export const StartItemParamsSchema = z
+  .object({
+    itemId: ItemIdSchema,
+  })
+  .strict();
+
+export const StartItemResponseSchema = z
+  .object({
+    ok: z.literal(true),
+  })
+  .strict();
+
+// ---------------------------------------------------------------------------
+// 9.1.3 POST /api/vision/guide
+// ---------------------------------------------------------------------------
+
+const VisionRequestBodySchema = z
+  .object({
+    item_id: ItemIdSchema,
+    step_id: z.string().min(1),
+  })
+  .strict();
+
+export const VisionGuideRequestSchema = VisionRequestBodySchema;
+
+export const VisionGuideResponseSchema = z
+  .object({
+    call_id: z.string().min(1),
+    cached: z.boolean(),
+    latency_ms: z.number().int().nonnegative(),
+    result: VisionGuideResultSchema,
+  })
+  .strict();
+
+// ---------------------------------------------------------------------------
+// 9.1.4 POST /api/vision/verify
+// ---------------------------------------------------------------------------
+
+export const VisionVerifyRequestSchema = VisionRequestBodySchema;
+
+export const VisionVerifyResponseSchema = z
+  .object({
+    call_id: z.string().min(1),
+    cached: z.boolean().optional(),
+    latency_ms: z.number().int().nonnegative().optional(),
+    result: VisionVerifyResultSchema,
+  })
+  .strict();
+
+// ---------------------------------------------------------------------------
+// 9.1.5 GET /api/vision/rate-limit
+// ---------------------------------------------------------------------------
+
+export const RATE_LIMIT_STATES = ['normal', 'alert', 'paused'] as const;
+export const RateLimitStateSchema = z.enum(RATE_LIMIT_STATES);
+export type RateLimitState = z.infer<typeof RateLimitStateSchema>;
+
+export const RateLimitResponseSchema = z
+  .object({
+    current_hour_calls: z.number().int().nonnegative(),
+    state: RateLimitStateSchema,
+    reset_at: z.number().int().nonnegative(),
+  })
+  .strict();
+
+// ---------------------------------------------------------------------------
+// 9.1.6 POST/GET /api/consents
+// ---------------------------------------------------------------------------
+
+export const PostConsentRequestSchema = z
+  .object({
+    consent_type: ConsentTypeSchema,
+    granted: z.boolean(),
+  })
+  .strict();
+
+export const PostConsentResponseSchema = z
+  .object({
+    ok: z.literal(true),
+  })
+  .strict();
+
+export const GetConsentsResponseSchema = z
+  .object({
+    screen_recording: ConsentRecordSchema,
+    anthropic_transmission: ConsentRecordSchema,
+  })
+  .strict();
+
+// ---------------------------------------------------------------------------
+// 9.1.7 POST /api/clipboard
+// ---------------------------------------------------------------------------
+
+export const ClipboardRequestSchema = z
+  .object({
+    command: z.string().min(1),
+  })
+  .strict();
+
+export const ClipboardResponseSchema = z
+  .object({
+    ok: z.literal(true),
+  })
+  .strict();
+
+// ---------------------------------------------------------------------------
+// 9.1.8 POST /api/verify/run
+// ---------------------------------------------------------------------------
+
+export const VerifyRunRequestSchema = z
+  .object({
+    item_id: ItemIdSchema,
+    verification: VerificationSchema,
+  })
+  .strict();
+
+export const VerifyRunResponseSchema = z
+  .object({
+    status: z.enum(['pass', 'fail']),
+    details: z.string(),
+  })
+  .strict();
+
+// ---------------------------------------------------------------------------
+// Error responses (PRD §9.1.3 401/403/429/503 + general API error)
+// ---------------------------------------------------------------------------
+
+export const VISION_GUIDE_ERROR_CODES = [
+  'screen_recording_permission_required',
+  'consent_required',
+  'rate_limit_exceeded',
+  'vision_api_timeout',
+] as const;
+
+export const ScreenRecordingPermissionErrorSchema = z
+  .object({
+    error: z.literal('screen_recording_permission_required'),
+  })
+  .strict();
+
+export const ConsentRequiredErrorSchema = z
+  .object({
+    error: z.literal('consent_required'),
+  })
+  .strict();
+
+export const RateLimitExceededErrorSchema = z
+  .object({
+    error: z.literal('rate_limit_exceeded'),
+    state: z.literal('paused'),
+    reset_at: z.number().int().nonnegative(),
+  })
+  .strict();
+
+export const VisionApiTimeoutErrorSchema = z
+  .object({
+    error: z.literal('vision_api_timeout'),
+  })
+  .strict();
+
+export const VisionGuideErrorResponseSchema = z.discriminatedUnion('error', [
+  ScreenRecordingPermissionErrorSchema,
+  ConsentRequiredErrorSchema,
+  RateLimitExceededErrorSchema,
+  VisionApiTimeoutErrorSchema,
+]);

--- a/packages/shared/src/schemas/checklist.ts
+++ b/packages/shared/src/schemas/checklist.ts
@@ -1,0 +1,84 @@
+import { z } from 'zod';
+
+export const ChecklistInputSchema = z
+  .object({
+    key: z.string().min(1),
+    label: z.string().min(1),
+    required: z.boolean(),
+  })
+  .strict();
+
+export const ClipboardInjectSchema = z
+  .object({
+    command: z.string().min(1),
+    ui_hint: z.string().min(1).optional(),
+  })
+  .strict();
+
+export const CommandVerificationSchema = z
+  .object({
+    type: z.literal('command'),
+    command: z.string().min(1),
+    expect_contains: z.string().min(1).optional(),
+    poll_interval_sec: z.number().int().positive().optional(),
+  })
+  .strict();
+
+export const ProcessCheckVerificationSchema = z
+  .object({
+    type: z.literal('process_check'),
+    process_name: z.string().min(1),
+    poll_interval_sec: z.number().int().positive().optional(),
+  })
+  .strict();
+
+export const VerificationSchema = z.discriminatedUnion('type', [
+  CommandVerificationSchema,
+  ProcessCheckVerificationSchema,
+]);
+
+export const ChecklistStepSchema = z
+  .object({
+    id: z.string().min(1),
+    intent: z.string().min(1),
+    success_criteria: z.string().min(1),
+    system_panel_url: z.string().min(1).optional(),
+    common_mistakes: z.string().min(1).optional(),
+  })
+  .strict();
+
+export const AiCoachingSchema = z
+  .object({
+    overall_goal: z.string().min(1),
+    steps: z.array(ChecklistStepSchema).min(1),
+  })
+  .strict();
+
+export const TemplateSchema = z
+  .object({
+    content: z.string().min(1),
+    paste_target: z.string().min(1),
+  })
+  .strict();
+
+export const ChecklistItemSchema = z
+  .object({
+    id: z.string().min(1),
+    title: z.string().min(1),
+    estimated_minutes: z.number().int().positive(),
+    inputs: z.array(ChecklistInputSchema).optional(),
+    clipboard_inject: ClipboardInjectSchema.optional(),
+    ai_coaching: AiCoachingSchema.optional(),
+    template: TemplateSchema.optional(),
+    verification: VerificationSchema.optional(),
+    system_panel_url: z.string().min(1).optional(),
+  })
+  .strict();
+
+export const ChecklistFileSchema = z
+  .object({
+    version: z.number().int().positive(),
+    schema: z.string().min(1),
+    items: z.array(ChecklistItemSchema).min(1),
+  })
+  .strict();

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -1,0 +1,2 @@
+export * from './api.js';
+export * from './checklist.js';

--- a/packages/shared/src/types/checklist.ts
+++ b/packages/shared/src/types/checklist.ts
@@ -1,0 +1,61 @@
+export interface ChecklistInput {
+  key: string;
+  label: string;
+  required: boolean;
+}
+
+export interface ClipboardInject {
+  command: string;
+  ui_hint?: string;
+}
+
+export interface CommandVerification {
+  type: 'command';
+  command: string;
+  expect_contains?: string;
+  poll_interval_sec?: number;
+}
+
+export interface ProcessCheckVerification {
+  type: 'process_check';
+  process_name: string;
+  poll_interval_sec?: number;
+}
+
+export type Verification = CommandVerification | ProcessCheckVerification;
+
+export interface ChecklistStep {
+  id: string;
+  intent: string;
+  success_criteria: string;
+  system_panel_url?: string;
+  common_mistakes?: string;
+}
+
+export interface AiCoaching {
+  overall_goal: string;
+  steps: ChecklistStep[];
+}
+
+export interface Template {
+  content: string;
+  paste_target: string;
+}
+
+export interface ChecklistItem {
+  id: string;
+  title: string;
+  estimated_minutes: number;
+  inputs?: ChecklistInput[];
+  clipboard_inject?: ClipboardInject;
+  ai_coaching?: AiCoaching;
+  template?: Template;
+  verification?: Verification;
+  system_panel_url?: string;
+}
+
+export interface ChecklistFile {
+  version: number;
+  schema: string;
+  items: ChecklistItem[];
+}

--- a/packages/shared/src/types/consent.ts
+++ b/packages/shared/src/types/consent.ts
@@ -1,0 +1,13 @@
+export const CONSENT_TYPES = [
+  'screen_recording',
+  'anthropic_transmission',
+] as const;
+
+export type ConsentType = (typeof CONSENT_TYPES)[number];
+
+export interface ConsentRecord {
+  consent_type: ConsentType;
+  granted: boolean;
+  granted_at: number | null;
+  revoked_at: number | null;
+}

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -1,0 +1,4 @@
+export * from './item.js';
+export * from './vision.js';
+export * from './consent.js';
+export * from './checklist.js';

--- a/packages/shared/src/types/item.ts
+++ b/packages/shared/src/types/item.ts
@@ -1,0 +1,20 @@
+export type ItemId = string;
+
+export const ITEM_STATUSES = [
+  'pending',
+  'in_progress',
+  'completed',
+  'skipped',
+  'blocked',
+] as const;
+
+export type ItemStatus = (typeof ITEM_STATUSES)[number];
+
+export interface ItemState {
+  item_id: ItemId;
+  status: ItemStatus;
+  current_step: string | null;
+  started_at: number | null;
+  completed_at: number | null;
+  attempt_count: number;
+}

--- a/packages/shared/src/types/vision.ts
+++ b/packages/shared/src/types/vision.ts
@@ -1,0 +1,26 @@
+export interface HighlightRegion {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export const VISION_CONFIDENCES = ['low', 'medium', 'high'] as const;
+export type VisionConfidence = (typeof VISION_CONFIDENCES)[number];
+
+export interface VisionGuideResult {
+  type: 'guide';
+  message: string;
+  highlight_region?: HighlightRegion;
+  confidence: VisionConfidence;
+}
+
+export const VISION_VERIFY_STATUSES = ['pass', 'fail', 'unclear'] as const;
+export type VisionVerifyStatus = (typeof VISION_VERIFY_STATUSES)[number];
+
+export interface VisionVerifyResult {
+  type: 'verify';
+  status: VisionVerifyStatus;
+  reasoning: string;
+  next_action_hint?: string;
+}

--- a/packages/shared/tests/api.schemas.test.ts
+++ b/packages/shared/tests/api.schemas.test.ts
@@ -1,0 +1,397 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ClipboardRequestSchema,
+  ClipboardResponseSchema,
+  ConsentRecordSchema,
+  GetChecklistResponseSchema,
+  GetConsentsResponseSchema,
+  HighlightRegionSchema,
+  ItemStateSchema,
+  PostConsentRequestSchema,
+  PostConsentResponseSchema,
+  RateLimitResponseSchema,
+  StartItemParamsSchema,
+  StartItemResponseSchema,
+  VerifyRunRequestSchema,
+  VerifyRunResponseSchema,
+  VisionGuideErrorResponseSchema,
+  VisionGuideRequestSchema,
+  VisionGuideResponseSchema,
+  VisionGuideResultSchema,
+  VisionVerifyRequestSchema,
+  VisionVerifyResponseSchema,
+  VisionVerifyResultSchema,
+} from '../src/schemas/api.js';
+
+function roundTrip<T>(schema: { parse: (v: unknown) => T }, value: unknown): T {
+  const parsed = schema.parse(value);
+  const reparsed = schema.parse(JSON.parse(JSON.stringify(parsed)));
+  expect(reparsed).toEqual(parsed);
+  return parsed;
+}
+
+describe('HighlightRegionSchema (spec AC: 4 fields, reject negative/zero)', () => {
+  it('accepts strictly positive {x,y,width,height} round-trip', () => {
+    const region = { x: 24, y: 480, width: 32, height: 32 };
+    const parsed = roundTrip(HighlightRegionSchema, region);
+    expect(parsed).toEqual(region);
+  });
+
+  it.each([
+    { x: 0, y: 1, width: 1, height: 1 },
+    { x: 1, y: 0, width: 1, height: 1 },
+    { x: 1, y: 1, width: 0, height: 1 },
+    { x: 1, y: 1, width: 1, height: 0 },
+  ])('rejects zero in any dimension (%o)', (region) => {
+    expect(() => HighlightRegionSchema.parse(region)).toThrow();
+  });
+
+  it.each([
+    { x: -1, y: 1, width: 1, height: 1 },
+    { x: 1, y: -1, width: 1, height: 1 },
+    { x: 1, y: 1, width: -1, height: 1 },
+    { x: 1, y: 1, width: 1, height: -1 },
+  ])('rejects negative values in any dimension (%o)', (region) => {
+    expect(() => HighlightRegionSchema.parse(region)).toThrow();
+  });
+
+  it('rejects extra fields', () => {
+    expect(() =>
+      HighlightRegionSchema.parse({ x: 1, y: 1, width: 1, height: 1, extra: 0 }),
+    ).toThrow();
+  });
+
+  it('rejects non-number fields', () => {
+    expect(() =>
+      HighlightRegionSchema.parse({ x: '1', y: 1, width: 1, height: 1 }),
+    ).toThrow();
+  });
+});
+
+describe('ItemStateSchema (PRD §8.1 item_states 1:1)', () => {
+  it('round-trips a fully populated record', () => {
+    const v = {
+      item_id: 'install-homebrew',
+      status: 'in_progress',
+      current_step: 'install',
+      started_at: 1_700_000_000,
+      completed_at: null,
+      attempt_count: 2,
+    };
+    expect(roundTrip(ItemStateSchema, v)).toEqual(v);
+  });
+
+  it('accepts all PRD-defined statuses', () => {
+    for (const status of ['pending', 'in_progress', 'completed', 'skipped', 'blocked']) {
+      expect(() =>
+        ItemStateSchema.parse({
+          item_id: 'x',
+          status,
+          current_step: null,
+          started_at: null,
+          completed_at: null,
+          attempt_count: 0,
+        }),
+      ).not.toThrow();
+    }
+  });
+
+  it('rejects an unknown status', () => {
+    expect(() =>
+      ItemStateSchema.parse({
+        item_id: 'x',
+        status: 'mystery',
+        current_step: null,
+        started_at: null,
+        completed_at: null,
+        attempt_count: 0,
+      }),
+    ).toThrow();
+  });
+
+  it('rejects negative attempt_count', () => {
+    expect(() =>
+      ItemStateSchema.parse({
+        item_id: 'x',
+        status: 'pending',
+        current_step: null,
+        started_at: null,
+        completed_at: null,
+        attempt_count: -1,
+      }),
+    ).toThrow();
+  });
+});
+
+describe('VisionGuideResultSchema (PRD §9.1.3 result)', () => {
+  it('round-trips a result with highlight_region', () => {
+    const v = {
+      type: 'guide',
+      message: '화면 좌측 잠금 아이콘을 클릭하세요',
+      highlight_region: { x: 24, y: 480, width: 32, height: 32 },
+      confidence: 'high',
+    };
+    expect(roundTrip(VisionGuideResultSchema, v)).toEqual(v);
+  });
+
+  it('round-trips a result without highlight_region', () => {
+    const v = { type: 'guide', message: 'hi', confidence: 'low' };
+    expect(roundTrip(VisionGuideResultSchema, v)).toEqual(v);
+  });
+
+  it('rejects mismatched literal type', () => {
+    expect(() =>
+      VisionGuideResultSchema.parse({
+        type: 'verify',
+        message: 'x',
+        confidence: 'low',
+      }),
+    ).toThrow();
+  });
+});
+
+describe('VisionVerifyResultSchema (PRD §9.1.4 result)', () => {
+  it.each(['pass', 'fail', 'unclear'] as const)('accepts status=%s', (status) => {
+    const v = { type: 'verify', status, reasoning: 'because' };
+    expect(roundTrip(VisionVerifyResultSchema, v)).toEqual(v);
+  });
+
+  it('round-trips with optional next_action_hint', () => {
+    const v = {
+      type: 'verify',
+      status: 'fail',
+      reasoning: 'r',
+      next_action_hint: 'try again',
+    };
+    expect(roundTrip(VisionVerifyResultSchema, v)).toEqual(v);
+  });
+
+  it('rejects unknown status', () => {
+    expect(() =>
+      VisionVerifyResultSchema.parse({
+        type: 'verify',
+        status: 'maybe',
+        reasoning: 'x',
+      }),
+    ).toThrow();
+  });
+});
+
+describe('GetChecklistResponseSchema (PRD §9.1.1)', () => {
+  it('round-trips an items array', () => {
+    const v = {
+      items: [
+        {
+          item_id: 'a',
+          status: 'pending',
+          current_step: null,
+          started_at: null,
+          completed_at: null,
+          attempt_count: 0,
+        },
+      ],
+    };
+    expect(roundTrip(GetChecklistResponseSchema, v)).toEqual(v);
+  });
+});
+
+describe('Start item endpoint (PRD §9.1.2)', () => {
+  it('round-trips params and ok response', () => {
+    expect(roundTrip(StartItemParamsSchema, { itemId: 'install-homebrew' })).toEqual({
+      itemId: 'install-homebrew',
+    });
+    expect(roundTrip(StartItemResponseSchema, { ok: true })).toEqual({ ok: true });
+  });
+
+  it('rejects ok=false', () => {
+    expect(() => StartItemResponseSchema.parse({ ok: false })).toThrow();
+  });
+});
+
+describe('Vision guide endpoint (PRD §9.1.3)', () => {
+  it('round-trips request', () => {
+    const req = { item_id: 'install-homebrew', step_id: 'download' };
+    expect(roundTrip(VisionGuideRequestSchema, req)).toEqual(req);
+  });
+
+  it('round-trips a 200 response with cached=false', () => {
+    const v = {
+      call_id: 'vc_abc',
+      cached: false,
+      latency_ms: 2840,
+      result: {
+        type: 'guide',
+        message: '화면 좌측 잠금 아이콘을 클릭하세요',
+        highlight_region: { x: 24, y: 480, width: 32, height: 32 },
+        confidence: 'high',
+      },
+    };
+    expect(roundTrip(VisionGuideResponseSchema, v)).toEqual(v);
+  });
+
+  it('rejects negative latency_ms', () => {
+    expect(() =>
+      VisionGuideResponseSchema.parse({
+        call_id: 'x',
+        cached: false,
+        latency_ms: -1,
+        result: { type: 'guide', message: 'x', confidence: 'low' },
+      }),
+    ).toThrow();
+  });
+
+  describe('error responses', () => {
+    it('round-trips 401 screen_recording_permission_required', () => {
+      const v = { error: 'screen_recording_permission_required' };
+      expect(roundTrip(VisionGuideErrorResponseSchema, v)).toEqual(v);
+    });
+
+    it('round-trips 403 consent_required', () => {
+      const v = { error: 'consent_required' };
+      expect(roundTrip(VisionGuideErrorResponseSchema, v)).toEqual(v);
+    });
+
+    it('round-trips 429 rate_limit_exceeded', () => {
+      const v = {
+        error: 'rate_limit_exceeded',
+        state: 'paused',
+        reset_at: 1_700_000_000,
+      };
+      expect(roundTrip(VisionGuideErrorResponseSchema, v)).toEqual(v);
+    });
+
+    it('round-trips 503 vision_api_timeout', () => {
+      const v = { error: 'vision_api_timeout' };
+      expect(roundTrip(VisionGuideErrorResponseSchema, v)).toEqual(v);
+    });
+
+    it('rejects unknown error code', () => {
+      expect(() =>
+        VisionGuideErrorResponseSchema.parse({ error: 'unknown_thing' }),
+      ).toThrow();
+    });
+  });
+});
+
+describe('Vision verify endpoint (PRD §9.1.4)', () => {
+  it('round-trips request and 200 response', () => {
+    const req = { item_id: 'a', step_id: 'b' };
+    expect(roundTrip(VisionVerifyRequestSchema, req)).toEqual(req);
+
+    const res = {
+      call_id: 'vc_x',
+      result: { type: 'verify', status: 'pass', reasoning: 'ok' },
+    };
+    expect(roundTrip(VisionVerifyResponseSchema, res)).toEqual(res);
+  });
+});
+
+describe('Rate limit endpoint (PRD §9.1.5)', () => {
+  it('round-trips a normal-state response', () => {
+    const v = { current_hour_calls: 47, state: 'normal', reset_at: 1_700_003_600 };
+    expect(roundTrip(RateLimitResponseSchema, v)).toEqual(v);
+  });
+
+  it.each(['normal', 'alert', 'paused'] as const)('accepts state=%s', (state) => {
+    const v = { current_hour_calls: 1, state, reset_at: 0 };
+    expect(() => RateLimitResponseSchema.parse(v)).not.toThrow();
+  });
+
+  it('rejects unknown state', () => {
+    expect(() =>
+      RateLimitResponseSchema.parse({
+        current_hour_calls: 1,
+        state: 'cool',
+        reset_at: 0,
+      }),
+    ).toThrow();
+  });
+});
+
+describe('Consent endpoints (PRD §9.1.6)', () => {
+  it('round-trips POST /api/consents request and response', () => {
+    const req = { consent_type: 'anthropic_transmission', granted: true };
+    expect(roundTrip(PostConsentRequestSchema, req)).toEqual(req);
+    expect(roundTrip(PostConsentResponseSchema, { ok: true })).toEqual({ ok: true });
+  });
+
+  it('rejects unknown consent_type', () => {
+    expect(() =>
+      PostConsentRequestSchema.parse({ consent_type: 'mystery', granted: true }),
+    ).toThrow();
+  });
+
+  it('round-trips GET /api/consents response', () => {
+    const v = {
+      screen_recording: {
+        consent_type: 'screen_recording',
+        granted: true,
+        granted_at: 1,
+        revoked_at: null,
+      },
+      anthropic_transmission: {
+        consent_type: 'anthropic_transmission',
+        granted: false,
+        granted_at: null,
+        revoked_at: 2,
+      },
+    };
+    expect(roundTrip(GetConsentsResponseSchema, v)).toEqual(v);
+  });
+
+  it('round-trips a single ConsentRecord', () => {
+    const v = {
+      consent_type: 'screen_recording',
+      granted: true,
+      granted_at: 1,
+      revoked_at: null,
+    };
+    expect(roundTrip(ConsentRecordSchema, v)).toEqual(v);
+  });
+});
+
+describe('Clipboard endpoint (PRD §9.1.7)', () => {
+  it('round-trips request and response', () => {
+    const req = { command: 'echo hi' };
+    expect(roundTrip(ClipboardRequestSchema, req)).toEqual(req);
+    expect(roundTrip(ClipboardResponseSchema, { ok: true })).toEqual({ ok: true });
+  });
+
+  it('rejects empty command', () => {
+    expect(() => ClipboardRequestSchema.parse({ command: '' })).toThrow();
+  });
+});
+
+describe('Verify run endpoint (PRD §9.1.8)', () => {
+  it('round-trips command verification request', () => {
+    const v = {
+      item_id: 'install-homebrew',
+      verification: {
+        type: 'command',
+        command: 'brew --version',
+        poll_interval_sec: 5,
+      },
+    };
+    expect(roundTrip(VerifyRunRequestSchema, v)).toEqual(v);
+  });
+
+  it('round-trips process_check verification request', () => {
+    const v = {
+      item_id: 'install-security-agent',
+      verification: { type: 'process_check', process_name: 'SecurityAgent' },
+    };
+    expect(roundTrip(VerifyRunRequestSchema, v)).toEqual(v);
+  });
+
+  it.each(['pass', 'fail'] as const)('round-trips response status=%s', (status) => {
+    const res = { status, details: 'exit code 0' };
+    expect(roundTrip(VerifyRunResponseSchema, res)).toEqual(res);
+  });
+
+  it('rejects an "unclear" status (only used by Vision verify)', () => {
+    expect(() =>
+      VerifyRunResponseSchema.parse({ status: 'unclear', details: '' }),
+    ).toThrow();
+  });
+});

--- a/packages/shared/tests/checklist.schemas.test.ts
+++ b/packages/shared/tests/checklist.schemas.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AiCoachingSchema,
+  ChecklistFileSchema,
+  ChecklistInputSchema,
+  ChecklistItemSchema,
+  ChecklistStepSchema,
+  ClipboardInjectSchema,
+  CommandVerificationSchema,
+  ProcessCheckVerificationSchema,
+  TemplateSchema,
+  VerificationSchema,
+} from '../src/schemas/checklist.js';
+
+function roundTrip<T>(schema: { parse: (v: unknown) => T }, value: unknown): T {
+  const parsed = schema.parse(value);
+  const reparsed = schema.parse(JSON.parse(JSON.stringify(parsed)));
+  expect(reparsed).toEqual(parsed);
+  return parsed;
+}
+
+describe('ChecklistInputSchema (PRD §11 inputs[])', () => {
+  it('round-trips a required input', () => {
+    const v = { key: 'git_email', label: 'Git 이메일', required: true };
+    expect(roundTrip(ChecklistInputSchema, v)).toEqual(v);
+  });
+
+  it('rejects empty key', () => {
+    expect(() =>
+      ChecklistInputSchema.parse({ key: '', label: 'x', required: true }),
+    ).toThrow();
+  });
+});
+
+describe('ClipboardInjectSchema (PRD §11 clipboard_inject)', () => {
+  it('round-trips with ui_hint', () => {
+    const v = { command: 'open https://example.com', ui_hint: '브라우저가 열립니다' };
+    expect(roundTrip(ClipboardInjectSchema, v)).toEqual(v);
+  });
+
+  it('round-trips without ui_hint', () => {
+    const v = { command: 'echo hi' };
+    expect(roundTrip(ClipboardInjectSchema, v)).toEqual(v);
+  });
+
+  it('rejects empty command', () => {
+    expect(() => ClipboardInjectSchema.parse({ command: '' })).toThrow();
+  });
+});
+
+describe('VerificationSchema (PRD §11 verification)', () => {
+  it('round-trips command verification', () => {
+    const v = { type: 'command', command: 'brew --version', poll_interval_sec: 5 };
+    expect(roundTrip(VerificationSchema, v)).toEqual(v);
+    expect(roundTrip(CommandVerificationSchema, v)).toEqual(v);
+  });
+
+  it('round-trips command verification with expect_contains', () => {
+    const v = {
+      type: 'command',
+      command: 'git config --global user.email',
+      expect_contains: 'user@example.com',
+    };
+    expect(roundTrip(VerificationSchema, v)).toEqual(v);
+  });
+
+  it('round-trips process_check verification', () => {
+    const v = {
+      type: 'process_check',
+      process_name: 'SecurityAgent',
+      poll_interval_sec: 5,
+    };
+    expect(roundTrip(VerificationSchema, v)).toEqual(v);
+    expect(roundTrip(ProcessCheckVerificationSchema, v)).toEqual(v);
+  });
+
+  it('rejects an unknown verification type', () => {
+    expect(() =>
+      VerificationSchema.parse({ type: 'magic', command: 'x' }),
+    ).toThrow();
+  });
+
+  it('rejects zero or negative poll_interval_sec', () => {
+    expect(() =>
+      VerificationSchema.parse({
+        type: 'command',
+        command: 'x',
+        poll_interval_sec: 0,
+      }),
+    ).toThrow();
+    expect(() =>
+      VerificationSchema.parse({
+        type: 'command',
+        command: 'x',
+        poll_interval_sec: -1,
+      }),
+    ).toThrow();
+  });
+});
+
+describe('ChecklistStepSchema + AiCoachingSchema (PRD §11 ai_coaching)', () => {
+  it('round-trips a step with all optional fields', () => {
+    const v = {
+      id: 'grant_permission',
+      intent: '권한 부여',
+      success_criteria: 'pgrep SecurityAgent → PID 반환',
+      system_panel_url:
+        'x-apple.systempreferences:com.apple.preference.security',
+      common_mistakes: '잠금 해제 안 한 채 클릭 시도',
+    };
+    expect(roundTrip(ChecklistStepSchema, v)).toEqual(v);
+  });
+
+  it('round-trips ai_coaching with multiple steps', () => {
+    const v = {
+      overall_goal: '보안 에이전트 설치',
+      steps: [
+        { id: 'download', intent: 'd', success_criteria: 'c1' },
+        {
+          id: 'install',
+          intent: 'i',
+          success_criteria: 'c2',
+          system_panel_url: 'x-apple.systempreferences:com.apple.preference',
+        },
+      ],
+    };
+    expect(roundTrip(AiCoachingSchema, v)).toEqual(v);
+  });
+
+  it('rejects ai_coaching with empty steps', () => {
+    expect(() =>
+      AiCoachingSchema.parse({ overall_goal: 'g', steps: [] }),
+    ).toThrow();
+  });
+});
+
+describe('TemplateSchema (PRD §11 template)', () => {
+  it('round-trips a Gmail signature template', () => {
+    const v = {
+      content: '{{user_profile.name}}\n{{inputs.job_title}}',
+      paste_target: 'Gmail 서명 입력란',
+    };
+    expect(roundTrip(TemplateSchema, v)).toEqual(v);
+  });
+
+  it('rejects empty content or paste_target', () => {
+    expect(() =>
+      TemplateSchema.parse({ content: '', paste_target: 'x' }),
+    ).toThrow();
+    expect(() =>
+      TemplateSchema.parse({ content: 'x', paste_target: '' }),
+    ).toThrow();
+  });
+});
+
+describe('ChecklistItemSchema (PRD §11 items[])', () => {
+  it('round-trips a minimal item', () => {
+    const v = {
+      id: 'install-homebrew',
+      title: 'Homebrew 설치',
+      estimated_minutes: 3,
+    };
+    expect(roundTrip(ChecklistItemSchema, v)).toEqual(v);
+  });
+
+  it('round-trips a P2+P4 item (homebrew)', () => {
+    const v = {
+      id: 'install-homebrew',
+      title: 'Homebrew 설치',
+      estimated_minutes: 3,
+      clipboard_inject: {
+        command: '/bin/bash -c "$(curl -fsSL ...)"',
+        ui_hint: '터미널에 ⌘V',
+      },
+      verification: {
+        type: 'command',
+        command: 'brew --version',
+        poll_interval_sec: 5,
+      },
+    };
+    expect(roundTrip(ChecklistItemSchema, v)).toEqual(v);
+  });
+
+  it('round-trips a P5+/P8/P4 item (security agent)', () => {
+    const v = {
+      id: 'install-security-agent',
+      title: '사내 보안 에이전트 설치',
+      estimated_minutes: 15,
+      ai_coaching: {
+        overall_goal: '에이전트 설치 및 권한 부여',
+        steps: [
+          { id: 'download', intent: 'd', success_criteria: 'pkg in ~/Downloads' },
+          {
+            id: 'grant_permission',
+            intent: 'g',
+            success_criteria: 'pid returned',
+            system_panel_url:
+              'x-apple.systempreferences:com.apple.preference.security',
+          },
+        ],
+      },
+      verification: { type: 'process_check', process_name: 'SecurityAgent' },
+    };
+    expect(roundTrip(ChecklistItemSchema, v)).toEqual(v);
+  });
+
+  it('rejects estimated_minutes <= 0', () => {
+    expect(() =>
+      ChecklistItemSchema.parse({ id: 'x', title: 'y', estimated_minutes: 0 }),
+    ).toThrow();
+    expect(() =>
+      ChecklistItemSchema.parse({ id: 'x', title: 'y', estimated_minutes: -1 }),
+    ).toThrow();
+  });
+
+  it('rejects extra fields (strict)', () => {
+    expect(() =>
+      ChecklistItemSchema.parse({
+        id: 'x',
+        title: 'y',
+        estimated_minutes: 1,
+        unknown_field: 'oops',
+      }),
+    ).toThrow();
+  });
+});
+
+describe('ChecklistFileSchema (top-level yaml)', () => {
+  it('round-trips a v2 ai-coaching file', () => {
+    const v = {
+      version: 2,
+      schema: 'ai-coaching',
+      items: [{ id: 'a', title: 'A', estimated_minutes: 1 }],
+    };
+    expect(roundTrip(ChecklistFileSchema, v)).toEqual(v);
+  });
+
+  it('rejects empty items', () => {
+    expect(() =>
+      ChecklistFileSchema.parse({ version: 2, schema: 'ai-coaching', items: [] }),
+    ).toThrow();
+  });
+});

--- a/packages/shared/tests/types.test.ts
+++ b/packages/shared/tests/types.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, expectTypeOf } from 'vitest';
+
+import {
+  CONSENT_TYPES,
+  ITEM_STATUSES,
+  VISION_CONFIDENCES,
+  VISION_VERIFY_STATUSES,
+  type ChecklistItem,
+  type ConsentRecord,
+  type ConsentType,
+  type ItemId,
+  type ItemState,
+  type ItemStatus,
+  type Verification,
+  type VisionConfidence,
+  type VisionGuideResult,
+  type VisionVerifyResult,
+  type VisionVerifyStatus,
+} from '../src/index.js';
+
+describe('item types', () => {
+  it('exposes all SQLite-mandated statuses (PRD §8.1 item_states)', () => {
+    expect(ITEM_STATUSES).toEqual([
+      'pending',
+      'in_progress',
+      'completed',
+      'skipped',
+      'blocked',
+    ]);
+  });
+
+  it('maps PRD §8.1 item_states columns 1:1 to ItemState', () => {
+    const sample: ItemState = {
+      item_id: 'install-homebrew',
+      status: 'in_progress',
+      current_step: 'install',
+      started_at: 1_700_000_000,
+      completed_at: null,
+      attempt_count: 1,
+    };
+    expectTypeOf<ItemState['item_id']>().toEqualTypeOf<ItemId>();
+    expectTypeOf<ItemState['status']>().toEqualTypeOf<ItemStatus>();
+    expect(sample.attempt_count).toBe(1);
+  });
+});
+
+describe('vision types', () => {
+  it('lists all confidences and verify statuses (PRD §9.1.3 / 9.1.4)', () => {
+    expect(VISION_CONFIDENCES).toEqual(['low', 'medium', 'high']);
+    expect(VISION_VERIFY_STATUSES).toEqual(['pass', 'fail', 'unclear']);
+  });
+
+  it('binds VisionGuideResult.confidence to VisionConfidence', () => {
+    const guide: VisionGuideResult = {
+      type: 'guide',
+      message: '잠금 아이콘을 클릭하세요',
+      highlight_region: { x: 24, y: 480, width: 32, height: 32 },
+      confidence: 'high',
+    };
+    expectTypeOf<VisionGuideResult['confidence']>().toEqualTypeOf<VisionConfidence>();
+    expect(guide.type).toBe('guide');
+  });
+
+  it('binds VisionVerifyResult.status to VisionVerifyStatus', () => {
+    const verify: VisionVerifyResult = {
+      type: 'verify',
+      status: 'pass',
+      reasoning: '체크박스가 표시됨',
+    };
+    expectTypeOf<VisionVerifyResult['status']>().toEqualTypeOf<VisionVerifyStatus>();
+    expect(verify.type).toBe('verify');
+  });
+});
+
+describe('consent types', () => {
+  it('lists exactly the two PRD §8.1 consent types', () => {
+    expect(CONSENT_TYPES).toEqual(['screen_recording', 'anthropic_transmission']);
+  });
+
+  it('maps PRD §8.1 consents columns 1:1 to ConsentRecord', () => {
+    const record: ConsentRecord = {
+      consent_type: 'anthropic_transmission',
+      granted: true,
+      granted_at: 1_700_000_000,
+      revoked_at: null,
+    };
+    expectTypeOf<ConsentRecord['consent_type']>().toEqualTypeOf<ConsentType>();
+    expect(record.granted).toBe(true);
+  });
+});
+
+describe('checklist types', () => {
+  it('represents a PRD §11 yaml item with all optional sections', () => {
+    const command: Verification = {
+      type: 'command',
+      command: 'brew --version',
+      poll_interval_sec: 5,
+    };
+    const item: ChecklistItem = {
+      id: 'install-homebrew',
+      title: 'Homebrew 설치',
+      estimated_minutes: 3,
+      clipboard_inject: {
+        command: '/bin/bash -c "$(curl -fsSL ...)"',
+        ui_hint: '터미널에 붙여넣기',
+      },
+      verification: command,
+    };
+    expect(item.id).toBe('install-homebrew');
+  });
+});

--- a/packages/shared/tsconfig.build.json
+++ b/packages/shared/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["tests", "node_modules", "dist"]
+}

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  },
+  "include": ["src/**/*", "tests/**/*", "vitest.config.ts"]
+}

--- a/packages/shared/vitest.config.ts
+++ b/packages/shared/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary'],
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/index.ts'],
+      thresholds: {
+        lines: 80,
+        functions: 80,
+        branches: 80,
+        statements: 80,
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,3 +7,1379 @@ settings:
 importers:
 
   .: {}
+
+  packages/shared:
+    dependencies:
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
+    devDependencies:
+      '@vitest/coverage-v8':
+        specifier: ^2.1.0
+        version: 2.1.9(vitest@2.1.9)
+      typescript:
+        specifier: ^5.5.4
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9
+
+packages:
+
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.3':
+    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@0.2.3':
+    resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  '@istanbuljs/schema@0.1.6':
+    resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
+    engines: {node: '>=8'}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    resolution: {integrity: sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    resolution: {integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    resolution: {integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    resolution: {integrity: sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    resolution: {integrity: sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    resolution: {integrity: sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    resolution: {integrity: sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    resolution: {integrity: sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@vitest/coverage-v8@2.1.9':
+    resolution: {integrity: sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==}
+    peerDependencies:
+      '@vitest/browser': 2.1.9
+      vitest: 2.1.9
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  brace-expansion@2.1.0:
+    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
+
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+    engines: {node: 18 || 20 || >=22}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  postcss@8.5.13:
+    resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  rollup@4.60.2:
+    resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  test-exclude@7.0.2:
+    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
+    engines: {node: '>=18'}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+snapshots:
+
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/parser@7.29.3':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@0.2.3': {}
+
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@istanbuljs/schema@0.1.6': {}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    optional: true
+
+  '@types/estree@1.0.8': {}
+
+  '@vitest/coverage-v8@2.1.9(vitest@2.1.9)':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 0.2.3
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.21
+      magicast: 0.3.5
+      std-env: 3.10.0
+      test-exclude: 7.0.2
+      tinyrainbow: 1.2.0
+      vitest: 2.1.9
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21)':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
+
+  assertion-error@2.0.1: {}
+
+  balanced-match@1.0.2: {}
+
+  balanced-match@4.0.4: {}
+
+  brace-expansion@2.1.0:
+    dependencies:
+      balanced-match: 1.0.2
+
+  brace-expansion@5.0.5:
+    dependencies:
+      balanced-match: 4.0.4
+
+  cac@6.7.14: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@5.0.2: {}
+
+  eastasianwidth@0.2.0: {}
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
+
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
+  fsevents@2.3.3:
+    optional: true
+
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
+  has-flag@4.0.0: {}
+
+  html-escaper@2.0.2: {}
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  isexe@2.0.0: {}
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
+  loupe@3.2.1: {}
+
+  lru-cache@10.4.3: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.5
+
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.0
+
+  minipass@7.1.3: {}
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.12: {}
+
+  package-json-from-dist@1.0.1: {}
+
+  path-key@3.1.1: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
+
+  pathe@1.1.2: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  postcss@8.5.13:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  rollup@4.60.2:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.2
+      '@rollup/rollup-android-arm64': 4.60.2
+      '@rollup/rollup-darwin-arm64': 4.60.2
+      '@rollup/rollup-darwin-x64': 4.60.2
+      '@rollup/rollup-freebsd-arm64': 4.60.2
+      '@rollup/rollup-freebsd-x64': 4.60.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.2
+      '@rollup/rollup-linux-arm64-gnu': 4.60.2
+      '@rollup/rollup-linux-arm64-musl': 4.60.2
+      '@rollup/rollup-linux-loong64-gnu': 4.60.2
+      '@rollup/rollup-linux-loong64-musl': 4.60.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.2
+      '@rollup/rollup-linux-ppc64-musl': 4.60.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.2
+      '@rollup/rollup-linux-riscv64-musl': 4.60.2
+      '@rollup/rollup-linux-s390x-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-musl': 4.60.2
+      '@rollup/rollup-openbsd-x64': 4.60.2
+      '@rollup/rollup-openharmony-arm64': 4.60.2
+      '@rollup/rollup-win32-arm64-msvc': 4.60.2
+      '@rollup/rollup-win32-ia32-msvc': 4.60.2
+      '@rollup/rollup-win32-x64-gnu': 4.60.2
+      '@rollup/rollup-win32-x64-msvc': 4.60.2
+      fsevents: 2.3.3
+
+  semver@7.7.4: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  siginfo@2.0.0: {}
+
+  signal-exit@4.1.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  test-exclude@7.0.2:
+    dependencies:
+      '@istanbuljs/schema': 0.1.6
+      glob: 10.5.0
+      minimatch: 10.2.5
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
+
+  typescript@5.9.3: {}
+
+  vite-node@2.1.9:
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21:
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.13
+      rollup: 4.60.2
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  vitest@2.1.9:
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21)
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21
+      vite-node: 2.1.9
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
+
+  zod@3.25.76: {}


### PR DESCRIPTION
# Review — spec-001-shared

- **대상 spec**: `specs/spec-001-shared.md`
- **브랜치**: `feature/spec-001-shared` (HEAD `7b20ac2`)
- **diff base**: `main`
- **검토 일자**: 2026-05-01
- **검토자**: Code Review Agent

## 변경 범위 (git diff main...HEAD --stat)

```
packages/shared/.gitignore                   |    4 +
packages/shared/package.json                 |   48 +
packages/shared/src/index.ts                 |    2 +
packages/shared/src/schemas/api.ts           |  251 +++++
packages/shared/src/schemas/checklist.ts     |   84 ++
packages/shared/src/schemas/index.ts         |    2 +
packages/shared/src/types/checklist.ts       |   61 +
packages/shared/src/types/consent.ts         |   13 +
packages/shared/src/types/index.ts           |    4 +
packages/shared/src/types/item.ts            |   20 +
packages/shared/src/types/vision.ts          |   26 +
packages/shared/tests/api.schemas.test.ts    |  397 +++++++
packages/shared/tests/checklist.schemas.test.ts | 244 ++++
packages/shared/tests/types.test.ts          |  111 ++
packages/shared/tsconfig.build.json          |   11 +
packages/shared/tsconfig.json                |    9 +
packages/shared/vitest.config.ts             |   19 +
pnpm-lock.yaml                               | 1376 ++++++++++++++++++++++
```

루트 `pnpm-workspace.yaml`, `package.json`, `tsconfig.base.json`은 main과 동일(0 변경).

---

## 검증 결과 요약

| # | 항목 | 판정 |
|---|------|------|
| 1 | AC 정합성 (PRD §10 / spec AC) | **PASS** |
| 2 | PRD 정합성 | **PASS** |
| 3 | 데이터 모델 정합성 (PRD §8) | **PASS** |
| 4 | API 계약 정합성 (PRD §9) | **PASS** |
| 5 | 보안 점검 | **PASS** |
| 6 | 코드 품질 | **PASS** |
| 7 | BOUNDARIES.md 준수 | **PASS** |
| 8 | 의존성 체크 (PRD §12) | **WARN** |

**최종 판정: PASS_WITH_WARN** (FAIL 0건, WARN 1건)

---

## 1. AC 정합성 — PASS

`spec-001-shared.md`의 Acceptance Criteria를 코드/테스트 위치와 매핑:

| AC 항목 | 충족 위치 | 판정 |
|---------|-----------|------|
| PRD §9 모든 엔드포인트(8개) 요청·응답 타입 정의 | `src/schemas/api.ts:76-207` (9.1.1~9.1.8 모두 정의) | ✅ |
| §9.1.3 401/403/429/503 에러 응답 | `src/schemas/api.ts:213-251` (`VisionGuideErrorResponseSchema` discriminated union) | ✅ |
| PRD §8 item_states/consents SQLite 컬럼 1:1 TS 매핑 | `src/types/item.ts:13-20` (`ItemState`), `src/types/consent.ts:8-13` (`ConsentRecord`) — 컬럼 6/4 모두 매핑, nullable 필드 정확 | ✅ |
| PRD §11 yaml(items, clipboard_inject, verification, ai_coaching, system_panel_url, template) zod 정의 | `src/schemas/checklist.ts:11-84` (모든 절 포함) | ✅ |
| HighlightRegion 4필드 number, 음수/0 검증 | `src/schemas/api.ts:30-37` (`.positive()` × 4), test `tests/api.schemas.test.ts:34-69` | ✅ |
| 모든 zod 스키마 round-trip 테스트 | `tests/api.schemas.test.ts:27-32` 헬퍼 + 모든 describe 블록에서 사용, `tests/checklist.schemas.test.ts:16-21` 동일 | ✅ |
| `pnpm --filter @onboarding/shared test` 통과 | 81 tests passed (3 files) | ✅ |
| `pnpm --filter @onboarding/shared build` 통과 (tsc emit) | 통과, dist/ 생성 | ✅ |
| `pnpm --filter @onboarding/shared lint` 에러 0 | `tsc -p tsconfig.json` 0 에러 | ✅ |
| 테스트 커버리지 ≥ 80% | v8 커버리지 100% (lines/branches/functions/statements 모두 100) | ✅ |

> 참고: `types/checklist.ts`는 v8 커버리지 0%로 표시되나, 순수 interface/type 선언만 있어 JS 산출물이 없는 정상 케이스. `vitest.config.ts:9`가 `src/**/index.ts`를 커버리지에서 제외해 배럴 파일은 측정 대상에서 빠짐.

PRD §10의 런타임 AC(AC-CORE-NN, AC-VIS-NN, AC-INT-01 등)는 daemon/floating-hint spec(SPEC-002+)이 책임. 본 spec 범위는 타입/스키마 SoT이며, 모든 §10 AC가 의존하는 인터페이스를 빠짐없이 노출함.

## 2. PRD 정합성 — PASS

- `RATE_LIMIT_STATES = ['normal', 'alert', 'paused']`(`api.ts:139`)는 PRD §7.7 F-P8-06("시간당 100회 알림 / 200회 일시 정지")과 §9.1.3 429 응답(`state: "paused"`)의 결합을 자연스럽게 표현. 임의 추가 아님.
- spec 비범위(daemon 서버 구현, yaml 로드, Anthropic SDK 래핑 등)에 대한 침범 없음. 모든 export는 데이터 모양 정의만 담당.
- `cached: z.boolean()`이 vision/guide 응답에는 필수, vision/verify에는 optional(`api.ts:114, 129`)인 점은 PRD 예시 본문(§9.1.3에 cached 명시, §9.1.4에 미명시)을 그대로 반영. 의도된 모델링으로 판단.

## 3. 데이터 모델 정합성 (PRD §8) — PASS

| PRD §8.1 테이블 | 매핑 위치 | 비고 |
|----------------|-----------|------|
| `item_states` (item_id, status, current_step, started_at, completed_at, attempt_count) | `types/item.ts` `ItemState` + `schemas/api.ts` `ItemStateSchema` | 컬럼 6/6, nullable 정확, status enum 5개 모두 |
| `consents` (consent_type, granted, granted_at, revoked_at) | `types/consent.ts` `ConsentRecord` + `schemas/api.ts` `ConsentRecordSchema` | 컬럼 4/4, consent_type enum 2개 모두 |
| `profile`, `vision_calls`, `rate_limit_buckets`, `vision_cache` | 매핑 없음 | spec 출력 목록(§Output)이 명시적으로 item/vision/consent/checklist만 요구 — daemon 내부 상태로 SPEC-002+ 책임 |

임의 status 값/임의 컬럼 추가 없음. 필드명은 SQLite 그대로 `snake_case` 유지(`zod` parse 시 변환 없음).

## 4. API 계약 정합성 (PRD §9) — PASS

| PRD §9.1.x | Schema | 일치 |
|-----------|--------|------|
| 9.1.1 GET /api/checklist | `GetChecklistResponseSchema` | ✅ `{ items: ItemState[] }` |
| 9.1.2 POST /api/items/:itemId/start | `StartItemParamsSchema` + `StartItemResponseSchema` | ✅ `{ ok: true }` literal |
| 9.1.3 POST /api/vision/guide | `VisionGuideRequestSchema` + `VisionGuideResponseSchema` | ✅ call_id, cached, latency_ms, result(message + highlight_region? + confidence) |
| 9.1.3 401/403/429/503 | `VisionGuideErrorResponseSchema` (discriminated union) | ✅ 4개 에러 코드 모두, 429에 state="paused"+reset_at |
| 9.1.4 POST /api/vision/verify | `VisionVerifyRequestSchema` + `VisionVerifyResponseSchema` | ✅ result(status: pass/fail/unclear, reasoning, next_action_hint?) |
| 9.1.5 GET /api/vision/rate-limit | `RateLimitResponseSchema` | ✅ current_hour_calls, state, reset_at |
| 9.1.6 POST/GET /api/consents | `PostConsentRequestSchema`, `PostConsentResponseSchema`, `GetConsentsResponseSchema` | ✅ |
| 9.1.7 POST /api/clipboard | `ClipboardRequestSchema` + `ClipboardResponseSchema` | ✅ |
| 9.1.8 POST /api/verify/run | `VerifyRunRequestSchema` + `VerifyRunResponseSchema` | ✅ status: pass/fail (unclear는 vision-only로 정확히 분리, test `api.schemas.test.ts:392-396`) |

모든 객체 스키마가 `.strict()`로 잠겨 있어 PRD 미정의 필드 추가가 런타임에서 차단됨. Greenfield 첫 spec이므로 breaking change 없음.

## 5. 보안 점검 — PASS

- 시크릿 하드코딩: `Grep`/리뷰 기준 소스 18파일 + 테스트 3파일 어디에도 `sk-ant-`, `ANTHROPIC_API_KEY`, 사내 URL 평문, 이메일 평문 미존재. 테스트 픽스처는 `'vc_abc'`, `'vc_x'`, `'install-homebrew'`, `'user@example.com'`(테스트 명시) 같이 명백한 더미만 사용.
- SQL 인젝션: 본 spec은 SQL을 다루지 않음(타입/스키마만). N/A.
- 캡처 이미지 데이터: `HighlightRegion`은 좌표만(`x,y,w,h: number`), 이미지 byte 필드 없음. `vision_calls`에 `image_hash`(string)만 두고 base64/binary 필드 없음 — PRD §8.2(메모리만, 즉시 파기) 정책과 정합.
- `.gitignore`에 `dist/`, `coverage/`, `node_modules/`, `*.tsbuildinfo` 포함 — 시크릿 누출 위험 산출물 차단.

## 6. 코드 품질 — PASS

- 함수 50줄 미만: 본 spec에 사실상 함수 없음(zod 스키마 선언 + interface). 테스트 헬퍼 `roundTrip`은 5줄(`api.schemas.test.ts:27-32`).
- 테스트 커버리지: **lines 100% / branches 100% / functions 100% / statements 100%** (목표 80% 대폭 초과).
- 테스트 수: 81개 (api: 51, checklist: 22, types: 8). 각 스키마에 round-trip + 음성 케이스(잘못된 status/empty/extra 필드/음수 등) 모두 포함.
- ESM + NodeNext + strict + `noUncheckedIndexedAccess`/`noUnusedLocals`/`noUnusedParameters` 활성. `tsc` 0 에러.
- 배럴 파일(`src/index.ts`, `src/types/index.ts`, `src/schemas/index.ts`) 통해 외부 import 표면 정리.

## 7. BOUNDARIES.md 준수 — PASS

| 규칙 | 판정 |
|------|------|
| §1 수정 금지 파일(`docs/`, `BOUNDARIES.md`, `spec-template.md`, 다른 spec) 미수정 | ✅ git diff에서 미등장 |
| §2 패키지 경로 — `packages/shared/` 내부만 수정 | ✅ 다른 `packages/<other>/` 변경 0 |
| §2 루트 워크스페이스 설정 미변경 | ✅ `pnpm-workspace.yaml`, root `package.json`, `tsconfig.base.json` main과 동일 |
| §4 Breaking change(API 라우트/필드/상태코드/스키마) | N/A — 첫 spec, 모두 신규 정의 |
| §5 시크릿/캡처 이미지 raw 미포함 | ✅ |

## 8. 의존성 체크 (PRD §12) — WARN

`packages/shared/package.json`에 다음이 추가됨:

| 패키지 | 버전 | PRD §12 | 판정 |
|--------|------|---------|------|
| `zod` | `^3.23.8` | ✅ `zod ^3.23` | OK |
| `typescript` | `^5.5.4` | ✅ `typescript ^5.5` | OK |
| `vitest` | `^2.1.0` | ✅ `vitest ^2.0` | OK |
| `@vitest/coverage-v8` | `^2.1.0` | ❌ §12 표 미등재 | **WARN** |

**WARN 사유**: `@vitest/coverage-v8`은 vitest의 별도 peer 패키지이며, BOUNDARIES.md §3은 "신규 라이브러리는 PRD §12 개정 후에만 추가"로 명시. 단 표 외 transitive는 허용하나 본 항목은 `devDependencies`에 직접 선언되어 transitive로 보기 어려움.

**완화**: vitest의 공식 coverage provider이며 spec AC("테스트 커버리지 ≥ 80%")를 측정하기 위해 필요. 현실적으로 vitest 패밀리의 일부로 PRD 의도(§12 vitest)에 부합. 다만 엄격 해석상 PRD §12 표에 `@vitest/coverage-v8`을 추가하는 PRD 개정이 권장됨. FAIL은 아님.

**제안**: 다음 PRD 개정 시 §12에 한 줄 추가:
```
| @vitest/coverage-v8 | ^2.0 | 모든 패키지 | vitest 커버리지 측정 |
```

---

## 비고: 개선 후보 (필수 아님)

- `VisionGuideResponseSchema.cached`(필수)와 `VisionVerifyResponseSchema.cached`(optional)의 비대칭은 PRD 예시문을 그대로 반영한 것이지만, 후속 spec(SPEC-002+)에서 daemon이 verify 응답에도 cached/latency_ms를 항상 채우게 되면 양쪽을 동일 모양으로 정렬할 수 있음.
- spec 출력 목록에 명시되지 않았으나, daemon 작업 시 `profile`/`vision_calls`/`rate_limit_buckets`/`vision_cache` 테이블에 대응하는 타입을 daemon-internal에 둘지 shared로 옮길지는 SPEC-002+에서 판단 필요.

---

## 결론

8개 검증 항목 중 7개 PASS, 1개 WARN(의존성 카탈로그 미등재 1건). FAIL 없음.

<promise>SPEC_001_SHARED_REVIEW_PASS_WITH_WARN</promise>
