### PR TITLE
[Ralph] spec-003-daemon-checklist-loader

### DIFF
--- a/packages/daemon/content/checklist.yaml
+++ b/packages/daemon/content/checklist.yaml
@@ -1,0 +1,146 @@
+version: 2
+schema: ai-coaching
+
+items:
+  # 항목 1: P2 + P4
+  - id: install-homebrew
+    title: Homebrew 설치
+    estimated_minutes: 3
+
+    clipboard_inject:
+      command: '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"'
+      ui_hint: "터미널을 열고 ⌘V로 붙여넣어 실행하세요"
+
+    verification:
+      type: command
+      command: brew --version
+      poll_interval_sec: 5
+
+  # 항목 2: P2 + P4
+  - id: configure-git
+    title: Git 글로벌 설정
+    estimated_minutes: 1
+
+    inputs:
+      - key: git_name
+        label: Git 사용자 이름
+        required: true
+      - key: git_email
+        label: Git 이메일
+        required: true
+
+    clipboard_inject:
+      command: |
+        git config --global user.name "{{inputs.git_name}}" && \
+        git config --global user.email "{{inputs.git_email}}"
+
+    verification:
+      type: command
+      command: git config --global user.email
+      expect_contains: "{{inputs.git_email}}"
+
+  # 항목 3: P5+ + P8 + P4 (MVP 핵심 시연)
+  - id: install-security-agent
+    title: 사내 보안 에이전트 설치
+    estimated_minutes: 15
+
+    ai_coaching:
+      overall_goal: |
+        사용자가 사내 보안 에이전트(.pkg)를 다운로드하고 설치한 뒤,
+        시스템 환경설정에서 권한을 부여하고 백그라운드 프로세스가 실행되도록 한다.
+
+      steps:
+        - id: download
+          intent: |
+            security.wrtn.io/download 페이지에서 .pkg 파일을 다운로드한다.
+          success_criteria: |
+            ~/Downloads 폴더에 SecurityAgent-*.pkg 파일이 존재한다.
+
+        - id: install
+          intent: |
+            .pkg 파일을 더블클릭해서 설치 마법사를 진행한다.
+            관리자 비밀번호 입력이 필요하다.
+          success_criteria: |
+            /Applications/SecurityAgent.app 디렉토리가 존재한다.
+
+        - id: grant_permission
+          intent: |
+            시스템 환경설정 → 개인정보 보호 및 보안에서
+            SecurityAgent에 디스크 접근 권한을 부여한다.
+          system_panel_url: x-apple.systempreferences:com.apple.preference.security
+          success_criteria: |
+            pgrep SecurityAgent 결과가 PID를 반환한다.
+          common_mistakes: |
+            - 잠금 해제 안 한 채 클릭 시도
+            - SecurityAgent가 PrivilegedHelperTools 폴더에 있어 일반 Applications 폴더에서 못 찾음
+
+    verification:
+      type: process_check
+      process_name: SecurityAgent
+      poll_interval_sec: 5
+
+  # 항목 4: P5+ + P8 + P4
+  - id: setup-vpn
+    title: 사내망 VPN 설정
+    estimated_minutes: 10
+
+    clipboard_inject:
+      command: 'open https://vpn.wrtn.ax/profile'
+      ui_hint: "VPN 프로파일 다운로드 페이지가 열립니다"
+
+    ai_coaching:
+      overall_goal: "VPN 프로파일을 macOS에 등록하고 연결 가능 상태로"
+      steps:
+        - id: download_profile
+          intent: ".mobileconfig 파일 다운로드"
+          success_criteria: "~/Downloads에 wrtn-vpn.mobileconfig 존재"
+
+        - id: install_profile
+          intent: "다운로드된 파일을 더블클릭하여 시스템 환경설정으로 가져오기"
+          system_panel_url: x-apple.systempreferences:com.apple.preferences.configurationprofiles
+          success_criteria: "프로파일 목록에 WRTN VPN 표시"
+
+    verification:
+      type: command
+      command: scutil --nc list
+      expect_contains: "WRTN VPN"
+
+  # 항목 5: P2 + P8 (Gmail 서명)
+  - id: setup-gmail-signature
+    title: Gmail 회사 표준 서명 등록
+    estimated_minutes: 5
+
+    inputs:
+      - key: job_title
+        label: 직무
+        required: true
+      - key: phone
+        label: 전화번호
+        required: true
+
+    clipboard_inject:
+      command: 'open https://mail.google.com/mail/u/0/#settings/general'
+      ui_hint: "Gmail 설정 페이지가 열립니다"
+
+    template:
+      content: |
+        {{user_profile.name}}
+        {{inputs.job_title}}
+        Wrtn Technologies
+        Tel: {{inputs.phone}}
+      paste_target: "Gmail 서명 입력란에 ⌘V로 붙여넣기"
+
+    ai_coaching:
+      overall_goal: "Gmail 설정의 서명 영역에 회사 표준 서명을 등록"
+      steps:
+        - id: navigate_to_signature
+          intent: "Gmail 설정에서 '서명' 영역까지 스크롤"
+          success_criteria: "화면에 '서명' 헤더와 [+ 새로 만들기] 버튼이 보임"
+
+        - id: input_signature
+          intent: "[+ 새로 만들기]로 서명 추가, 클립보드 내용 붙여넣기, 기본 서명으로 지정"
+          success_criteria: "서명 미리보기에 사용자 이름이 표시되고 기본 서명 드롭다운에 선택됨"
+
+        - id: save
+          intent: "페이지 하단 [변경사항 저장] 버튼 클릭"
+          success_criteria: "변경사항 저장 알림 표시"

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -7,7 +7,8 @@
   "main": "./dist/index.js",
   "files": [
     "dist",
-    "src"
+    "src",
+    "content"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json && node scripts/copy-migrations.mjs",
@@ -22,6 +23,7 @@
     "better-sqlite3": "^11.0.0",
     "express": "^4.19.2",
     "pino": "^9.0.0",
+    "yaml": "^2.4.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/packages/daemon/src/checklist/loader.ts
+++ b/packages/daemon/src/checklist/loader.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  ChecklistFileSchema,
+  type ChecklistFile,
+} from '@onboarding/shared';
+import { parse as parseYaml } from 'yaml';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+// loader.ts lives at packages/daemon/{src,dist}/checklist/loader.{ts,js}.
+// `../../content/checklist.yaml` resolves to packages/daemon/content/checklist.yaml
+// from either location.
+const DEFAULT_PATH = join(HERE, '..', '..', 'content', 'checklist.yaml');
+
+export interface LoadChecklistOptions {
+  path?: string;
+}
+
+let cached: ChecklistFile | null = null;
+
+export function loadChecklist(options: LoadChecklistOptions = {}): ChecklistFile {
+  if (options.path) {
+    return parse(options.path);
+  }
+  if (cached) return cached;
+  cached = parse(DEFAULT_PATH);
+  return cached;
+}
+
+export function resetChecklistCache(): void {
+  cached = null;
+}
+
+function parse(path: string): ChecklistFile {
+  const raw = readFileSync(path, 'utf-8');
+  const data: unknown = parseYaml(raw);
+  return ChecklistFileSchema.parse(data);
+}

--- a/packages/daemon/src/checklist/repository.ts
+++ b/packages/daemon/src/checklist/repository.ts
@@ -1,0 +1,58 @@
+import type { ItemState, ItemStatus } from '@onboarding/shared';
+
+import type { DatabaseInstance } from '../db/index.js';
+
+interface ItemStateRow {
+  item_id: string;
+  status: ItemStatus;
+  current_step: string | null;
+  started_at: number | null;
+  completed_at: number | null;
+  attempt_count: number;
+}
+
+export interface ChecklistRepository {
+  getState(itemId: string): ItemState | null;
+  startItem(itemId: string, now: number): void;
+}
+
+export function createChecklistRepository(
+  db: DatabaseInstance,
+): ChecklistRepository {
+  const selectStmt = db.prepare(
+    `SELECT item_id, status, current_step, started_at, completed_at, attempt_count
+       FROM item_states
+      WHERE item_id = ?`,
+  );
+
+  // INSERT new row in 'in_progress' with attempt_count=1, OR
+  // bump existing row to 'in_progress', refresh started_at, attempt_count++.
+  const startStmt = db.prepare(
+    `INSERT INTO item_states
+       (item_id, status, current_step, started_at, completed_at, attempt_count)
+     VALUES (@item_id, 'in_progress', NULL, @now, NULL, 1)
+     ON CONFLICT(item_id) DO UPDATE SET
+       status = 'in_progress',
+       started_at = @now,
+       attempt_count = item_states.attempt_count + 1`,
+  );
+
+  return {
+    getState(itemId) {
+      const row = selectStmt.get(itemId) as ItemStateRow | undefined;
+      if (!row) return null;
+      return {
+        item_id: row.item_id,
+        status: row.status,
+        current_step: row.current_step,
+        started_at: row.started_at,
+        completed_at: row.completed_at,
+        attempt_count: row.attempt_count,
+      };
+    },
+
+    startItem(itemId, now) {
+      startStmt.run({ item_id: itemId, now });
+    },
+  };
+}

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -1,6 +1,8 @@
+import { loadChecklist } from './checklist/loader.js';
 import { defaultDbPath, openDatabase } from './db/index.js';
 import { migrate } from './db/migrate.js';
 import { logger } from './logger.js';
+import { registerApiRoutes } from './routes/index.js';
 import { createServer } from './server.js';
 
 const DEFAULT_PORT = 7777;
@@ -21,8 +23,19 @@ function bootstrap(): void {
     'migrations_complete',
   );
 
+  // Loading the bundled checklist must happen before the server starts.
+  // An invalid yaml throws (zod) and aborts boot — see spec-003 AC.
+  const checklist = loadChecklist();
+  logger.info(
+    { items: checklist.items.length, version: checklist.version },
+    'checklist_loaded',
+  );
+
   const port = parsePort();
-  const app = createServer({ logger });
+  const app = createServer({
+    logger,
+    registerRoutes: (a) => registerApiRoutes(a, { checklist, db }),
+  });
   const server = app.listen(port, () => {
     logger.info({ port }, 'daemon_listening');
   });

--- a/packages/daemon/src/routes/checklist.ts
+++ b/packages/daemon/src/routes/checklist.ts
@@ -1,0 +1,68 @@
+import type { ChecklistFile, ChecklistItem, ItemState } from '@onboarding/shared';
+import { Router, type Request, type Response } from 'express';
+
+import {
+  createChecklistRepository,
+  type ChecklistRepository,
+} from '../checklist/repository.js';
+import type { DatabaseInstance } from '../db/index.js';
+
+export interface ChecklistRouterDeps {
+  checklist: ChecklistFile;
+  db: DatabaseInstance;
+  now?: () => number;
+}
+
+interface ChecklistResponseItem extends ItemState {
+  title: string;
+}
+
+export function createChecklistRouter(deps: ChecklistRouterDeps): Router {
+  const router = Router();
+  const repo = createChecklistRepository(deps.db);
+  const now = deps.now ?? Date.now;
+  const itemsById = new Map<string, ChecklistItem>(
+    deps.checklist.items.map((item) => [item.id, item]),
+  );
+
+  router.get('/api/checklist', (_req: Request, res: Response) => {
+    const items: ChecklistResponseItem[] = deps.checklist.items.map((item) =>
+      buildResponseItem(item, repo),
+    );
+    res.status(200).json({ items });
+  });
+
+  router.post(
+    '/api/items/:itemId/start',
+    (req: Request, res: Response) => {
+      const itemId = req.params.itemId;
+      if (!itemId || !itemsById.has(itemId)) {
+        res.status(404).json({ error: 'item_not_found' });
+        return;
+      }
+      repo.startItem(itemId, now());
+      res.status(200).json({ ok: true });
+    },
+  );
+
+  return router;
+}
+
+function buildResponseItem(
+  item: ChecklistItem,
+  repo: ChecklistRepository,
+): ChecklistResponseItem {
+  const state = repo.getState(item.id);
+  if (state) {
+    return { ...state, title: item.title };
+  }
+  return {
+    item_id: item.id,
+    title: item.title,
+    status: 'pending',
+    current_step: null,
+    started_at: null,
+    completed_at: null,
+    attempt_count: 0,
+  };
+}

--- a/packages/daemon/src/routes/index.ts
+++ b/packages/daemon/src/routes/index.ts
@@ -1,0 +1,15 @@
+import type { ChecklistFile } from '@onboarding/shared';
+import type { Application } from 'express';
+
+import type { DatabaseInstance } from '../db/index.js';
+import { createChecklistRouter } from './checklist.js';
+
+export interface ApiRoutesDeps {
+  checklist: ChecklistFile;
+  db: DatabaseInstance;
+  now?: () => number;
+}
+
+export function registerApiRoutes(app: Application, deps: ApiRoutesDeps): void {
+  app.use(createChecklistRouter(deps));
+}

--- a/packages/daemon/tests/checklist-loader.test.ts
+++ b/packages/daemon/tests/checklist-loader.test.ts
@@ -1,0 +1,143 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ZodError } from 'zod';
+
+import {
+  loadChecklist,
+  resetChecklistCache,
+} from '../src/checklist/loader.js';
+
+const EXPECTED_ITEM_IDS = [
+  'install-homebrew',
+  'configure-git',
+  'install-security-agent',
+  'setup-vpn',
+  'setup-gmail-signature',
+] as const;
+
+describe('loadChecklist (bundled content/checklist.yaml)', () => {
+  beforeEach(() => {
+    resetChecklistCache();
+  });
+
+  it('parses the bundled yaml and exposes 5 PRD §11 items in order', () => {
+    const checklist = loadChecklist();
+    expect(checklist.version).toBe(2);
+    expect(checklist.schema).toBe('ai-coaching');
+    expect(checklist.items.map((i) => i.id)).toEqual([...EXPECTED_ITEM_IDS]);
+  });
+
+  it('caches the result across subsequent calls (same reference)', () => {
+    const a = loadChecklist();
+    const b = loadChecklist();
+    expect(b).toBe(a);
+  });
+});
+
+describe('loadChecklist with custom path', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    resetChecklistCache();
+    tmpDir = mkdtempSync(join(tmpdir(), 'onboarding-checklist-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    resetChecklistCache();
+  });
+
+  it('parses a minimal valid yaml and returns ChecklistFile', () => {
+    const path = join(tmpDir, 'good.yaml');
+    writeFileSync(
+      path,
+      [
+        'version: 2',
+        'schema: ai-coaching',
+        'items:',
+        '  - id: hello',
+        '    title: Hello',
+        '    estimated_minutes: 1',
+        '',
+      ].join('\n'),
+      'utf-8',
+    );
+    const checklist = loadChecklist({ path });
+    expect(checklist.items).toHaveLength(1);
+    expect(checklist.items[0]?.id).toBe('hello');
+  });
+
+  it('throws ZodError when required fields are missing', () => {
+    const path = join(tmpDir, 'missing-title.yaml');
+    writeFileSync(
+      path,
+      [
+        'version: 2',
+        'schema: ai-coaching',
+        'items:',
+        '  - id: hello',
+        '    estimated_minutes: 1',
+        '',
+      ].join('\n'),
+      'utf-8',
+    );
+    expect(() => loadChecklist({ path })).toThrow(ZodError);
+  });
+
+  it('throws ZodError when items is empty', () => {
+    const path = join(tmpDir, 'empty-items.yaml');
+    writeFileSync(
+      path,
+      ['version: 2', 'schema: ai-coaching', 'items: []', ''].join('\n'),
+      'utf-8',
+    );
+    expect(() => loadChecklist({ path })).toThrow(ZodError);
+  });
+
+  it('throws ZodError when version is not a positive integer', () => {
+    const path = join(tmpDir, 'bad-version.yaml');
+    writeFileSync(
+      path,
+      [
+        'version: 0',
+        'schema: ai-coaching',
+        'items:',
+        '  - id: hello',
+        '    title: Hello',
+        '    estimated_minutes: 1',
+        '',
+      ].join('\n'),
+      'utf-8',
+    );
+    expect(() => loadChecklist({ path })).toThrow(ZodError);
+  });
+
+  it('throws when the file is not yaml at all', () => {
+    const path = join(tmpDir, 'not-yaml.yaml');
+    writeFileSync(path, 'this is just a plain string', 'utf-8');
+    expect(() => loadChecklist({ path })).toThrow();
+  });
+
+  it('does not cache when called with a custom path', () => {
+    const goodPath = join(tmpDir, 'a.yaml');
+    writeFileSync(
+      goodPath,
+      [
+        'version: 2',
+        'schema: ai-coaching',
+        'items:',
+        '  - id: a',
+        '    title: A',
+        '    estimated_minutes: 1',
+        '',
+      ].join('\n'),
+      'utf-8',
+    );
+    const a = loadChecklist({ path: goodPath });
+    const b = loadChecklist({ path: goodPath });
+    expect(b).not.toBe(a);
+  });
+});

--- a/packages/daemon/tests/checklist-routes.test.ts
+++ b/packages/daemon/tests/checklist-routes.test.ts
@@ -1,0 +1,199 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { ChecklistFile } from '@onboarding/shared';
+import pino from 'pino';
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  openDatabase,
+  type DatabaseInstance,
+} from '../src/db/index.js';
+import { migrate } from '../src/db/migrate.js';
+import { registerApiRoutes } from '../src/routes/index.js';
+import { createServer } from '../src/server.js';
+
+const silentLogger = pino({ level: 'silent' });
+
+const FIXTURE_CHECKLIST: ChecklistFile = {
+  version: 2,
+  schema: 'ai-coaching',
+  items: [
+    {
+      id: 'install-homebrew',
+      title: 'Homebrew 설치',
+      estimated_minutes: 3,
+      clipboard_inject: {
+        command: 'brew install something',
+        ui_hint: '터미널에 ⌘V',
+      },
+      verification: {
+        type: 'command',
+        command: 'brew --version',
+      },
+    },
+    {
+      id: 'configure-git',
+      title: 'Git 설정',
+      estimated_minutes: 1,
+    },
+  ],
+};
+
+function buildApp(checklist: ChecklistFile, db: DatabaseInstance, now = Date.now) {
+  return createServer({
+    logger: silentLogger,
+    registerRoutes: (app) => {
+      registerApiRoutes(app, { checklist, db, now });
+    },
+  });
+}
+
+describe('checklist routes', () => {
+  let tmpDir: string;
+  let dbPath: string;
+  let db: DatabaseInstance;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'onboarding-checklist-routes-'));
+    dbPath = join(tmpDir, 'agent.db');
+    db = openDatabase(dbPath);
+    migrate(db);
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('GET /api/checklist', () => {
+    it('returns all yaml items merged with state, defaulting to pending when no row exists', async () => {
+      const app = buildApp(FIXTURE_CHECKLIST, db);
+      const res = await request(app).get('/api/checklist');
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body.items)).toBe(true);
+      expect(res.body.items).toHaveLength(2);
+
+      const homebrew = res.body.items[0];
+      expect(homebrew.item_id).toBe('install-homebrew');
+      expect(homebrew.title).toBe('Homebrew 설치');
+      expect(homebrew.status).toBe('pending');
+      expect(homebrew.current_step).toBeNull();
+      expect(homebrew.started_at).toBeNull();
+      expect(homebrew.completed_at).toBeNull();
+      expect(homebrew.attempt_count).toBe(0);
+
+      const git = res.body.items[1];
+      expect(git.item_id).toBe('configure-git');
+      expect(git.title).toBe('Git 설정');
+      expect(git.status).toBe('pending');
+    });
+
+    it('reflects existing item_states rows from SQLite', async () => {
+      db.prepare(
+        `INSERT INTO item_states
+           (item_id, status, current_step, started_at, completed_at, attempt_count)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      ).run('install-homebrew', 'in_progress', 'step-1', 1000, null, 1);
+
+      const app = buildApp(FIXTURE_CHECKLIST, db);
+      const res = await request(app).get('/api/checklist');
+      expect(res.status).toBe(200);
+      const homebrew = res.body.items.find(
+        (i: { item_id: string }) => i.item_id === 'install-homebrew',
+      );
+      expect(homebrew).toMatchObject({
+        item_id: 'install-homebrew',
+        title: 'Homebrew 설치',
+        status: 'in_progress',
+        current_step: 'step-1',
+        started_at: 1000,
+        completed_at: null,
+        attempt_count: 1,
+      });
+    });
+
+    it('preserves yaml item order in the response', async () => {
+      const app = buildApp(FIXTURE_CHECKLIST, db);
+      const res = await request(app).get('/api/checklist');
+      expect(res.body.items.map((i: { item_id: string }) => i.item_id)).toEqual([
+        'install-homebrew',
+        'configure-git',
+      ]);
+    });
+  });
+
+  describe('POST /api/items/:itemId/start', () => {
+    it('inserts a new in_progress row with started_at and attempt_count=1', async () => {
+      const fixedNow = 1_700_000_000_000;
+      const app = buildApp(FIXTURE_CHECKLIST, db, () => fixedNow);
+      const res = await request(app).post('/api/items/install-homebrew/start');
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ ok: true });
+
+      const row = db
+        .prepare('SELECT * FROM item_states WHERE item_id = ?')
+        .get('install-homebrew') as {
+          item_id: string;
+          status: string;
+          started_at: number | null;
+          completed_at: number | null;
+          attempt_count: number;
+        };
+      expect(row.status).toBe('in_progress');
+      expect(row.started_at).toBe(fixedNow);
+      expect(row.completed_at).toBeNull();
+      expect(row.attempt_count).toBe(1);
+    });
+
+    it('increments attempt_count and refreshes started_at on subsequent starts', async () => {
+      let now = 1_000;
+      const app = buildApp(FIXTURE_CHECKLIST, db, () => now);
+      await request(app).post('/api/items/install-homebrew/start').expect(200);
+      now = 2_000;
+      await request(app).post('/api/items/install-homebrew/start').expect(200);
+
+      const row = db
+        .prepare('SELECT * FROM item_states WHERE item_id = ?')
+        .get('install-homebrew') as {
+          status: string;
+          started_at: number | null;
+          attempt_count: number;
+        };
+      expect(row.status).toBe('in_progress');
+      expect(row.started_at).toBe(2_000);
+      expect(row.attempt_count).toBe(2);
+    });
+
+    it('returns 404 with item_not_found error when itemId is unknown', async () => {
+      const app = buildApp(FIXTURE_CHECKLIST, db);
+      const res = await request(app).post('/api/items/does-not-exist/start');
+      expect(res.status).toBe(404);
+      expect(res.body).toEqual({ error: 'item_not_found' });
+    });
+
+    it('does not insert a row when item is unknown', async () => {
+      const app = buildApp(FIXTURE_CHECKLIST, db);
+      await request(app).post('/api/items/nope/start');
+      const row = db
+        .prepare('SELECT * FROM item_states WHERE item_id = ?')
+        .get('nope');
+      expect(row).toBeUndefined();
+    });
+
+    it('after start, GET /api/checklist reflects in_progress state', async () => {
+      const fixedNow = 5_555;
+      const app = buildApp(FIXTURE_CHECKLIST, db, () => fixedNow);
+      await request(app).post('/api/items/install-homebrew/start').expect(200);
+      const res = await request(app).get('/api/checklist');
+      const homebrew = res.body.items.find(
+        (i: { item_id: string }) => i.item_id === 'install-homebrew',
+      );
+      expect(homebrew.status).toBe('in_progress');
+      expect(homebrew.started_at).toBe(fixedNow);
+      expect(homebrew.attempt_count).toBe(1);
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,9 @@ importers:
       pino:
         specifier: ^9.0.0
         version: 9.14.0
+      yaml:
+        specifier: ^2.4.0
+        version: 2.8.3
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -1346,6 +1349,11 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
@@ -2603,5 +2611,7 @@ snapshots:
       strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
+
+  yaml@2.8.3: {}
 
   zod@3.25.76: {}


### PR DESCRIPTION
# Code Review — spec-003-daemon-checklist-loader

- **브랜치**: feature/spec-003-daemon-checklist-loader (HEAD = 5d5ad52)
- **베이스**: main (cb192a0)
- **리뷰 대상 commit**: 5d5ad52 `feat(spec-003-daemon-checklist-loader): bundle checklist.yaml + GET/POST /api/checklist`
- **권위 문서**: docs/PRD-MVP-SLIM.md v0.10, BOUNDARIES.md v1.0
- **spec**: specs/spec-003-daemon-checklist-loader.md
- **검증 환경**: `pnpm install` → `pnpm -r build` → `pnpm -r lint` → `pnpm -r test` 모두 통과

---

## 종합 판정

| # | 항목 | 판정 |
|---|------|-----|
| 1 | AC 정합성 (PRD §10 / spec §AC) | **PASS** |
| 2 | PRD 정합성 | **PASS** |
| 3 | 데이터 모델 정합성 (PRD §8) | **PASS** |
| 4 | API 계약 정합성 (PRD §9) | **PASS** |
| 5 | 보안 점검 | **PASS** |
| 6 | 코드 품질 (함수 50줄/커버리지 80%+) | **PASS** |
| 7 | BOUNDARIES.md 준수 | **PASS** |
| 8 | 의존성 체크 (PRD §12) | **PASS** |

**최종**: 모두 PASS.

---

## 1. AC 정합성 — **PASS**

spec §Acceptance Criteria 항목별 충족 매핑.

| AC | 코드/테스트 | 결과 |
|----|------------|-----|
| `GET /api/checklist`가 PRD §9.1.1 형태(`items[]`, 항목별 `item_id`/`title`/`status`/`current_step`) 반환 | `packages/daemon/src/routes/checklist.ts:28-33` (라우터) + `:51-68` (`buildResponseItem`) → `tests/checklist-routes.test.ts:71-92` | PASS |
| 첫 호출 시 row 없으면 `status: "pending"` 자동 채움 | `routes/checklist.ts:56-67` (state null → pending 디폴트) → `tests/checklist-routes.test.ts:79-92` | PASS |
| `POST /api/items/install-homebrew/start` → `in_progress`, `started_at` 채움, `attempt_count` 1↑ | `src/checklist/repository.ts:30-38` UPSERT (`ON CONFLICT DO UPDATE` `attempt_count = item_states.attempt_count + 1`) → `tests/checklist-routes.test.ts:128-168` | PASS |
| 존재하지 않는 `:itemId` → 404 `{"error":"item_not_found"}` | `routes/checklist.ts:38-42` (`itemsById.has` 가드) → `tests/checklist-routes.test.ts:170-184` | PASS |
| 잘못된 yaml 부팅 시 명시적 에러 → 서버 기동 실패 | `src/checklist/loader.ts:37-41` (`ChecklistFileSchema.parse` throws), `src/index.ts:28` (bootstrap에서 동기 호출하여 throw 시 listen 안 함) → `tests/checklist-loader.test.ts:73-122` | PASS |
| PRD §11 5개 항목 모두 zod 통과 | 번들된 `content/checklist.yaml` + `tests/checklist-loader.test.ts:26-31` (5 ID 순서 검증) | PASS |
| `pnpm test` 통과 | 32 tests / 6 files all green | PASS |
| `pnpm build` 통과 | tsc + copy-migrations 모두 성공 | PASS |
| `pnpm lint` 에러 0 | tsc `noEmit` typecheck 0 errors | PASS |
| 테스트 커버리지 ≥ 80% | 100% lines/funcs/stmts, 97.56% branches (vitest threshold 80% 통과) | PASS |
| BOUNDARIES.md 준수 | §7 별도 점검 — 위반 없음 | PASS |
| 신규 의존성은 `yaml`만 추가 | `packages/daemon/package.json` diff: `yaml ^2.4.0` 한 건 (PRD §12에 등재) | PASS |

---

## 2. PRD 정합성 — **PASS**

- PRD §6.2 B "Daemon … HTTP 서버 (localhost:7777)" 의도와 일치 (포트는 `index.ts:8` `DEFAULT_PORT = 7777`).
- PRD §F-CORE-03 "콘텐츠는 데몬에 번들된 yaml 사용" — `packages/daemon/content/checklist.yaml`을 `package.json#files`에 포함하여 npm tarball에 동봉하고, 런타임은 `dist/checklist/loader.js` 기준 `../../content/checklist.yaml`로 해소(소스/배포 양쪽 동일 경로).
- PRD §11 콘텐츠 5개 항목 yaml은 한 글자 단위로 일치하는 복사본임을 확인 (PRD §11 lines 650-797 vs `content/checklist.yaml` lines 1-147).
- 비범위(SPEC-005 자동 완료, SPEC-006 클립보드 트리거, SPEC-007 검증 실행, SPEC-012 step 전이, yaml 핫리로드/webhook) 모두 구현 안 됨 — spec 외 영역 침범 없음.

---

## 3. 데이터 모델 정합성 (PRD §8) — **PASS**

- 사용 테이블은 `item_states` 단일. PRD §8.1 정의:
  ```
  item_id TEXT PRIMARY KEY, status TEXT NOT NULL CHECK(...), current_step TEXT,
  started_at INTEGER, completed_at INTEGER, attempt_count INTEGER DEFAULT 0
  ```
  과 사용 패턴 정확히 일치 (`repository.ts:22-38`, `routes/checklist.ts:56-67`).
- 새 컬럼/테이블 추가 없음, 임의 타입 추가 없음.
- `status` 값은 `pending`/`in_progress`만 사용 — `CHECK(status IN(...))` 제약과 일치.
- `attempt_count` 증분은 SQL 표현식(`item_states.attempt_count + 1`)으로 처리 — read-modify-write 레이스 없음. 좋음.
- `started_at`은 호출 시 주입한 `now()` 그대로 저장 (epoch ms; PRD §8 `INTEGER` 타입과 호환).

---

## 4. API 계약 정합성 (PRD §9) — **PASS**

| 엔드포인트 | PRD § | 구현 위치 | 결과 |
|-----------|------|----------|------|
| `GET /api/checklist` → 200 `{items:[{item_id,status,...}]}` | §9.1.1 | `routes/checklist.ts:28-33` | PASS — `items` 배열, 각 객체에 `item_id`+`status` 포함. 추가 필드(`title`/`current_step`/`started_at`/`completed_at`/`attempt_count`)는 PRD가 `...`로 남겨둔 부분이며 spec AC가 명시 요구한 필드 집합과 합치. |
| `POST /api/items/:itemId/start` → 200 `{"ok":true}` | §9.1.2 | `routes/checklist.ts:35-46` | PASS — 응답 형태 정확히 일치. |
| 404 `{"error":"item_not_found"}` | spec 정의 (PRD에 명시 없음) | `routes/checklist.ts:38-42` | PASS — PRD에 미정의된 영역이므로 spec 정의를 따름. Breaking change 아님. |

- 라우트 경로/메서드/요청·응답 JSON 필드 모두 PRD 준수.
- PRD §9의 다른 라우트(`/api/vision/...`, `/api/consents`, `/api/clipboard`, `/api/verify/run`)는 후속 spec 영역 — 본 spec에서 손대지 않음.
- shared 패키지의 Zod 스키마(`ChecklistResponseSchema`/`StartItemResponseSchema` 등)와 응답 shape이 일치.

---

## 5. 보안 점검 — **PASS**

- **시크릿 하드코딩**: 코드/yaml/테스트 어디에도 API 키, 토큰, 사용자 PII 평문 없음. yaml 안의 `vpn.wrtn.ax`/`security.wrtn.io` 같은 사내 URL은 BOUNDARIES §5 "yaml은 OK"에 해당. 코드 상수 박제 없음.
- **SQL 인젝션**: `repository.ts`의 모든 쿼리는 `db.prepare(...)` + 위치/named 파라미터(`?`, `@item_id`, `@now`)만 사용. 문자열 연결 0건. 라우트 핸들러는 `req.params.itemId`를 prepared stmt 파라미터로만 전달하고, 별도로 `itemsById.has(itemId)` 가드로 화이트리스트 검증. 두 단계 안전장치.
- **캡처 이미지 파기 (PRD §8.2 / AC-VIS-07)**: 본 spec은 Vision 호출/스크린 캡처를 다루지 않음 — 해당 영역에 어떤 디스크/메모리 흔적도 남기지 않음 (검증: 코드 상에 `screencapture`/`sharp`/이미지 buffer 처리 0건). 보존 정책 위반 가능성 없음.
- **에러 응답 누설**: `server.ts`의 글로벌 에러 핸들러는 `internal_server_error` 일반 메시지만 응답. ZodError는 `validation_error` + `issues`만 응답하며 stack/internal path 노출 없음.

---

## 6. 코드 품질 — **PASS**

함수 길이 (50줄 미만, 빈줄 포함):

| 함수 | 위치 | 라인 수 |
|------|------|--------|
| `loadChecklist` | `loader.ts:24-31` | 8 |
| `parse` | `loader.ts:37-41` | 5 |
| `createChecklistRepository` | `repository.ts:19-58` | 40 |
| `createChecklistRouter` | `routes/checklist.ts:20-49` | 30 |
| `buildResponseItem` | `routes/checklist.ts:51-68` | 18 |
| `registerApiRoutes` | `routes/index.ts:13-15` | 3 |

모두 50줄 미만. ✅

테스트 커버리지 (vitest --coverage):

```
src/checklist/loader.ts      100% / 100% / 100% / 100%
src/checklist/repository.ts  100% / 100% / 100% / 100%
src/routes/checklist.ts      100% / 90.9% / 100% / 100%   ← line 23 미커버 분기는 `deps.now ?? Date.now`의 디폴트 측 — 무해
src/routes/index.ts          100% / 100% / 100% / 100%
```

threshold 80%(lines/funcs/branches/statements) 모두 충족 — vitest가 강제 검증.

기타 품질 관찰:
- DI 친화 (라우터 deps에 `now`/`db`/`checklist` 주입) → 테스트 재현성 확보.
- 모듈 캐시(`cached`)는 `resetChecklistCache()`로 테스트에서 리셋 가능 — 글로벌 상태 누출 안전장치 갖춤.
- TypeScript strict 통과, 미사용 변수/파라미터 0.

---

## 7. BOUNDARIES.md 준수 — **PASS**

`git show 5d5ad52 --stat`로 spec-003 commit 변경 파일 확인:

```
packages/daemon/content/checklist.yaml         | 신규
packages/daemon/package.json                   | yaml dep + files["content"]
packages/daemon/src/checklist/loader.ts        | 신규
packages/daemon/src/checklist/repository.ts    | 신규
packages/daemon/src/index.ts                   | bootstrap에 loadChecklist + registerApiRoutes 추가
packages/daemon/src/routes/checklist.ts        | 신규
packages/daemon/src/routes/index.ts            | 신규
packages/daemon/tests/checklist-loader.test.ts | 신규
packages/daemon/tests/checklist-routes.test.ts | 신규
pnpm-lock.yaml                                 | yaml 추가 반영
```

- BOUNDARIES §1 (read-only PRD/archive/BOUNDARIES.md/spec-template.md/.git/타 spec): 변경 0건 ✅
- BOUNDARIES §2 (spec 패키지 경로 = `packages/daemon/`만 수정): 모든 변경이 `packages/daemon/` 또는 루트 `pnpm-lock.yaml`(자동 생성)에 한정 ✅. 루트 `package.json`/`pnpm-workspace.yaml`/`tsconfig.base.json` 변경 0건. 다른 패키지 디렉토리(`shared`, `floating-hint`, `cli`) 변경 0건.
- BOUNDARIES §4 (API/스키마 Breaking Change 금지): 라우트 경로/메서드/필드/HTTP 코드 모두 PRD §9 준수, SQLite 스키마 변경 0건, shared export 호환성 깨는 변경 0건 ✅
- BOUNDARIES §5 (시크릿): 위반 없음 ✅

---

## 8. 의존성 체크 (PRD §12) — **PASS**

`packages/daemon/package.json` diff(spec-003 commit)에서 추가된 의존성:

| 추가 패키지 | 버전 | PRD §12 매칭 |
|-----------|------|------------|
| `yaml` | `^2.4.0` | ✅ "yaml ^2.4 / daemon / checklist.yaml 파싱" |

- 그 외 직접 의존성 추가/제거 없음.
- 메이저 버전 변경 없음 (`yaml ^2.4` 그대로).
- 의존성 빌드/번들 외 transitive 신규 import 없음 (코드 검색 결과 `yaml` import는 `loader.ts` 1곳).

---

## 부가 관찰 (정보용, 판정에 영향 없음)

- `src/index.ts:28`의 `loadChecklist()`는 `migrate()` 이후 호출되어, yaml 파싱 실패 시 DB는 이미 초기화되었지만 listen 전에 throw하므로 사용자 영향 없음 (서버 미기동). 이상 동작 없음.
- 루트 `package.json`의 `pnpm.onlyBuiltDependencies`(spec-002에서 추가됨)에 `better-sqlite3` 포함 — postinstall 빌드 신뢰 범위 적절히 좁힘.
- `routes/checklist.ts:24` `Map<string, ChecklistItem>` 캐싱은 라우터 인스턴스당 1회 빌드 — O(1) lookup으로 핫패스 부하 최소.
- 응답 객체 키 순서가 `state` 분기/`pending` 분기에서 다름(`...state, title` vs 명시 객체). JSON 직렬화에 영향 없음. 무해.

---

## 결론

8개 항목 모두 PASS. AC 13개 전부 코드 또는 테스트로 충족, PRD §8/§9 계약 준수, BOUNDARIES.md 위반 없음, 신규 의존성은 PRD §12 화이트리스트의 `yaml`만 추가. 머지 가능 상태.

<promise>SPEC_003_DAEMON_CHECKLIST_LOADER_REVIEW_PASS</promise>
