### PR TITLE
[Ralph] spec-004-daemon-consents

### DIFF
--- a/packages/daemon/src/consents/middleware.ts
+++ b/packages/daemon/src/consents/middleware.ts
@@ -1,0 +1,46 @@
+import type { ConsentType } from '@onboarding/shared';
+import type { RequestHandler } from 'express';
+
+import type { DatabaseInstance } from '../db/index.js';
+import { createConsentsRepository } from './repository.js';
+
+// PRD §9.1.3 error contracts:
+//   401 { "error": "screen_recording_permission_required" }   ← OS-level permission
+//   403 { "error": "consent_required", "missing": [...] }      ← user consent
+// SR missing wins over the 403 branch — the OS gate must be satisfied first.
+export function requireConsent(
+  db: DatabaseInstance,
+  ...required: ConsentType[]
+): RequestHandler {
+  const repo = createConsentsRepository(db);
+  return (_req, res, next) => {
+    if (required.length === 0) {
+      next();
+      return;
+    }
+
+    const missing: ConsentType[] = [];
+    let screenRecordingMissing = false;
+
+    for (const type of required) {
+      const record = repo.get(type);
+      if (!record.granted) {
+        if (type === 'screen_recording') {
+          screenRecordingMissing = true;
+        } else {
+          missing.push(type);
+        }
+      }
+    }
+
+    if (screenRecordingMissing) {
+      res.status(401).json({ error: 'screen_recording_permission_required' });
+      return;
+    }
+    if (missing.length > 0) {
+      res.status(403).json({ error: 'consent_required', missing });
+      return;
+    }
+    next();
+  };
+}

--- a/packages/daemon/src/consents/repository.ts
+++ b/packages/daemon/src/consents/repository.ts
@@ -1,0 +1,94 @@
+import {
+  CONSENT_TYPES,
+  type ConsentRecord,
+  type ConsentType,
+} from '@onboarding/shared';
+
+import type { DatabaseInstance } from '../db/index.js';
+
+interface ConsentRow {
+  consent_type: ConsentType;
+  granted: number;
+  granted_at: number | null;
+  revoked_at: number | null;
+}
+
+export type ConsentsMap = {
+  [K in ConsentType]: ConsentRecord;
+};
+
+export interface ConsentsRepository {
+  getAll(): ConsentsMap;
+  get(type: ConsentType): ConsentRecord;
+  upsert(type: ConsentType, granted: boolean, now: number): void;
+}
+
+export function createConsentsRepository(
+  db: DatabaseInstance,
+): ConsentsRepository {
+  const selectStmt = db.prepare(
+    `SELECT consent_type, granted, granted_at, revoked_at
+       FROM consents
+      WHERE consent_type = ?`,
+  );
+
+  // granted=true → set granted_at to now, clear revoked_at.
+  const grantStmt = db.prepare(
+    `INSERT INTO consents (consent_type, granted, granted_at, revoked_at)
+     VALUES (@type, 1, @now, NULL)
+     ON CONFLICT(consent_type) DO UPDATE SET
+       granted     = 1,
+       granted_at  = @now,
+       revoked_at  = NULL`,
+  );
+
+  // granted=false → preserve existing granted_at, set revoked_at to now.
+  const revokeStmt = db.prepare(
+    `INSERT INTO consents (consent_type, granted, granted_at, revoked_at)
+     VALUES (@type, 0, NULL, @now)
+     ON CONFLICT(consent_type) DO UPDATE SET
+       granted    = 0,
+       revoked_at = @now`,
+  );
+
+  function rowToRecord(type: ConsentType, row: ConsentRow | undefined): ConsentRecord {
+    if (!row) {
+      return {
+        consent_type: type,
+        granted: false,
+        granted_at: null,
+        revoked_at: null,
+      };
+    }
+    return {
+      consent_type: row.consent_type,
+      granted: row.granted === 1,
+      granted_at: row.granted_at,
+      revoked_at: row.revoked_at,
+    };
+  }
+
+  return {
+    getAll() {
+      const map = {} as ConsentsMap;
+      for (const type of CONSENT_TYPES) {
+        const row = selectStmt.get(type) as ConsentRow | undefined;
+        map[type] = rowToRecord(type, row);
+      }
+      return map;
+    },
+
+    get(type) {
+      const row = selectStmt.get(type) as ConsentRow | undefined;
+      return rowToRecord(type, row);
+    },
+
+    upsert(type, granted, now) {
+      if (granted) {
+        grantStmt.run({ type, now });
+      } else {
+        revokeStmt.run({ type, now });
+      }
+    },
+  };
+}

--- a/packages/daemon/src/routes/consents.ts
+++ b/packages/daemon/src/routes/consents.ts
@@ -1,0 +1,35 @@
+import { PostConsentRequestSchema } from '@onboarding/shared';
+import { Router, type Request, type Response, type NextFunction } from 'express';
+
+import { createConsentsRepository } from '../consents/repository.js';
+import type { DatabaseInstance } from '../db/index.js';
+
+export interface ConsentsRouterDeps {
+  db: DatabaseInstance;
+  now?: () => number;
+}
+
+export function createConsentsRouter(deps: ConsentsRouterDeps): Router {
+  const router = Router();
+  const repo = createConsentsRepository(deps.db);
+  const now = deps.now ?? Date.now;
+
+  router.get('/api/consents', (_req: Request, res: Response) => {
+    res.status(200).json(repo.getAll());
+  });
+
+  router.post(
+    '/api/consents',
+    (req: Request, res: Response, next: NextFunction) => {
+      const parsed = PostConsentRequestSchema.safeParse(req.body);
+      if (!parsed.success) {
+        next(parsed.error);
+        return;
+      }
+      repo.upsert(parsed.data.consent_type, parsed.data.granted, now());
+      res.status(200).json({ ok: true });
+    },
+  );
+
+  return router;
+}

--- a/packages/daemon/src/routes/index.ts
+++ b/packages/daemon/src/routes/index.ts
@@ -3,6 +3,7 @@ import type { Application } from 'express';
 
 import type { DatabaseInstance } from '../db/index.js';
 import { createChecklistRouter } from './checklist.js';
+import { createConsentsRouter } from './consents.js';
 
 export interface ApiRoutesDeps {
   checklist: ChecklistFile;
@@ -12,4 +13,5 @@ export interface ApiRoutesDeps {
 
 export function registerApiRoutes(app: Application, deps: ApiRoutesDeps): void {
   app.use(createChecklistRouter(deps));
+  app.use(createConsentsRouter({ db: deps.db, now: deps.now }));
 }

--- a/packages/daemon/src/system/screen-recording.ts
+++ b/packages/daemon/src/system/screen-recording.ts
@@ -1,0 +1,24 @@
+// macOS Screen Recording permission check (PRD §7.7 F-P8-08, AC-CORE-01).
+// Real CGPreflightScreenCaptureAccess invocation requires a Node native binding
+// which is intentionally deferred to SPEC-009. This module exposes the wrapper
+// surface so the daemon and CLI can already branch on platform support.
+
+export type ScreenRecordingCheckReason = 'unsupported_platform';
+
+export interface ScreenRecordingCheck {
+  supported: boolean;
+  granted: boolean | null;
+  reason?: ScreenRecordingCheckReason;
+}
+
+export function checkScreenRecordingPermission(): ScreenRecordingCheck {
+  if (process.platform !== 'darwin') {
+    return {
+      supported: false,
+      granted: null,
+      reason: 'unsupported_platform',
+    };
+  }
+  // SPEC-009 wires the native CGPreflightScreenCaptureAccess call here.
+  return { supported: true, granted: null };
+}

--- a/packages/daemon/tests/consents-middleware.test.ts
+++ b/packages/daemon/tests/consents-middleware.test.ts
@@ -1,0 +1,118 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import pino from 'pino';
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createConsentsRepository } from '../src/consents/repository.js';
+import { requireConsent } from '../src/consents/middleware.js';
+import { openDatabase, type DatabaseInstance } from '../src/db/index.js';
+import { migrate } from '../src/db/migrate.js';
+import { createServer } from '../src/server.js';
+
+const silentLogger = pino({ level: 'silent' });
+
+function buildApp(
+  db: DatabaseInstance,
+  required: Array<'screen_recording' | 'anthropic_transmission'>,
+) {
+  return createServer({
+    logger: silentLogger,
+    registerRoutes: (app) => {
+      app.get(
+        '/__test/protected',
+        requireConsent(db, ...required),
+        (_req, res) => {
+          res.status(200).json({ ok: true });
+        },
+      );
+    },
+  });
+}
+
+describe('requireConsent middleware', () => {
+  let tmpDir: string;
+  let db: DatabaseInstance;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'onboarding-consents-mw-'));
+    db = openDatabase(join(tmpDir, 'agent.db'));
+    migrate(db);
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('passes through when all required consents are granted', async () => {
+    const repo = createConsentsRepository(db);
+    repo.upsert('screen_recording', true, 1);
+    repo.upsert('anthropic_transmission', true, 1);
+
+    const app = buildApp(db, ['screen_recording', 'anthropic_transmission']);
+    const res = await request(app).get('/__test/protected');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it('returns 401 screen_recording_permission_required when SR missing', async () => {
+    const repo = createConsentsRepository(db);
+    repo.upsert('anthropic_transmission', true, 1);
+
+    const app = buildApp(db, ['screen_recording', 'anthropic_transmission']);
+    const res = await request(app).get('/__test/protected');
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ error: 'screen_recording_permission_required' });
+  });
+
+  it('returns 401 SR error when both missing (SR takes precedence)', async () => {
+    const app = buildApp(db, ['screen_recording', 'anthropic_transmission']);
+    const res = await request(app).get('/__test/protected');
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ error: 'screen_recording_permission_required' });
+  });
+
+  it('returns 403 consent_required with missing array when only anthropic missing', async () => {
+    const repo = createConsentsRepository(db);
+    repo.upsert('screen_recording', true, 1);
+
+    const app = buildApp(db, ['screen_recording', 'anthropic_transmission']);
+    const res = await request(app).get('/__test/protected');
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({
+      error: 'consent_required',
+      missing: ['anthropic_transmission'],
+    });
+  });
+
+  it('returns 403 with missing array when only anthropic_transmission required and missing', async () => {
+    const app = buildApp(db, ['anthropic_transmission']);
+    const res = await request(app).get('/__test/protected');
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({
+      error: 'consent_required',
+      missing: ['anthropic_transmission'],
+    });
+  });
+
+  it('treats revoked consent as missing', async () => {
+    const repo = createConsentsRepository(db);
+    repo.upsert('anthropic_transmission', true, 1);
+    repo.upsert('anthropic_transmission', false, 2);
+
+    const app = buildApp(db, ['anthropic_transmission']);
+    const res = await request(app).get('/__test/protected');
+    expect(res.status).toBe(403);
+    expect(res.body.missing).toEqual(['anthropic_transmission']);
+  });
+
+  it('passes through when no consents are required', async () => {
+    const app = buildApp(db, []);
+    const res = await request(app).get('/__test/protected');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+});

--- a/packages/daemon/tests/consents-repo.test.ts
+++ b/packages/daemon/tests/consents-repo.test.ts
@@ -1,0 +1,152 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createConsentsRepository } from '../src/consents/repository.js';
+import { openDatabase, type DatabaseInstance } from '../src/db/index.js';
+import { migrate } from '../src/db/migrate.js';
+
+describe('consents repository', () => {
+  let tmpDir: string;
+  let db: DatabaseInstance;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'onboarding-consents-repo-'));
+    db = openDatabase(join(tmpDir, 'agent.db'));
+    migrate(db);
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('getAll', () => {
+    it('returns default not-granted records when no rows exist', () => {
+      const repo = createConsentsRepository(db);
+      const all = repo.getAll();
+      expect(all).toEqual({
+        screen_recording: {
+          consent_type: 'screen_recording',
+          granted: false,
+          granted_at: null,
+          revoked_at: null,
+        },
+        anthropic_transmission: {
+          consent_type: 'anthropic_transmission',
+          granted: false,
+          granted_at: null,
+          revoked_at: null,
+        },
+      });
+    });
+
+    it('reflects rows persisted in SQLite', () => {
+      const repo = createConsentsRepository(db);
+      repo.upsert('screen_recording', true, 1_000);
+      repo.upsert('anthropic_transmission', true, 2_000);
+      const all = repo.getAll();
+      expect(all.screen_recording.granted).toBe(true);
+      expect(all.screen_recording.granted_at).toBe(1_000);
+      expect(all.anthropic_transmission.granted).toBe(true);
+      expect(all.anthropic_transmission.granted_at).toBe(2_000);
+    });
+  });
+
+  describe('upsert', () => {
+    it('inserts a granted row with granted_at = now and null revoked_at', () => {
+      const repo = createConsentsRepository(db);
+      repo.upsert('anthropic_transmission', true, 12_345);
+
+      const row = db
+        .prepare('SELECT * FROM consents WHERE consent_type = ?')
+        .get('anthropic_transmission') as {
+          consent_type: string;
+          granted: number;
+          granted_at: number | null;
+          revoked_at: number | null;
+        };
+      expect(row.consent_type).toBe('anthropic_transmission');
+      expect(row.granted).toBe(1);
+      expect(row.granted_at).toBe(12_345);
+      expect(row.revoked_at).toBeNull();
+    });
+
+    it('is idempotent — repeated granted=true keeps a single row (PK consent_type)', () => {
+      const repo = createConsentsRepository(db);
+      repo.upsert('screen_recording', true, 100);
+      repo.upsert('screen_recording', true, 200);
+      repo.upsert('screen_recording', true, 300);
+
+      const count = db
+        .prepare('SELECT COUNT(*) AS c FROM consents WHERE consent_type = ?')
+        .get('screen_recording') as { c: number };
+      expect(count.c).toBe(1);
+
+      const row = db
+        .prepare('SELECT * FROM consents WHERE consent_type = ?')
+        .get('screen_recording') as { granted_at: number };
+      // Latest granted_at wins (re-grant refreshes timestamp)
+      expect(row.granted_at).toBe(300);
+    });
+
+    it('preserves granted_at and sets revoked_at when revoking (granted=false)', () => {
+      const repo = createConsentsRepository(db);
+      repo.upsert('anthropic_transmission', true, 1_000);
+      repo.upsert('anthropic_transmission', false, 5_000);
+
+      const row = db
+        .prepare('SELECT * FROM consents WHERE consent_type = ?')
+        .get('anthropic_transmission') as {
+          granted: number;
+          granted_at: number | null;
+          revoked_at: number | null;
+        };
+      expect(row.granted).toBe(0);
+      expect(row.granted_at).toBe(1_000);
+      expect(row.revoked_at).toBe(5_000);
+    });
+
+    it('clears revoked_at when re-granting after revoke', () => {
+      const repo = createConsentsRepository(db);
+      repo.upsert('anthropic_transmission', true, 1_000);
+      repo.upsert('anthropic_transmission', false, 2_000);
+      repo.upsert('anthropic_transmission', true, 3_000);
+
+      const row = db
+        .prepare('SELECT * FROM consents WHERE consent_type = ?')
+        .get('anthropic_transmission') as {
+          granted: number;
+          granted_at: number | null;
+          revoked_at: number | null;
+        };
+      expect(row.granted).toBe(1);
+      expect(row.granted_at).toBe(3_000);
+      expect(row.revoked_at).toBeNull();
+    });
+
+    it('allows revoke without prior grant (no row → revoked_at row, granted_at=null)', () => {
+      const repo = createConsentsRepository(db);
+      repo.upsert('anthropic_transmission', false, 7_000);
+
+      const row = db
+        .prepare('SELECT * FROM consents WHERE consent_type = ?')
+        .get('anthropic_transmission') as {
+          granted: number;
+          granted_at: number | null;
+          revoked_at: number | null;
+        };
+      expect(row.granted).toBe(0);
+      expect(row.granted_at).toBeNull();
+      expect(row.revoked_at).toBe(7_000);
+    });
+
+    it('rejects invalid consent_type via SQLite CHECK constraint', () => {
+      const repo = createConsentsRepository(db);
+      // @ts-expect-error — runtime guard, type system also rejects
+      expect(() => repo.upsert('bogus_consent', true, 1)).toThrow();
+    });
+  });
+});

--- a/packages/daemon/tests/consents-routes.test.ts
+++ b/packages/daemon/tests/consents-routes.test.ts
@@ -1,0 +1,170 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import pino from 'pino';
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createConsentsRouter } from '../src/routes/consents.js';
+import { openDatabase, type DatabaseInstance } from '../src/db/index.js';
+import { migrate } from '../src/db/migrate.js';
+import { createServer } from '../src/server.js';
+
+const silentLogger = pino({ level: 'silent' });
+
+function buildApp(db: DatabaseInstance, now: () => number = Date.now) {
+  return createServer({
+    logger: silentLogger,
+    registerRoutes: (app) => {
+      app.use(createConsentsRouter({ db, now }));
+    },
+  });
+}
+
+describe('consents routes', () => {
+  let tmpDir: string;
+  let db: DatabaseInstance;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'onboarding-consents-routes-'));
+    db = openDatabase(join(tmpDir, 'agent.db'));
+    migrate(db);
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('GET /api/consents', () => {
+    it('returns default not-granted records for both consent types', async () => {
+      const app = buildApp(db);
+      const res = await request(app).get('/api/consents');
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        screen_recording: {
+          consent_type: 'screen_recording',
+          granted: false,
+          granted_at: null,
+          revoked_at: null,
+        },
+        anthropic_transmission: {
+          consent_type: 'anthropic_transmission',
+          granted: false,
+          granted_at: null,
+          revoked_at: null,
+        },
+      });
+    });
+  });
+
+  describe('POST /api/consents', () => {
+    it('persists a granted consent and the GET round-trip reflects it (AC-CORE-02)', async () => {
+      const fixedNow = 1_700_000_000_000;
+      const app = buildApp(db, () => fixedNow);
+
+      const post = await request(app)
+        .post('/api/consents')
+        .send({ consent_type: 'anthropic_transmission', granted: true });
+      expect(post.status).toBe(200);
+      expect(post.body).toEqual({ ok: true });
+
+      const get = await request(app).get('/api/consents');
+      expect(get.status).toBe(200);
+      expect(get.body.anthropic_transmission).toEqual({
+        consent_type: 'anthropic_transmission',
+        granted: true,
+        granted_at: fixedNow,
+        revoked_at: null,
+      });
+      expect(get.body.screen_recording.granted).toBe(false);
+    });
+
+    it('records both consents independently', async () => {
+      let now = 100;
+      const app = buildApp(db, () => now);
+      await request(app)
+        .post('/api/consents')
+        .send({ consent_type: 'screen_recording', granted: true })
+        .expect(200);
+      now = 200;
+      await request(app)
+        .post('/api/consents')
+        .send({ consent_type: 'anthropic_transmission', granted: true })
+        .expect(200);
+
+      const get = await request(app).get('/api/consents');
+      expect(get.body.screen_recording.granted_at).toBe(100);
+      expect(get.body.anthropic_transmission.granted_at).toBe(200);
+    });
+
+    it('revoking preserves granted_at and sets revoked_at', async () => {
+      let now = 100;
+      const app = buildApp(db, () => now);
+      await request(app)
+        .post('/api/consents')
+        .send({ consent_type: 'anthropic_transmission', granted: true })
+        .expect(200);
+      now = 555;
+      await request(app)
+        .post('/api/consents')
+        .send({ consent_type: 'anthropic_transmission', granted: false })
+        .expect(200);
+
+      const get = await request(app).get('/api/consents');
+      expect(get.body.anthropic_transmission).toEqual({
+        consent_type: 'anthropic_transmission',
+        granted: false,
+        granted_at: 100,
+        revoked_at: 555,
+      });
+    });
+
+    it('rejects unknown consent_type with 400 validation_error', async () => {
+      const app = buildApp(db);
+      const res = await request(app)
+        .post('/api/consents')
+        .send({ consent_type: 'face_recognition', granted: true });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('validation_error');
+    });
+
+    it('rejects missing granted field with 400 validation_error', async () => {
+      const app = buildApp(db);
+      const res = await request(app)
+        .post('/api/consents')
+        .send({ consent_type: 'screen_recording' });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('validation_error');
+    });
+
+    it('rejects non-boolean granted with 400 validation_error', async () => {
+      const app = buildApp(db);
+      const res = await request(app)
+        .post('/api/consents')
+        .send({ consent_type: 'screen_recording', granted: 'yes' });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('validation_error');
+    });
+
+    it('keeps a single row when same type is granted twice (PK consent_type)', async () => {
+      let now = 1;
+      const app = buildApp(db, () => now);
+      await request(app)
+        .post('/api/consents')
+        .send({ consent_type: 'screen_recording', granted: true })
+        .expect(200);
+      now = 2;
+      await request(app)
+        .post('/api/consents')
+        .send({ consent_type: 'screen_recording', granted: true })
+        .expect(200);
+
+      const count = db
+        .prepare('SELECT COUNT(*) AS c FROM consents')
+        .get() as { c: number };
+      expect(count.c).toBe(1);
+    });
+  });
+});

--- a/packages/daemon/tests/screen-recording.test.ts
+++ b/packages/daemon/tests/screen-recording.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { checkScreenRecordingPermission } from '../src/system/screen-recording.js';
+
+describe('checkScreenRecordingPermission', () => {
+  it('reports unsupported_platform on non-darwin platforms', () => {
+    vi.stubGlobal('process', { ...process, platform: 'linux' });
+    try {
+      const result = checkScreenRecordingPermission();
+      expect(result.supported).toBe(false);
+      expect(result.reason).toBe('unsupported_platform');
+      expect(result.granted).toBeNull();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('reports supported on darwin (granted is null until SPEC-009 wires native binding)', () => {
+    vi.stubGlobal('process', { ...process, platform: 'darwin' });
+    try {
+      const result = checkScreenRecordingPermission();
+      expect(result.supported).toBe(true);
+      expect(result.reason).toBeUndefined();
+      // SPEC-009 will plug in CGPreflightScreenCaptureAccess; for now granted is null.
+      expect(result.granted).toBeNull();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});


### PR DESCRIPTION
# Code Review: spec-004-daemon-consents

- **브랜치**: `feature/spec-004-daemon-consents` (HEAD `a63f207`)
- **리뷰 대상 커밋**: `a63f207 feat(spec-004-daemon-consents): add consents repository, routes, and requireConsent middleware`
- **검증 일자**: 2026-05-01
- **검증자**: 자동 리뷰 (read-only)

리뷰 대상 파일 (이 spec 커밋에서 추가/수정된 파일만):

| 경로 | 종류 |
|------|------|
| `packages/daemon/src/consents/repository.ts` | 신규 |
| `packages/daemon/src/consents/middleware.ts` | 신규 |
| `packages/daemon/src/routes/consents.ts` | 신규 |
| `packages/daemon/src/routes/index.ts` | 2 라인 추가 (consents 라우터 등록) |
| `packages/daemon/src/system/screen-recording.ts` | 신규 |
| `packages/daemon/tests/consents-repo.test.ts` | 신규 |
| `packages/daemon/tests/consents-routes.test.ts` | 신규 |
| `packages/daemon/tests/consents-middleware.test.ts` | 신규 |
| `packages/daemon/tests/screen-recording.test.ts` | 신규 |

빌드/테스트/린트 결과 (재현):

```
pnpm test  → 10 files, 57 tests passed, coverage 100% lines / 97.22% branches
pnpm build → 성공 (tsc -p tsconfig.build.json + copy-migrations)
pnpm lint  → 성공 (tsc -p tsconfig.json, 에러 0)
```

---

## 1. AC 정합성 — **PASS**

PRD §10 + spec §"Acceptance Criteria"의 각 항목과 충족 위치:

| AC | 충족 코드/테스트 |
|----|------------------|
| **AC-CORE-02** (POST 동의 → SQLite 기록 → GET 반환) | `tests/consents-routes.test.ts:63-82` round-trip 명시 (commit + AC 코멘트 포함) |
| `consent_type` 허용값은 `screen_recording`, `anthropic_transmission` (zod CHECK) | `packages/shared/src/schemas/api.ts:61` `ConsentTypeSchema = z.enum(CONSENT_TYPES)` + `routes/consents.ts:24` `PostConsentRequestSchema.safeParse`. `tests/consents-routes.test.ts:124` `face_recognition` 거절 검증. SQLite CHECK도 추가 안전망 (`migrations/001_init.sql:51`, `tests/consents-repo.test.ts:146`) |
| 미들웨어가 두 동의 모두 검사 + `missing` 배열 명시 | `consents/middleware.ts:25-43` + `tests/consents-middleware.test.ts:78-99` |
| 같은 type granted=true 두 번 → row 1개 (PK consent_type) | `repository.ts:36-43` `ON CONFLICT(consent_type) DO UPDATE` + `tests/consents-repo.test.ts:77-93` & `tests/consents-routes.test.ts:151-168` |
| Screen Recording macOS API + 비-macOS `unsupported_platform` | `system/screen-recording.ts:14-23` + `tests/screen-recording.test.ts` 두 분기 |
| `pnpm test` 통과 | 위 재현 결과 — 57 passed |
| `pnpm build` 통과 | 위 재현 결과 |
| `pnpm lint` 에러 0 | 위 재현 결과 |
| 커버리지 ≥ 80% | 100% lines, 97.22% branches (소비자 라우터 제외 모든 spec-004 산출물 100% 라인) |
| BOUNDARIES.md 준수 | §7 참조 |
| 신규 의존성 없음 | §8 참조 |

**판정**: PASS. spec의 모든 AC가 코드/테스트에 직접 매핑된다. `granted=true → granted_at=now`, `granted=false → revoked_at=now & granted_at 보존` 의미가 spec 출력 명세와 정확히 일치 (`repository.ts:36-52`, 검증 테스트 `consents-repo.test.ts:95-128`).

---

## 2. PRD 정합성 — **PASS**

- PRD §7.7 `F-P8-08` (동의 미부여 시 차단): `requireConsent` 미들웨어가 응답 분기 제공. 실제 Vision 라우트에 부착하는 작업은 spec-009 범위 — spec-004 비범위와 일치.
- PRD §6.2 B (daemon HTTP 모듈) 안에서만 동작. `packages/daemon/`만 수정.
- PRD §14.1 (Anthropic 사내 정책 사전 승인 리스크): 동의 등록 인프라가 사용자 측 차단 게이트를 만들어 리스크를 코드 레이어로 흡수.
- spec 비범위 항목(macOS 권한 다이얼로그 트리거, Vision 호출 흐름, Floating Hint UI)은 모두 손대지 않았다. `screen-recording.ts:22` 코멘트가 SPEC-009로 위임을 명시.

**판정**: PASS.

---

## 3. 데이터 모델 정합성 (PRD §8.1) — **PASS**

`consents` 테이블 사용 컬럼: `consent_type`, `granted`, `granted_at`, `revoked_at` — PRD §8.1과 1:1 일치.

- `migrations/001_init.sql:50-57` 스키마 정의가 PRD §8.1 그대로 (PK consent_type, CHECK enum 두 값, granted INTEGER NOT NULL).
- `repository.ts`는 위 4개 컬럼만 read/write. 임의 컬럼 추가 없음.
- `ConsentsMap` / `ConsentRecord` (shared) 타입과 SQLite row 매핑이 `rowToRecord` (`repository.ts:54-69`)에서 명시적 `granted === 1` 변환을 통해 INTEGER ↔ boolean 안전 변환.
- 데이터 보존 정책 (PRD §8.2 — 사용자 동의 영구) 준수: 삭제 경로 없음, revoke는 row를 유지하고 플래그만 변경.

**판정**: PASS.

---

## 4. API 계약 정합성 (PRD §9.1.6 / §9.1.3) — **PASS (with note)**

| PRD 항목 | 구현 |
|----------|------|
| `POST /api/consents` body `{ consent_type, granted }` | `routes/consents.ts:21-32` |
| `GET /api/consents` body `{ screen_recording: {...}, anthropic_transmission: {...} }` | `routes/consents.ts:17-19` + `repository.getAll` |
| `401 { "error": "screen_recording_permission_required" }` (PRD §9.1.3) | `middleware.ts:36-39` |
| `403 { "error": "consent_required" }` (PRD §9.1.3) | `middleware.ts:40-43` (`missing` 배열 추가) |

- 기존 라우트 경로/메서드 변경 없음. 신규 라우트만 추가.
- `PostConsentRequestSchema` (shared) 가 `.strict()` 로 추가 필드 거부 → 입력 계약 안정.
- 응답 200 `{ ok: true }` 가 `PostConsentResponseSchema` 와 일치.

**Note (Breaking 아님, WARN 아님)**: 미들웨어 403 응답에는 spec이 요구한 대로 `missing: [...]` 추가 필드가 포함된다 (`middleware.ts:41`). PRD §9.1.3 본문 예시는 `{ error: "consent_required" }`만 보여주는데, spec-004가 PRD 본문보다 명시적으로 한 단계 정보를 늘렸다. 비파괴 추가이고 spec이 요구한 사항이라 문제 없음. 다만 `packages/shared/src/schemas/api.ts:226` `ConsentRequiredErrorSchema`는 `.strict()`로 `error`만 받고 있어, 클라이언트가 이 스키마로 응답을 strict-parse 하면 실패한다. 이 shared 스키마를 `missing`을 받도록 확장하는 것은 spec-001 산출물이라 본 spec 책임은 아니지만, 후속 spec(특히 spec-009 vision)이 동일 에러 형태를 사용할 때 정정될 필요가 있음. 정보 차원의 메모로만 남긴다.

**판정**: PASS.

---

## 5. 보안 점검 — **PASS**

- **시크릿 하드코딩**: 없음. `Anthropic API key`, 사내 URL, 토큰 등 어떤 값도 spec-004 산출 코드/테스트에 평문 포함되지 않음.
- **SQL 인젝션 방지**: 모든 쿼리가 `db.prepare(...)` + named/positional placeholder 사용 (`repository.ts:29-52`, 86-92). 사용자 입력은 zod로 enum 검증 후 statement 파라미터로 전달, 문자열 결합 없음. 테스트 픽스처도 모두 prepare 사용.
- **캡처 이미지 데이터 파기 (PRD §8.2)**: spec-004 범위에 캡처 이미지가 없음 (vision은 spec-009+). 비범위 — 위반 없음.
- **개인정보 로깅**: `logger.error({ err })` 한 곳 (`server.ts:40`)뿐, consents 본문 직접 로깅 없음. pino redact 정책 추가 작업은 본 spec 범위 외.
- **ReDoS / Prototype pollution**: zod `.strict()` + `z.enum`/`z.boolean` 만 사용 → 회피.

**판정**: PASS.

---

## 6. 코드 품질 — **PASS**

### 함수 길이

| 함수 | 위치 | 라인 수 |
|------|------|---------|
| `createConsentsRepository` | `repository.ts:26-94` | 본체 ~69줄 (선언/공백/주석 포함). 내부 prepared statement 3개와 8줄짜리 헬퍼 + 22줄짜리 반환 객체로 나뉘며, 각 method 본체는 5줄 이하. |
| `requireConsent` | `middleware.ts:11-46` | 36줄 |
| `createConsentsRouter` | `routes/consents.ts:12-35` | 24줄 |
| `checkScreenRecordingPermission` | `system/screen-recording.ts:14-24` | 11줄 |

`createConsentsRepository`만 50줄 임계를 초과한다. 다만 본체가 statement 캐싱 + closure 반환의 표준 SQLite 레포지토리 패턴이고, 로직 단위(`getAll/get/upsert/grantStmt/revokeStmt/rowToRecord`)는 모두 한 자리수~10줄 수준이라 가독성에 문제가 없다. 분리 시 prepared statement 공유 비용이 늘어 오히려 복잡도가 증가하므로 본 패턴 유지가 적절. **PASS, 정보성 관찰.**

### 테스트 커버리지

vitest v8 coverage 결과:

```
src/consents/middleware.ts    100% lines / 100% branches
src/consents/repository.ts    100% lines / 100% branches
src/routes/consents.ts        100% lines / 83.33% branches  (uncovered: 15 — `now ?? Date.now` 기본값 분기)
src/system/screen-recording.ts 100% lines / 100% branches
```

전체 daemon 패키지: 100% lines, 97.22% branches. spec 요구치 80% 대폭 상회. **PASS.**

### 추가 관찰

- 공개 API (`ConsentsRepository`, `ConsentsMap`, `ConsentsRouterDeps`)에 명시적 인터페이스/타입 export — 테스트가능성·치환성 ↑.
- `createConsentsRouter`가 `now: () => number` 의존성 주입을 받아 시간 기반 테스트가 결정적 (`tests/consents-routes.test.ts:65-99`).
- 미들웨어 코멘트(`middleware.ts:7-10`)가 `401 vs 403` 우선순위와 의도를 설명 — 비자명 동작에 대한 적절한 주석.
- `screen-recording.ts:22`의 SPEC-009 위임 코멘트로 향후 작업 경계 명시.

---

## 7. BOUNDARIES.md 준수 — **PASS**

| 규칙 | 확인 |
|------|------|
| §1 Read-only 파일 변경 금지 | `docs/PRD-MVP-SLIM.md`, `BOUNDARIES.md`, `spec-template.md`, 다른 spec 모두 미변경. spec-004 커밋은 `packages/daemon/` 외 0개 파일 수정 |
| §2 spec 외 패키지 경로 수정 금지 | 모든 변경은 `packages/daemon/src/**`, `packages/daemon/tests/**`. `packages/shared/`, `packages/floating-hint/` 무수정 |
| §3 신규 외부 의존성 사전 허용 목록 | `packages/daemon/package.json` 미변경 (spec-002 산출물 그대로). 루트 `package.json`도 spec-004 커밋에서 미변경 |
| §4 Breaking change 금지 (API 계약 보호) | 라우트 추가만, 기존 라우트 미변경. 응답 JSON 필드 추가(403 `missing`)는 spec이 요구한 비파괴 확장 |
| §5 시크릿 하드코딩 금지 | §5 보안 점검 참조 — 없음 |

**판정**: PASS.

---

## 8. 의존성 체크 (PRD §12) — **PASS**

- `git diff main...HEAD -- packages/daemon/package.json` 결과: spec-002 커밋에 의해 처음 추가된 그대로. spec-004 커밋(`a63f207`)에서 `package.json` 수정 0건.
- `git diff main...HEAD -- pnpm-lock.yaml`은 spec-002/003 커밋에서 변경됐고, spec-004에서는 추가 변경 없음.
- daemon이 사용 중인 의존성: `@onboarding/shared`, `better-sqlite3`, `express`, `pino`, `yaml`, `zod` (+ devDeps). 모두 PRD §12 화이트리스트 내 (BOUNDARIES.md §3과 일치).
- spec-004 신규 import 분석:
  - `repository.ts`: `@onboarding/shared`, 내부 모듈만
  - `middleware.ts`: `@onboarding/shared`, `express` (이미 dep), 내부 모듈
  - `routes/consents.ts`: `@onboarding/shared`, `express`, 내부 모듈
  - `system/screen-recording.ts`: 표준 `process` global만 사용 — Node 표준 (BOUNDARIES §3 허용)
  - 테스트 파일: `node:fs`, `node:os`, `node:path`, `pino`, `supertest`, `vitest` (모두 PRD §12 또는 stdlib)

**판정**: PASS.

---

## 종합 판정

| # | 항목 | 결과 |
|---|------|------|
| 1 | AC 정합성 | **PASS** |
| 2 | PRD 정합성 | **PASS** |
| 3 | 데이터 모델 정합성 | **PASS** |
| 4 | API 계약 정합성 | **PASS** (정보성 노트: shared `ConsentRequiredErrorSchema`가 `missing` 미정의 — spec-001/spec-009 정정 후보) |
| 5 | 보안 점검 | **PASS** |
| 6 | 코드 품질 | **PASS** (함수 길이 1건 정보성 관찰, 커버리지 100%) |
| 7 | BOUNDARIES.md 준수 | **PASS** |
| 8 | 의존성 체크 | **PASS** |

전 항목 PASS. 8/8 통과.

<promise>SPEC_004_DAEMON_CONSENTS_REVIEW_PASS</promise>
