### PR TITLE
[Ralph] spec-005-daemon-p1-state-probe

### DIFF
--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@onboarding/shared": "workspace:*",
     "better-sqlite3": "^11.0.0",
+    "execa": "^9.0.0",
     "express": "^4.19.2",
     "pino": "^9.0.0",
     "yaml": "^2.4.0",

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -2,6 +2,7 @@ import { loadChecklist } from './checklist/loader.js';
 import { defaultDbPath, openDatabase } from './db/index.js';
 import { migrate } from './db/migrate.js';
 import { logger } from './logger.js';
+import { runStateProbe } from './p1-state-probe/index.js';
 import { registerApiRoutes } from './routes/index.js';
 import { createServer } from './server.js';
 
@@ -14,7 +15,7 @@ function parsePort(): number {
   return Number.isFinite(n) && n > 0 ? n : DEFAULT_PORT;
 }
 
-function bootstrap(): void {
+async function bootstrap(): Promise<void> {
   const dbPath = process.env.ONBOARDING_DB_PATH ?? defaultDbPath();
   const db = openDatabase(dbPath);
   const result = migrate(db);
@@ -31,10 +32,14 @@ function bootstrap(): void {
     'checklist_loaded',
   );
 
+  // Probe machine state once on boot so already-installed items auto-complete
+  // before we start serving (spec-005, PRD §7.2 F-P1-01).
+  await runStateProbe({ checklist, db, logger });
+
   const port = parsePort();
   const app = createServer({
     logger,
-    registerRoutes: (a) => registerApiRoutes(a, { checklist, db }),
+    registerRoutes: (a) => registerApiRoutes(a, { checklist, db, logger }),
   });
   const server = app.listen(port, () => {
     logger.info({ port }, 'daemon_listening');
@@ -60,4 +65,7 @@ function bootstrap(): void {
   process.on('SIGTERM', () => shutdown('SIGTERM'));
 }
 
-bootstrap();
+bootstrap().catch((err) => {
+  logger.error({ err }, 'bootstrap_failed');
+  process.exit(1);
+});

--- a/packages/daemon/src/p1-state-probe/index.ts
+++ b/packages/daemon/src/p1-state-probe/index.ts
@@ -1,0 +1,84 @@
+import type { ChecklistFile } from '@onboarding/shared';
+import type { Logger } from 'pino';
+
+import type { DatabaseInstance } from '../db/index.js';
+import {
+  defaultProbeRunner,
+  runProbe,
+  type ProbeRunner,
+} from './probes.js';
+
+export { defaultProbeRunner, runProbe } from './probes.js';
+export type { ProbeRunner, ProbeResult } from './probes.js';
+
+export interface RunStateProbeOptions {
+  checklist: ChecklistFile;
+  db: DatabaseInstance;
+  runner?: ProbeRunner;
+  now?: () => number;
+  logger?: Logger;
+}
+
+export interface StateProbeSummary {
+  itemsChecked: number;
+  itemsCompleted: string[];
+  itemsSkipped: string[];
+}
+
+export async function runStateProbe(
+  options: RunStateProbeOptions,
+): Promise<StateProbeSummary> {
+  const runner = options.runner ?? defaultProbeRunner;
+  const now = options.now ?? Date.now;
+  const logger = options.logger;
+
+  const completedRows = options.db
+    .prepare(`SELECT item_id FROM item_states WHERE status = 'completed'`)
+    .all() as Array<{ item_id: string }>;
+  const alreadyCompleted = new Set(completedRows.map((r) => r.item_id));
+
+  const markCompleted = options.db.prepare(
+    `INSERT INTO item_states
+       (item_id, status, current_step, started_at, completed_at, attempt_count)
+     VALUES (@item_id, 'completed', NULL, NULL, @now, 1)
+     ON CONFLICT(item_id) DO UPDATE SET
+       status       = 'completed',
+       completed_at = @now`,
+  );
+
+  const summary: StateProbeSummary = {
+    itemsChecked: 0,
+    itemsCompleted: [],
+    itemsSkipped: [],
+  };
+
+  for (const item of options.checklist.items) {
+    if (alreadyCompleted.has(item.id)) {
+      summary.itemsSkipped.push(item.id);
+      continue;
+    }
+    if (!item.verification) continue;
+
+    summary.itemsChecked += 1;
+    const result = await runProbe(item.verification, runner);
+    logger?.info(
+      { item_id: item.id, status: result.status },
+      'state_probe_result',
+    );
+
+    if (result.status === 'PASS') {
+      markCompleted.run({ item_id: item.id, now: now() });
+      summary.itemsCompleted.push(item.id);
+    }
+  }
+
+  logger?.info(
+    {
+      checked: summary.itemsChecked,
+      completed: summary.itemsCompleted.length,
+      skipped: summary.itemsSkipped.length,
+    },
+    'state_probe_complete',
+  );
+  return summary;
+}

--- a/packages/daemon/src/p1-state-probe/probes.ts
+++ b/packages/daemon/src/p1-state-probe/probes.ts
@@ -1,0 +1,76 @@
+import type { Verification } from '@onboarding/shared';
+import { execa } from 'execa';
+
+export interface ProbeOutput {
+  stdout: string;
+  exitCode: number;
+}
+
+export type ProbeRunner = (command: string) => Promise<ProbeOutput>;
+
+export interface ProbeResult {
+  status: 'PASS' | 'FAIL';
+}
+
+const DEFAULT_TIMEOUT_MS = 5_000;
+
+export const defaultProbeRunner: ProbeRunner = async (command) => {
+  const result = await execa(command, {
+    shell: true,
+    timeout: DEFAULT_TIMEOUT_MS,
+    reject: false,
+  });
+  return {
+    stdout: typeof result.stdout === 'string' ? result.stdout : '',
+    exitCode: typeof result.exitCode === 'number' ? result.exitCode : 1,
+  };
+};
+
+export async function runProbe(
+  verification: Verification,
+  runner: ProbeRunner,
+): Promise<ProbeResult> {
+  if (verification.type === 'command') {
+    return runCommandProbe(verification.command, verification.expect_contains, runner);
+  }
+  return runProcessCheckProbe(verification.process_name, runner);
+}
+
+async function runCommandProbe(
+  command: string,
+  expectContains: string | undefined,
+  runner: ProbeRunner,
+): Promise<ProbeResult> {
+  let output: ProbeOutput;
+  try {
+    output = await runner(command);
+  } catch {
+    return { status: 'FAIL' };
+  }
+  if (output.exitCode !== 0) {
+    return { status: 'FAIL' };
+  }
+  if (expectContains && !output.stdout.includes(expectContains)) {
+    return { status: 'FAIL' };
+  }
+  return { status: 'PASS' };
+}
+
+async function runProcessCheckProbe(
+  processName: string,
+  runner: ProbeRunner,
+): Promise<ProbeResult> {
+  let output: ProbeOutput;
+  try {
+    output = await runner(`pgrep ${processName}`);
+  } catch {
+    return { status: 'FAIL' };
+  }
+  if (output.exitCode !== 0) {
+    return { status: 'FAIL' };
+  }
+  if (output.stdout.trim().length === 0) {
+    return { status: 'FAIL' };
+  }
+  return { status: 'PASS' };
+}

--- a/packages/daemon/src/routes/index.ts
+++ b/packages/daemon/src/routes/index.ts
@@ -1,17 +1,31 @@
 import type { ChecklistFile } from '@onboarding/shared';
 import type { Application } from 'express';
+import type { Logger } from 'pino';
 
 import type { DatabaseInstance } from '../db/index.js';
+import type { ProbeRunner } from '../p1-state-probe/probes.js';
 import { createChecklistRouter } from './checklist.js';
 import { createConsentsRouter } from './consents.js';
+import { createStateProbeRouter } from './state-probe.js';
 
 export interface ApiRoutesDeps {
   checklist: ChecklistFile;
   db: DatabaseInstance;
   now?: () => number;
+  probeRunner?: ProbeRunner;
+  logger?: Logger;
 }
 
 export function registerApiRoutes(app: Application, deps: ApiRoutesDeps): void {
   app.use(createChecklistRouter(deps));
   app.use(createConsentsRouter({ db: deps.db, now: deps.now }));
+  app.use(
+    createStateProbeRouter({
+      checklist: deps.checklist,
+      db: deps.db,
+      runner: deps.probeRunner,
+      now: deps.now,
+      logger: deps.logger,
+    }),
+  );
 }

--- a/packages/daemon/src/routes/state-probe.ts
+++ b/packages/daemon/src/routes/state-probe.ts
@@ -1,0 +1,38 @@
+import type { ChecklistFile } from '@onboarding/shared';
+import { Router, type Request, type Response, type NextFunction } from 'express';
+import type { Logger } from 'pino';
+
+import type { DatabaseInstance } from '../db/index.js';
+import { runStateProbe } from '../p1-state-probe/index.js';
+import type { ProbeRunner } from '../p1-state-probe/probes.js';
+
+export interface StateProbeRouterDeps {
+  checklist: ChecklistFile;
+  db: DatabaseInstance;
+  runner?: ProbeRunner;
+  now?: () => number;
+  logger?: Logger;
+}
+
+export function createStateProbeRouter(deps: StateProbeRouterDeps): Router {
+  const router = Router();
+
+  router.post(
+    '/api/state-probe/run',
+    (_req: Request, res: Response, next: NextFunction) => {
+      runStateProbe({
+        checklist: deps.checklist,
+        db: deps.db,
+        runner: deps.runner,
+        now: deps.now,
+        logger: deps.logger,
+      })
+        .then((summary) => {
+          res.status(200).json(summary);
+        })
+        .catch(next);
+    },
+  );
+
+  return router;
+}

--- a/packages/daemon/tests/p1-state-probe.test.ts
+++ b/packages/daemon/tests/p1-state-probe.test.ts
@@ -1,0 +1,442 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { ChecklistFile } from '@onboarding/shared';
+import pino from 'pino';
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { openDatabase, type DatabaseInstance } from '../src/db/index.js';
+import { migrate } from '../src/db/migrate.js';
+import { runStateProbe } from '../src/p1-state-probe/index.js';
+import {
+  defaultProbeRunner,
+  runProbe,
+  type ProbeRunner,
+} from '../src/p1-state-probe/probes.js';
+import { createStateProbeRouter } from '../src/routes/state-probe.js';
+import { createServer } from '../src/server.js';
+
+const silentLogger = pino({ level: 'silent' });
+
+const FIXTURE_CHECKLIST: ChecklistFile = {
+  version: 2,
+  schema: 'ai-coaching',
+  items: [
+    {
+      id: 'install-homebrew',
+      title: 'Homebrew',
+      estimated_minutes: 3,
+      verification: {
+        type: 'command',
+        command: 'brew --version',
+      },
+    },
+    {
+      id: 'configure-git',
+      title: 'Git',
+      estimated_minutes: 1,
+      verification: {
+        type: 'command',
+        command: 'git config --global user.email',
+        expect_contains: 'tao@wrtn.io',
+      },
+    },
+    {
+      id: 'install-security-agent',
+      title: 'Security agent',
+      estimated_minutes: 15,
+      verification: {
+        type: 'process_check',
+        process_name: 'SecurityAgent',
+      },
+    },
+    {
+      id: 'no-verification',
+      title: 'No probe',
+      estimated_minutes: 1,
+    },
+  ],
+};
+
+interface ItemStateRow {
+  item_id: string;
+  status: string;
+  current_step: string | null;
+  started_at: number | null;
+  completed_at: number | null;
+  attempt_count: number;
+}
+
+function readState(db: DatabaseInstance, itemId: string): ItemStateRow | undefined {
+  return db
+    .prepare('SELECT * FROM item_states WHERE item_id = ?')
+    .get(itemId) as ItemStateRow | undefined;
+}
+
+describe('runProbe (probes.ts)', () => {
+  describe('command verification', () => {
+    it('returns PASS when exit code is 0 and no expect_contains is given', async () => {
+      const runner: ProbeRunner = vi
+        .fn()
+        .mockResolvedValue({ stdout: 'Homebrew 4.3.0', exitCode: 0 });
+      const result = await runProbe(
+        { type: 'command', command: 'brew --version' },
+        runner,
+      );
+      expect(result.status).toBe('PASS');
+      expect(runner).toHaveBeenCalledWith('brew --version');
+    });
+
+    it('returns FAIL when exit code is non-zero', async () => {
+      const runner: ProbeRunner = vi
+        .fn()
+        .mockResolvedValue({ stdout: '', exitCode: 1 });
+      const result = await runProbe(
+        { type: 'command', command: 'brew --version' },
+        runner,
+      );
+      expect(result.status).toBe('FAIL');
+    });
+
+    it('returns PASS when expect_contains matches stdout', async () => {
+      const runner: ProbeRunner = vi
+        .fn()
+        .mockResolvedValue({ stdout: 'tao@wrtn.io\n', exitCode: 0 });
+      const result = await runProbe(
+        {
+          type: 'command',
+          command: 'git config --global user.email',
+          expect_contains: 'tao@wrtn.io',
+        },
+        runner,
+      );
+      expect(result.status).toBe('PASS');
+    });
+
+    it('returns FAIL when expect_contains does not match', async () => {
+      const runner: ProbeRunner = vi
+        .fn()
+        .mockResolvedValue({ stdout: 'someone-else@example.com\n', exitCode: 0 });
+      const result = await runProbe(
+        {
+          type: 'command',
+          command: 'git config --global user.email',
+          expect_contains: 'tao@wrtn.io',
+        },
+        runner,
+      );
+      expect(result.status).toBe('FAIL');
+    });
+
+    it('returns FAIL when runner throws', async () => {
+      const runner: ProbeRunner = vi
+        .fn()
+        .mockRejectedValue(new Error('command not found'));
+      const result = await runProbe(
+        { type: 'command', command: 'nonsense' },
+        runner,
+      );
+      expect(result.status).toBe('FAIL');
+    });
+  });
+
+  describe('process_check verification', () => {
+    it('returns PASS when pgrep exits 0 and prints a PID', async () => {
+      const runner: ProbeRunner = vi
+        .fn()
+        .mockResolvedValue({ stdout: '12345\n', exitCode: 0 });
+      const result = await runProbe(
+        { type: 'process_check', process_name: 'SecurityAgent' },
+        runner,
+      );
+      expect(result.status).toBe('PASS');
+      expect(runner).toHaveBeenCalledWith('pgrep SecurityAgent');
+    });
+
+    it('returns FAIL when pgrep exits non-zero (process not running)', async () => {
+      const runner: ProbeRunner = vi
+        .fn()
+        .mockResolvedValue({ stdout: '', exitCode: 1 });
+      const result = await runProbe(
+        { type: 'process_check', process_name: 'SecurityAgent' },
+        runner,
+      );
+      expect(result.status).toBe('FAIL');
+    });
+
+    it('returns FAIL when pgrep exits 0 with empty stdout', async () => {
+      const runner: ProbeRunner = vi
+        .fn()
+        .mockResolvedValue({ stdout: '\n', exitCode: 0 });
+      const result = await runProbe(
+        { type: 'process_check', process_name: 'SecurityAgent' },
+        runner,
+      );
+      expect(result.status).toBe('FAIL');
+    });
+
+    it('returns FAIL when runner throws (e.g. pgrep missing)', async () => {
+      const runner: ProbeRunner = vi
+        .fn()
+        .mockRejectedValue(new Error('spawn pgrep ENOENT'));
+      const result = await runProbe(
+        { type: 'process_check', process_name: 'SecurityAgent' },
+        runner,
+      );
+      expect(result.status).toBe('FAIL');
+    });
+  });
+
+  describe('defaultProbeRunner', () => {
+    it('executes a real shell command and returns stdout/exitCode (exit 0)', async () => {
+      const out = await defaultProbeRunner(
+        'node -e "process.stdout.write(\'hello\')"',
+      );
+      expect(out.exitCode).toBe(0);
+      expect(out.stdout).toContain('hello');
+    });
+
+    it('returns non-zero exitCode when the command fails', async () => {
+      const out = await defaultProbeRunner('node -e "process.exit(7)"');
+      expect(out.exitCode).toBe(7);
+    });
+  });
+});
+
+describe('runStateProbe', () => {
+  let tmpDir: string;
+  let db: DatabaseInstance;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'onboarding-p1-state-probe-'));
+    db = openDatabase(join(tmpDir, 'agent.db'));
+    migrate(db);
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('marks PASS items as completed with completed_at = now (AC-P1-01)', async () => {
+    const runner: ProbeRunner = vi.fn(async (cmd: string) => {
+      if (cmd === 'brew --version') return { stdout: 'Homebrew 4.3.0', exitCode: 0 };
+      if (cmd === 'git config --global user.email')
+        return { stdout: 'tao@wrtn.io\n', exitCode: 0 };
+      return { stdout: '', exitCode: 1 };
+    });
+
+    const fixedNow = 1_700_000_000_000;
+    const result = await runStateProbe({
+      checklist: FIXTURE_CHECKLIST,
+      db,
+      runner,
+      now: () => fixedNow,
+      logger: silentLogger,
+    });
+
+    expect(result.itemsCompleted).toEqual(
+      expect.arrayContaining(['install-homebrew', 'configure-git']),
+    );
+
+    const homebrew = readState(db, 'install-homebrew');
+    expect(homebrew?.status).toBe('completed');
+    expect(homebrew?.completed_at).toBe(fixedNow);
+
+    const git = readState(db, 'configure-git');
+    expect(git?.status).toBe('completed');
+    expect(git?.completed_at).toBe(fixedNow);
+  });
+
+  it('does not change state for items whose probe FAILS', async () => {
+    const runner: ProbeRunner = vi
+      .fn()
+      .mockResolvedValue({ stdout: '', exitCode: 1 });
+
+    const result = await runStateProbe({
+      checklist: FIXTURE_CHECKLIST,
+      db,
+      runner,
+      now: () => 1234,
+      logger: silentLogger,
+    });
+
+    expect(result.itemsCompleted).toEqual([]);
+    expect(readState(db, 'install-homebrew')).toBeUndefined();
+    expect(readState(db, 'configure-git')).toBeUndefined();
+    expect(readState(db, 'install-security-agent')).toBeUndefined();
+  });
+
+  it('skips items without a verification block', async () => {
+    const runner = vi
+      .fn<ProbeRunner>()
+      .mockResolvedValue({ stdout: 'ok', exitCode: 0 });
+
+    await runStateProbe({
+      checklist: FIXTURE_CHECKLIST,
+      db,
+      runner,
+      logger: silentLogger,
+    });
+
+    expect(readState(db, 'no-verification')).toBeUndefined();
+    const calls = (runner.mock.calls as unknown[][]).map((c) => c[0]);
+    expect(calls).not.toContain(undefined);
+    expect(calls.length).toBe(3); // 3 items have verification
+  });
+
+  it('is idempotent: items already completed are not probed again', async () => {
+    db.prepare(
+      `INSERT INTO item_states (item_id, status, completed_at, attempt_count)
+       VALUES ('install-homebrew', 'completed', 999, 1)`,
+    ).run();
+
+    const runner = vi
+      .fn<ProbeRunner>()
+      .mockResolvedValue({ stdout: '', exitCode: 1 });
+
+    const result = await runStateProbe({
+      checklist: FIXTURE_CHECKLIST,
+      db,
+      runner,
+      logger: silentLogger,
+    });
+
+    expect(result.itemsSkipped).toContain('install-homebrew');
+    const calls = (runner.mock.calls as unknown[][]).map((c) => c[0]);
+    expect(calls).not.toContain('brew --version');
+
+    const row = readState(db, 'install-homebrew');
+    expect(row?.status).toBe('completed');
+    expect(row?.completed_at).toBe(999);
+  });
+
+  it('returns a summary describing checked / completed / skipped', async () => {
+    const runner = vi.fn<ProbeRunner>(async (cmd: string) => {
+      if (cmd === 'brew --version') return { stdout: 'ok', exitCode: 0 };
+      return { stdout: '', exitCode: 1 };
+    });
+
+    const result = await runStateProbe({
+      checklist: FIXTURE_CHECKLIST,
+      db,
+      runner,
+      logger: silentLogger,
+    });
+
+    expect(result.itemsChecked).toBe(3);
+    expect(result.itemsCompleted).toEqual(['install-homebrew']);
+    expect(result.itemsSkipped).toEqual([]);
+  });
+
+  it('does not depend on consents (runs independently of AI consent)', async () => {
+    // No row inserted into `consents` — the probe should still mark items
+    // completed when the verification passes.
+    const runner = vi
+      .fn<ProbeRunner>()
+      .mockResolvedValue({ stdout: 'ok', exitCode: 0 });
+
+    const result = await runStateProbe({
+      checklist: {
+        version: 2,
+        schema: 'ai-coaching',
+        items: [
+          {
+            id: 'install-homebrew',
+            title: 'Homebrew',
+            estimated_minutes: 3,
+            verification: { type: 'command', command: 'brew --version' },
+          },
+        ],
+      },
+      db,
+      runner,
+      now: () => 42,
+      logger: silentLogger,
+    });
+
+    expect(result.itemsCompleted).toEqual(['install-homebrew']);
+  });
+});
+
+describe('POST /api/state-probe/run', () => {
+  let tmpDir: string;
+  let db: DatabaseInstance;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'onboarding-p1-state-probe-route-'));
+    db = openDatabase(join(tmpDir, 'agent.db'));
+    migrate(db);
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('triggers a re-run and reports the summary as JSON', async () => {
+    const runner = vi
+      .fn<ProbeRunner>()
+      .mockResolvedValue({ stdout: 'tao@wrtn.io ok 12345', exitCode: 0 });
+    const fixedNow = 1_700_000_000_000;
+
+    const app = createServer({
+      logger: silentLogger,
+      registerRoutes: (a) => {
+        a.use(
+          createStateProbeRouter({
+            checklist: FIXTURE_CHECKLIST,
+            db,
+            runner,
+            now: () => fixedNow,
+            logger: silentLogger,
+          }),
+        );
+      },
+    });
+
+    const res = await request(app).post('/api/state-probe/run');
+    expect(res.status).toBe(200);
+    expect(res.body.itemsChecked).toBe(3);
+    expect(res.body.itemsCompleted).toEqual(
+      expect.arrayContaining(['install-homebrew', 'configure-git', 'install-security-agent']),
+    );
+
+    const homebrew = readState(db, 'install-homebrew');
+    expect(homebrew?.status).toBe('completed');
+    expect(homebrew?.completed_at).toBe(fixedNow);
+  });
+
+  it('subsequent calls do not re-probe already-completed items', async () => {
+    const runner = vi
+      .fn<ProbeRunner>()
+      .mockResolvedValue({ stdout: 'tao@wrtn.io ok 12345', exitCode: 0 });
+
+    const app = createServer({
+      logger: silentLogger,
+      registerRoutes: (a) => {
+        a.use(
+          createStateProbeRouter({
+            checklist: FIXTURE_CHECKLIST,
+            db,
+            runner,
+            logger: silentLogger,
+          }),
+        );
+      },
+    });
+
+    await request(app).post('/api/state-probe/run').expect(200);
+    const callsAfterFirst = runner.mock.calls.length;
+
+    const res = await request(app).post('/api/state-probe/run');
+    expect(res.status).toBe(200);
+    expect(res.body.itemsChecked).toBe(0);
+    expect(res.body.itemsSkipped).toEqual(
+      expect.arrayContaining(['install-homebrew', 'configure-git', 'install-security-agent']),
+    );
+    expect(runner.mock.calls.length).toBe(callsAfterFirst); // no new runner invocations
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ importers:
       better-sqlite3:
         specifier: ^11.0.0
         version: 11.10.0
+      execa:
+        specifier: ^9.0.0
+        version: 9.6.1
       express:
         specifier: ^4.19.2
         version: 4.22.1
@@ -407,6 +410,13 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sec-ant/readable-stream@0.4.1':
+    resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
+  '@sindresorhus/merge-streams@4.0.0':
+    resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
+    engines: {node: '>=18'}
+
   '@types/better-sqlite3@7.6.13':
     resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
 
@@ -741,6 +751,10 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  execa@9.6.1:
+    resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
+    engines: {node: ^18.19.0 || >=20.5.0}
+
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
@@ -755,6 +769,10 @@ packages:
 
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+
+  figures@6.1.0:
+    resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
+    engines: {node: '>=18'}
 
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
@@ -802,6 +820,10 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-stream@9.0.1:
+    resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
+    engines: {node: '>=18'}
+
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
@@ -837,6 +859,10 @@ packages:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
+  human-signals@8.0.1:
+    resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
+    engines: {node: '>=18.18.0'}
+
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
@@ -857,6 +883,18 @@ packages:
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
+
+  is-stream@4.0.1:
+    resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
+    engines: {node: '>=18'}
+
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -973,6 +1011,10 @@ packages:
     resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
     engines: {node: '>=10'}
 
+  npm-run-path@6.0.0:
+    resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
+    engines: {node: '>=18'}
+
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -991,6 +1033,10 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  parse-ms@4.0.0:
+    resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
+    engines: {node: '>=18'}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -998,6 +1044,10 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
 
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
@@ -1035,6 +1085,10 @@ packages:
     engines: {node: '>=10'}
     deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
+
+  pretty-ms@9.3.0:
+    resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
+    engines: {node: '>=18'}
 
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
@@ -1185,6 +1239,10 @@ packages:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
 
+  strip-final-newline@4.0.0:
+    resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
+    engines: {node: '>=18'}
+
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
@@ -1251,6 +1309,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  unicorn-magic@0.3.0:
+    resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
+    engines: {node: '>=18'}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -1353,6 +1415,10 @@ packages:
     resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
     engines: {node: '>= 14.6'}
     hasBin: true
+
+  yoctocolors@2.1.2:
+    resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
+    engines: {node: '>=18'}
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -1558,6 +1624,10 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.60.2':
     optional: true
+
+  '@sec-ant/readable-stream@0.4.1': {}
+
+  '@sindresorhus/merge-streams@4.0.0': {}
 
   '@types/better-sqlite3@7.6.13':
     dependencies:
@@ -1923,6 +1993,21 @@ snapshots:
 
   etag@1.8.1: {}
 
+  execa@9.6.1:
+    dependencies:
+      '@sindresorhus/merge-streams': 4.0.0
+      cross-spawn: 7.0.6
+      figures: 6.1.0
+      get-stream: 9.0.1
+      human-signals: 8.0.1
+      is-plain-obj: 4.1.0
+      is-stream: 4.0.1
+      npm-run-path: 6.0.0
+      pretty-ms: 9.3.0
+      signal-exit: 4.1.0
+      strip-final-newline: 4.0.0
+      yoctocolors: 2.1.2
+
   expand-template@2.0.3: {}
 
   expect-type@1.3.0: {}
@@ -1964,6 +2049,10 @@ snapshots:
       - supports-color
 
   fast-safe-stringify@2.1.1: {}
+
+  figures@6.1.0:
+    dependencies:
+      is-unicode-supported: 2.1.0
 
   file-uri-to-path@1.0.0: {}
 
@@ -2027,6 +2116,11 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  get-stream@9.0.1:
+    dependencies:
+      '@sec-ant/readable-stream': 0.4.1
+      is-stream: 4.0.1
+
   github-from-package@0.0.0: {}
 
   glob@10.5.0:
@@ -2062,6 +2156,8 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  human-signals@8.0.1: {}
+
   iconv-lite@0.4.24:
     dependencies:
       safer-buffer: 2.1.2
@@ -2075,6 +2171,12 @@ snapshots:
   ipaddr.js@1.9.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
+
+  is-plain-obj@4.1.0: {}
+
+  is-stream@4.0.1: {}
+
+  is-unicode-supported@2.1.0: {}
 
   isexe@2.0.0: {}
 
@@ -2171,6 +2273,11 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
+  npm-run-path@6.0.0:
+    dependencies:
+      path-key: 4.0.0
+      unicorn-magic: 0.3.0
+
   object-inspect@1.13.4: {}
 
   on-exit-leak-free@2.1.2: {}
@@ -2185,9 +2292,13 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  parse-ms@4.0.0: {}
+
   parseurl@1.3.3: {}
 
   path-key@3.1.1: {}
+
+  path-key@4.0.0: {}
 
   path-scurry@1.11.1:
     dependencies:
@@ -2242,6 +2353,10 @@ snapshots:
       simple-get: 4.0.1
       tar-fs: 2.1.4
       tunnel-agent: 0.6.0
+
+  pretty-ms@9.3.0:
+    dependencies:
+      parse-ms: 4.0.0
 
   process-warning@5.0.0: {}
 
@@ -2441,6 +2556,8 @@ snapshots:
     dependencies:
       ansi-regex: 6.2.2
 
+  strip-final-newline@4.0.0: {}
+
   strip-json-comments@2.0.1: {}
 
   superagent@10.3.0:
@@ -2518,6 +2635,8 @@ snapshots:
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
+
+  unicorn-magic@0.3.0: {}
 
   unpipe@1.0.0: {}
 
@@ -2613,5 +2732,7 @@ snapshots:
   wrappy@1.0.2: {}
 
   yaml@2.8.3: {}
+
+  yoctocolors@2.1.2: {}
 
   zod@3.25.76: {}


### PR DESCRIPTION
# Code Review — spec-005-daemon-p1-state-probe

- **리뷰 대상 spec**: `specs/spec-005-daemon-p1-state-probe.md`
- **브랜치**: `feature/spec-005-daemon-p1-state-probe` (HEAD = `2f09683`)
- **검토 기준**: PRD `docs/PRD-MVP-SLIM.md` v0.10, `BOUNDARIES.md` v1.0, `spec-template.md`
- **리뷰 일시**: 2026-05-01

## 종합 판정: **PASS_WITH_WARN**

| # | 항목 | 판정 |
|---|------|------|
| 1 | AC 정합성 | PASS |
| 2 | PRD 정합성 | PASS |
| 3 | 데이터 모델 정합성 (PRD §8.1) | PASS |
| 4 | API 계약 정합성 (PRD §9) | **WARN** |
| 5 | 보안 점검 | PASS (note) |
| 6 | 코드 품질 | PASS |
| 7 | BOUNDARIES.md 준수 | **WARN** |
| 8 | 의존성 체크 (PRD §12) | PASS |

테스트·빌드·린트 실행 결과 (현지 검증):
- `pnpm --filter @onboarding/daemon test` → 11 files / **76 tests PASS**, p1-state-probe 19/19 PASS
- 커버리지: **100% lines / 100% funcs / 100% stmts / 95.32% branch**
- `pnpm --filter @onboarding/daemon lint` → exit 0
- `pnpm --filter @onboarding/daemon build` → 정상

---

## 1. AC 정합성 (PRD §10) — **PASS**

spec에 나열된 AC가 모두 코드/테스트로 충족됨.

| AC (spec) | 충족 위치 |
|-----------|-----------|
| AC-P1-01 충족: brew, git 이미 설치 시 두 항목 자동 completed | `tests/p1-state-probe.test.ts:223-251` ("marks PASS items as completed with completed_at = now (AC-P1-01)") + `src/p1-state-probe/index.ts:55-72` |
| 부팅 시 1회 자동 실행 | `src/index.ts:36-37` (`await runStateProbe(...)` — migrate 후, listen 전) |
| API로 수동 재실행 가능 | `src/routes/state-probe.ts:20-35` (`POST /api/state-probe/run`) + `tests/p1-state-probe.test.ts:379-410` |
| 이미 completed 항목 probe 제외 | `src/p1-state-probe/index.ts:35-38, 56-59` (alreadyCompleted Set) + `tests/p1-state-probe.test.ts:290-314` ("is idempotent") |
| AI 동의 무관 동작 | 코드: 어디에도 consents 조회 없음 + `tests/p1-state-probe.test.ts:334-361` ("does not depend on consents") |
| command/process_check 두 가지만 지원 | `src/p1-state-probe/probes.ts:29-37` — `Verification` 두 variant만 분기. Vision verify 없음 |
| `pnpm test/build/lint` 통과 | 위 종합 결과 참조 |
| 커버리지 ≥ 80% | 실측 100% lines/funcs/stmts |
| BOUNDARIES.md 준수 | §7 별도 평가 (WARN — 아래 참조) |
| 신규 의존성은 `execa`만 | `git show HEAD -- packages/daemon/package.json` → `execa: ^9.0.0` 1건만 추가 |

추가 검증 (테스트 추가 통과 항목):
- runner 예외 throw 시 FAIL 처리 (`probes.ts:46-48, 65-67` + 두 개 테스트)
- `expect_contains` 미스매치 FAIL 처리
- `pgrep` exit 0 + 빈 stdout → FAIL (PRD F-P4-02 "PID 반환이면 PASS" 해석 정확)
- `verification` 없는 항목은 probe 안 함 (테스트 line 272-288)

---

## 2. PRD 정합성 — **PASS**

| PRD 조항 | 일치 여부 |
|----------|-----------|
| §3.1 P1 State Probe — "시작 시점 1회 머신 상태 점검" | ✓ `bootstrap()`이 listen 직전 1회 호출 |
| §7.2 F-P1-01 시작 시 1회 머신 상태 점검 | ✓ |
| §7.2 F-P1-02 점검 결과를 yaml 항목과 매칭하여 자동 완료 처리 | ✓ yaml `verification` block의 PASS 항목 → `item_states.status = 'completed'` |
| §10 AC-P1-01 (brew/git 설치 시 자동 completed) | ✓ |
| §11 yaml `verification` 블록 (command / process_check) | ✓ shared의 `VerificationSchema` discriminatedUnion 그대로 사용 |

spec 비범위로 명시된 영역 (P4 진행 중 검증 / Vision / poll_interval_sec polling)은 코드에 포함되지 않음.

---

## 3. 데이터 모델 정합성 (PRD §8.1) — **PASS**

- 신규 마이그레이션 없음. 기존 `item_states` 테이블만 사용.
- 컬럼 매핑 (PRD §8.1 vs INSERT in `index.ts:40-47`):
  - `item_id` (PK), `status='completed'`, `current_step=NULL`, `started_at=NULL`, `completed_at=@now`, `attempt_count=1` — 모두 PRD 스키마 컬럼 셋 그대로.
- ON CONFLICT 경로: 기존 row가 `pending` 등으로 존재하면 `status / completed_at`만 업데이트 (PRD CHECK 제약 만족).
- 임의 컬럼·타입 추가 없음.

소소한 관찰 (FAIL 아님): 신규 row 삽입 시 `attempt_count = 1`로 명시. PRD는 DEFAULT 0이므로 0이어도 무방하나, "probe 1회 시도해서 PASS"의 의미 표현으로 허용 범위.

---

## 4. API 계약 정합성 (PRD §9) — **WARN**

### 4.1 라우트 추가 — PRD §9에 미정의

신규 라우트 `POST /api/state-probe/run` (`src/routes/state-probe.ts:21`)이 추가되었다. 그러나 PRD §9.1은 daemon 라우트로 다음 8개만 열거한다:

```
/api/checklist
/api/items/:itemId/start
/api/vision/guide
/api/vision/verify
/api/vision/rate-limit
/api/consents
/api/clipboard
/api/verify/run
```

`/api/state-probe/run`은 위 목록에 포함되지 않음. BOUNDARIES.md §4는 "라우트 경로 추가·변경·삭제"를 명시적으로 금지하며, "계약 변경이 필요해 보이면 PRD §9 개정이 선행되어야 한다"고 규정한다.

한편 spec-005 자체(approved by user)는 이 라우트를 출력 산출물로 명시한다(spec.md L27). 즉, **spec과 PRD/BOUNDARIES가 충돌**한다. 코드 자체는 spec을 정확히 구현했지만, spec 작성 시점에 PRD §9 갱신이 누락된 것으로 보인다.

권고: PRD §9.1.9 항목으로 `POST /api/state-probe/run` 추가하거나, 부팅 자동 실행만 남기고 외부 트리거 라우트를 제거. 후자라면 spec AC "API로 수동 재실행 가능" 재정의 필요.

### 4.2 기존 라우트 영향

기존 라우트 시그니처 변경 없음. `src/routes/index.ts` 변경은 신규 라우터 1개 추가뿐. Breaking change 없음.

### 4.3 응답 스키마

`POST /api/state-probe/run` 응답은 `StateProbeSummary` (`itemsChecked`, `itemsCompleted`, `itemsSkipped`)이며 PRD에 스펙 부재. 본 항목 추후 PRD §9 개정 시 스키마도 함께 명시 필요.

---

## 5. 보안 점검 — **PASS** (운영상 주의)

- **시크릿 하드코딩**: 코드/테스트 모두 시크릿 평문 없음. `tao@wrtn.io`는 PRD §11 yaml 예시 값과 동일한 사용자 식별자로 픽스처에서만 사용됨 (BOUNDARIES §5의 "사용자 개인정보" 항목은 런타임 입력 정책이며, yaml 콘텐츠 자체는 OK 범주). 통과.
- **SQL 인젝션**: `better-sqlite3.prepare(...)` + 명명 파라미터(`@item_id`, `@now`) 사용. 동적 문자열 합성 없음 (`index.ts:35-47`). 통과.
- **캡처 이미지 데이터 파기 (PRD §8.2 / AC-VIS-07)**: 본 spec은 P1(결정론) 범위로 캡처/Vision 미관여. 해당 사항 없음 (N/A).

⚠️ **운영상 주의 (FAIL 아님)**:

`probes.ts:18` `defaultProbeRunner`는 `execa(command, { shell: true, ... })`로 yaml의 `verification.command` 문자열을 셸 인터프리테이션에 통과시킨다. 또한 `process_check` 분기는 `pgrep ${processName}` (line 65)으로 `process_name`을 단순 문자열 보간한다. 현재 yaml은 데몬에 번들된 신뢰 콘텐츠(`packages/daemon/content/checklist.yaml`)이고, shared의 `CommandVerificationSchema`/`ProcessCheckVerificationSchema`가 `min(1)` 외 별도 metacharacter 검증을 두지 않음. 향후 yaml이 외부에서 주입되거나 동적 로딩될 가능성이 생기면 셸 인젝션 표면이 된다.

P1 한정 + 빌드 타임 yaml에서는 위협 모델상 무관하므로 통과 처리. 다만 PRD/Spec 단계에서 "yaml 출처가 영구히 신뢰 콘텐츠"임을 문서화해두면 좋다.

---

## 6. 코드 품질 — **PASS**

- 함수 길이 (50줄 가이드라인):
  - `runStateProbe` (`index.ts:28-84`): 본문 약 50라인 (signature/주석 포함 시 57라인). 가이드라인 경계선이지만 분기 단순(쿼리 1 + INSERT 1 + for-loop). 분리 강제하지 않음.
  - `runProbe` / `runCommandProbe` / `runProcessCheckProbe` / `defaultProbeRunner`: 모두 30라인 미만.
  - `createStateProbeRouter`: 22라인.
  - `bootstrap` (`src/index.ts:18-66`): 49라인.
- 테스트 커버리지: **100% lines / funcs / stmts**, 95.32% branch (전 패키지 기준).
  - p1-state-probe만 보면: `index.ts` 100/90/100/100, `probes.ts` 100/90.9/100/100, `routes/state-probe.ts` 100/100/100/100.
- 타이핑 엄격: `runProbe` 등이 `Verification` discriminated union을 그대로 받아 `if (type === 'command') { ... }` else 폴백 — exhaustive.
- 의존성 주입 (runner / now / logger 옵셔널) → 테스트 친화적이며 부팅 경로는 default 사용.
- 주석 1건만 있음 (왜 boot 직후에 호출하는지) — 이유 설명 위주로 적절함.

---

## 7. BOUNDARIES.md 준수 — **WARN**

| BOUNDARIES 조항 | 평가 |
|-----------------|------|
| §1 Read-Only 파일 변경 | 변경 없음. PASS. |
| §2 spec 외 패키지 경로 | 변경은 모두 `packages/daemon/` 내부. PASS. |
| §2 "다른 spec이 만든 파일 수정" | `src/index.ts` (spec-002) +14라인, `src/routes/index.ts` (spec-002/003) +14라인 변경됨. wiring(부팅 시 호출 + 라우터 등록) 목적의 추가만 있고 기존 spec 의도는 유지됨. 엄격 해석상 회색지대 — WARN. |
| §3 신규 의존성 | `execa ^9.0.0` 만 추가, PRD §12 카탈로그 내. PASS. |
| §4 API 계약 보호 (라우트 추가 금지) | `POST /api/state-probe/run` 신규 추가. **WARN** (§4 항목 1과 동일). |
| §5 시크릿 | PASS (§5 별도 분석 참조). |

종합: 본 spec은 "데몬 내부 기능 추가"이므로 wiring을 위한 기존 entry 파일 수정이 불가피하며, 이는 spec 산출물에서도 명시 (`packages/daemon/src/index.ts` — 부팅 시 `runStateProbe()` 1회 호출). 문제는 BOUNDARIES §4 (라우트 추가 금지)의 형식적 위반이다. 이는 spec 단계에서 PRD §9 갱신을 함께 청구했어야 한다.

---

## 8. 의존성 체크 (PRD §12) — **PASS**

`packages/daemon/package.json` 신규 추가:

```diff
+ "execa": "^9.0.0",
```

PRD §12 / BOUNDARIES §3 화이트리스트:

```
| execa | ^9.0 | daemon, cli | shell 명령 |
```

버전(`^9.0.0`)이 카탈로그(`^9.0`) 메이저와 일치. transitive (`@sec-ant/readable-stream`, `@sindresorhus/merge-streams` 등)는 execa가 끌어오는 자연스러운 의존이며 직접 import 없음 (코드 grep 확인). 통과.

다른 신규 dependency 없음.

---

## 부록: 강점

- runner를 옵셔널 의존성으로 분리 → 19개 단위 테스트가 execa 없이 결정론적으로 동작.
- 부팅 경로에서 listen 전에 await — race condition 없음.
- ON CONFLICT 사용으로 idempotent 갱신 보장.
- `attempt_count` 보존(ON CONFLICT 시 미터치) — 다른 spec(P4 polling)에서 카운터 의미를 깨지 않음.
- 19/19 신규 테스트 모두 빠르게 통과(157~172ms).

## 후속 권고 (action items)

1. **(WARN, §4·§7 공통)** PRD §9에 `POST /api/state-probe/run` 항목 추가 또는 spec-005 라우트 제거 결정. PRD 측 정정이 우선.
2. **(보안 운영 주의)** "yaml 출처는 데몬 빌드 시점에 번들된 신뢰 콘텐츠로 한정"을 PRD/spec 어딘가에 명문화.
3. **(데이터 모델 정합성, 경미)** 신규 row 삽입 시 `attempt_count = 1` 의미 — P4 spec 진행 시 일관 정의 필요할 수 있음.

---

<promise>SPEC_005_DAEMON_P1_STATE_PROBE_REVIEW_PASS_WITH_WARN</promise>
