### PR TITLE
[Ralph] spec-007-daemon-p4-verify

### DIFF
--- a/packages/daemon/src/p4-verify/index.ts
+++ b/packages/daemon/src/p4-verify/index.ts
@@ -1,0 +1,220 @@
+import type { ChecklistFile, Verification } from '@onboarding/shared';
+import { execa } from 'execa';
+import type { Logger } from 'pino';
+
+import type { DatabaseInstance } from '../db/index.js';
+
+export const VERIFY_TIMEOUT_MS = 30_000;
+const STDOUT_DETAILS_MAX_BYTES = 1024;
+
+export interface VerifyOutput {
+  stdout: string;
+  exitCode: number;
+  timedOut: boolean;
+}
+
+export type VerifyRunner = (command: string) => Promise<VerifyOutput>;
+
+export interface VerifyResult {
+  status: 'pass' | 'fail';
+  details: string;
+}
+
+export const defaultVerifyRunner: VerifyRunner = async (command) => {
+  const result = await execa(command, {
+    shell: true,
+    timeout: VERIFY_TIMEOUT_MS,
+    reject: false,
+  });
+  return {
+    stdout: typeof result.stdout === 'string' ? result.stdout : '',
+    exitCode: typeof result.exitCode === 'number' ? result.exitCode : 1,
+    timedOut: result.timedOut === true,
+  };
+};
+
+export class ItemNotFoundError extends Error {
+  readonly code = 'item_not_found';
+  constructor(public readonly itemId: string) {
+    super(`item_not_found: ${itemId}`);
+    this.name = 'ItemNotFoundError';
+  }
+}
+
+export class VerificationMissingError extends Error {
+  readonly code = 'verification_missing';
+  constructor(public readonly itemId: string) {
+    super(`verification_missing: ${itemId}`);
+    this.name = 'VerificationMissingError';
+  }
+}
+
+export interface RunVerifyOptions {
+  checklist: ChecklistFile;
+  db: DatabaseInstance;
+  verification?: Verification;
+  runner?: VerifyRunner;
+  now?: () => number;
+  logger?: Logger;
+}
+
+export async function runVerify(
+  itemId: string,
+  options: RunVerifyOptions,
+): Promise<VerifyResult> {
+  const item = options.checklist.items.find((i) => i.id === itemId);
+  if (!item) throw new ItemNotFoundError(itemId);
+
+  const verification = options.verification ?? item.verification;
+  if (!verification) throw new VerificationMissingError(itemId);
+
+  const runner = options.runner ?? defaultVerifyRunner;
+  const now = options.now ?? Date.now;
+
+  const result = await runVerificationProbe(verification, runner);
+  options.logger?.info(
+    { item_id: itemId, status: result.status },
+    'verify_result',
+  );
+
+  if (result.status === 'pass') {
+    markCompleted(options.db, itemId, now());
+  } else {
+    bumpAttemptCount(options.db, itemId);
+  }
+
+  return result;
+}
+
+async function runVerificationProbe(
+  verification: Verification,
+  runner: VerifyRunner,
+): Promise<VerifyResult> {
+  if (verification.type === 'command') {
+    return runCommandVerify(
+      verification.command,
+      verification.expect_contains,
+      runner,
+    );
+  }
+  return runProcessCheckVerify(verification.process_name, runner);
+}
+
+async function runCommandVerify(
+  command: string,
+  expectContains: string | undefined,
+  runner: VerifyRunner,
+): Promise<VerifyResult> {
+  let output: VerifyOutput;
+  try {
+    output = await runner(command);
+  } catch (err) {
+    return {
+      status: 'fail',
+      details: `command threw: ${errorMessage(err)}`,
+    };
+  }
+
+  if (output.timedOut) {
+    return {
+      status: 'fail',
+      details: `timeout after ${VERIFY_TIMEOUT_MS / 1000}s; ${stdoutSnippet(output.stdout)}`,
+    };
+  }
+
+  if (output.exitCode !== 0) {
+    return {
+      status: 'fail',
+      details: `command failed (exit ${output.exitCode}); ${stdoutSnippet(output.stdout)}`,
+    };
+  }
+
+  if (expectContains && !output.stdout.includes(expectContains)) {
+    return {
+      status: 'fail',
+      details: `expected stdout to contain ${JSON.stringify(expectContains)} (exit 0); got ${stdoutSnippet(output.stdout)}`,
+    };
+  }
+
+  return {
+    status: 'pass',
+    details: `command succeeded (exit 0)`,
+  };
+}
+
+async function runProcessCheckVerify(
+  processName: string,
+  runner: VerifyRunner,
+): Promise<VerifyResult> {
+  const command = `pgrep ${processName}`;
+  let output: VerifyOutput;
+  try {
+    output = await runner(command);
+  } catch (err) {
+    return {
+      status: 'fail',
+      details: `pgrep threw: ${errorMessage(err)}`,
+    };
+  }
+
+  if (output.timedOut) {
+    return {
+      status: 'fail',
+      details: `timeout after ${VERIFY_TIMEOUT_MS / 1000}s while probing process ${processName}`,
+    };
+  }
+
+  if (output.exitCode !== 0 || output.stdout.trim().length === 0) {
+    return {
+      status: 'fail',
+      details: `process ${processName} not running (exit ${output.exitCode})`,
+    };
+  }
+
+  return {
+    status: 'pass',
+    details: `process ${processName} running (pid ${output.stdout.trim().split(/\s+/)[0]})`,
+  };
+}
+
+function stdoutSnippet(stdout: string): string {
+  const trimmed = stdout.length > 0 ? stdout : '<empty>';
+  if (Buffer.byteLength(trimmed, 'utf8') <= STDOUT_DETAILS_MAX_BYTES) {
+    return `stdout=${JSON.stringify(trimmed)}`;
+  }
+  // Truncate by bytes (safe for ASCII; for multibyte we may cut a char short
+  // but the snippet is purely informational).
+  const buf = Buffer.from(trimmed, 'utf8').subarray(0, STDOUT_DETAILS_MAX_BYTES);
+  return `stdout=${JSON.stringify(buf.toString('utf8'))}<truncated>`;
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+function markCompleted(
+  db: DatabaseInstance,
+  itemId: string,
+  now: number,
+): void {
+  db.prepare(
+    `INSERT INTO item_states
+       (item_id, status, current_step, started_at, completed_at, attempt_count)
+     VALUES (@item_id, 'completed', NULL, NULL, @now, 1)
+     ON CONFLICT(item_id) DO UPDATE SET
+       status        = 'completed',
+       completed_at  = @now,
+       attempt_count = item_states.attempt_count + 1`,
+  ).run({ item_id: itemId, now });
+}
+
+function bumpAttemptCount(db: DatabaseInstance, itemId: string): void {
+  db.prepare(
+    `INSERT INTO item_states
+       (item_id, status, current_step, started_at, completed_at, attempt_count)
+     VALUES (@item_id, 'pending', NULL, NULL, NULL, 1)
+     ON CONFLICT(item_id) DO UPDATE SET
+       attempt_count = item_states.attempt_count + 1`,
+  ).run({ item_id: itemId });
+}

--- a/packages/daemon/src/routes/index.ts
+++ b/packages/daemon/src/routes/index.ts
@@ -5,10 +5,12 @@ import type { Logger } from 'pino';
 import type { DatabaseInstance } from '../db/index.js';
 import type { ProbeRunner } from '../p1-state-probe/probes.js';
 import type { ClipboardRunner } from '../p2-clipboard/index.js';
+import type { VerifyRunner } from '../p4-verify/index.js';
 import { createChecklistRouter } from './checklist.js';
 import { createClipboardRouter } from './clipboard.js';
 import { createConsentsRouter } from './consents.js';
 import { createStateProbeRouter } from './state-probe.js';
+import { createVerifyRouter } from './verify.js';
 
 export interface ApiRoutesDeps {
   checklist: ChecklistFile;
@@ -17,6 +19,7 @@ export interface ApiRoutesDeps {
   probeRunner?: ProbeRunner;
   clipboardRunner?: ClipboardRunner;
   clipboardPlatform?: NodeJS.Platform;
+  verifyRunner?: VerifyRunner;
   logger?: Logger;
 }
 
@@ -36,6 +39,15 @@ export function registerApiRoutes(app: Application, deps: ApiRoutesDeps): void {
     createClipboardRouter({
       runner: deps.clipboardRunner,
       platform: deps.clipboardPlatform,
+    }),
+  );
+  app.use(
+    createVerifyRouter({
+      checklist: deps.checklist,
+      db: deps.db,
+      runner: deps.verifyRunner,
+      now: deps.now,
+      logger: deps.logger,
     }),
   );
 }

--- a/packages/daemon/src/routes/verify.ts
+++ b/packages/daemon/src/routes/verify.ts
@@ -1,0 +1,78 @@
+import {
+  ItemIdSchema,
+  VerificationSchema,
+  type ChecklistFile,
+} from '@onboarding/shared';
+import {
+  Router,
+  type NextFunction,
+  type Request,
+  type Response,
+} from 'express';
+import type { Logger } from 'pino';
+import { z } from 'zod';
+
+import type { DatabaseInstance } from '../db/index.js';
+import {
+  ItemNotFoundError,
+  VerificationMissingError,
+  runVerify,
+  type VerifyRunner,
+} from '../p4-verify/index.js';
+
+// Local schema: verification is optional in the body — when omitted we fall
+// back to the yaml's verification block (spec-007 §출력).
+const VerifyRunBodySchema = z
+  .object({
+    item_id: ItemIdSchema,
+    verification: VerificationSchema.optional(),
+  })
+  .strict();
+
+export interface VerifyRouterDeps {
+  checklist: ChecklistFile;
+  db: DatabaseInstance;
+  runner?: VerifyRunner;
+  now?: () => number;
+  logger?: Logger;
+}
+
+export function createVerifyRouter(deps: VerifyRouterDeps): Router {
+  const router = Router();
+
+  router.post(
+    '/api/verify/run',
+    (req: Request, res: Response, next: NextFunction) => {
+      const parsed = VerifyRunBodySchema.safeParse(req.body);
+      if (!parsed.success) {
+        next(parsed.error);
+        return;
+      }
+
+      runVerify(parsed.data.item_id, {
+        checklist: deps.checklist,
+        db: deps.db,
+        verification: parsed.data.verification,
+        runner: deps.runner,
+        now: deps.now,
+        logger: deps.logger,
+      })
+        .then((result) => {
+          res.status(200).json(result);
+        })
+        .catch((err: unknown) => {
+          if (err instanceof ItemNotFoundError) {
+            res.status(404).json({ error: 'item_not_found' });
+            return;
+          }
+          if (err instanceof VerificationMissingError) {
+            res.status(400).json({ error: 'verification_missing' });
+            return;
+          }
+          next(err);
+        });
+    },
+  );
+
+  return router;
+}

--- a/packages/daemon/tests/p4-verify.test.ts
+++ b/packages/daemon/tests/p4-verify.test.ts
@@ -1,0 +1,614 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { ChecklistFile } from '@onboarding/shared';
+import pino from 'pino';
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { openDatabase, type DatabaseInstance } from '../src/db/index.js';
+import { migrate } from '../src/db/migrate.js';
+import {
+  defaultVerifyRunner,
+  ItemNotFoundError,
+  runVerify,
+  VerificationMissingError,
+  VERIFY_TIMEOUT_MS,
+  type VerifyRunner,
+} from '../src/p4-verify/index.js';
+import { createVerifyRouter } from '../src/routes/verify.js';
+import { registerApiRoutes } from '../src/routes/index.js';
+import { createServer } from '../src/server.js';
+
+const silentLogger = pino({ level: 'silent' });
+
+const FIXTURE_CHECKLIST: ChecklistFile = {
+  version: 2,
+  schema: 'ai-coaching',
+  items: [
+    {
+      id: 'install-homebrew',
+      title: 'Homebrew',
+      estimated_minutes: 3,
+      verification: {
+        type: 'command',
+        command: 'brew --version',
+      },
+    },
+    {
+      id: 'configure-git',
+      title: 'Git',
+      estimated_minutes: 1,
+      verification: {
+        type: 'command',
+        command: 'git config --global user.email',
+        expect_contains: 'tao@wrtn.io',
+      },
+    },
+    {
+      id: 'install-security-agent',
+      title: 'Security agent',
+      estimated_minutes: 15,
+      verification: {
+        type: 'process_check',
+        process_name: 'SecurityAgent',
+      },
+    },
+    {
+      id: 'no-verification',
+      title: 'No probe',
+      estimated_minutes: 1,
+    },
+  ],
+};
+
+interface ItemStateRow {
+  item_id: string;
+  status: string;
+  current_step: string | null;
+  started_at: number | null;
+  completed_at: number | null;
+  attempt_count: number;
+}
+
+function readState(db: DatabaseInstance, itemId: string): ItemStateRow | undefined {
+  return db
+    .prepare('SELECT * FROM item_states WHERE item_id = ?')
+    .get(itemId) as ItemStateRow | undefined;
+}
+
+describe('runVerify (p4-verify/index.ts)', () => {
+  let tmpDir: string;
+  let db: DatabaseInstance;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'onboarding-p4-verify-'));
+    db = openDatabase(join(tmpDir, 'agent.db'));
+    migrate(db);
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('command verification', () => {
+    it('returns pass and marks item completed when exit code is 0 (AC-P4-01)', async () => {
+      const runner: VerifyRunner = vi.fn().mockResolvedValue({
+        stdout: 'Homebrew 4.3.0',
+        exitCode: 0,
+        timedOut: false,
+      });
+      const fixedNow = 1_700_000_000_000;
+
+      const result = await runVerify('install-homebrew', {
+        checklist: FIXTURE_CHECKLIST,
+        db,
+        runner,
+        now: () => fixedNow,
+        logger: silentLogger,
+      });
+
+      expect(result.status).toBe('pass');
+      expect(runner).toHaveBeenCalledWith('brew --version');
+
+      const state = readState(db, 'install-homebrew');
+      expect(state?.status).toBe('completed');
+      expect(state?.completed_at).toBe(fixedNow);
+      expect(state?.attempt_count).toBe(1);
+    });
+
+    it('returns fail and increments attempt_count when exit code is non-zero', async () => {
+      const runner: VerifyRunner = vi.fn().mockResolvedValue({
+        stdout: 'command not found',
+        exitCode: 127,
+        timedOut: false,
+      });
+
+      const result = await runVerify('install-homebrew', {
+        checklist: FIXTURE_CHECKLIST,
+        db,
+        runner,
+        logger: silentLogger,
+      });
+
+      expect(result.status).toBe('fail');
+      expect(result.details).toContain('exit');
+      expect(result.details).toContain('127');
+
+      const state = readState(db, 'install-homebrew');
+      expect(state?.status).not.toBe('completed');
+      expect(state?.attempt_count).toBe(1);
+    });
+
+    it('preserves existing in_progress status on FAIL but bumps attempt_count', async () => {
+      db.prepare(
+        `INSERT INTO item_states
+           (item_id, status, current_step, started_at, completed_at, attempt_count)
+         VALUES ('install-homebrew', 'in_progress', NULL, 999, NULL, 2)`,
+      ).run();
+
+      const runner: VerifyRunner = vi
+        .fn()
+        .mockResolvedValue({ stdout: '', exitCode: 1, timedOut: false });
+
+      const result = await runVerify('install-homebrew', {
+        checklist: FIXTURE_CHECKLIST,
+        db,
+        runner,
+        logger: silentLogger,
+      });
+
+      expect(result.status).toBe('fail');
+      const state = readState(db, 'install-homebrew');
+      expect(state?.status).toBe('in_progress');
+      expect(state?.started_at).toBe(999);
+      expect(state?.attempt_count).toBe(3);
+    });
+
+    it('returns pass when expect_contains matches stdout', async () => {
+      const runner: VerifyRunner = vi.fn().mockResolvedValue({
+        stdout: 'tao@wrtn.io\n',
+        exitCode: 0,
+        timedOut: false,
+      });
+
+      const result = await runVerify('configure-git', {
+        checklist: FIXTURE_CHECKLIST,
+        db,
+        runner,
+      });
+
+      expect(result.status).toBe('pass');
+      expect(readState(db, 'configure-git')?.status).toBe('completed');
+    });
+
+    it('returns fail with details when expect_contains does not match', async () => {
+      const runner: VerifyRunner = vi.fn().mockResolvedValue({
+        stdout: 'someone-else@example.com\n',
+        exitCode: 0,
+        timedOut: false,
+      });
+
+      const result = await runVerify('configure-git', {
+        checklist: FIXTURE_CHECKLIST,
+        db,
+        runner,
+      });
+
+      expect(result.status).toBe('fail');
+      expect(result.details).toContain('tao@wrtn.io');
+      expect(result.details).toContain('someone-else@example.com');
+
+      const state = readState(db, 'configure-git');
+      expect(state?.status).not.toBe('completed');
+      expect(state?.attempt_count).toBe(1);
+    });
+
+    it('returns fail with timeout message when runner reports timedOut', async () => {
+      const runner: VerifyRunner = vi.fn().mockResolvedValue({
+        stdout: '',
+        exitCode: 1,
+        timedOut: true,
+      });
+
+      const result = await runVerify('install-homebrew', {
+        checklist: FIXTURE_CHECKLIST,
+        db,
+        runner,
+      });
+
+      expect(result.status).toBe('fail');
+      expect(result.details).toContain('timeout');
+    });
+
+    it('returns fail when runner throws an error', async () => {
+      const runner: VerifyRunner = vi
+        .fn()
+        .mockRejectedValue(new Error('spawn error: ENOENT'));
+
+      const result = await runVerify('install-homebrew', {
+        checklist: FIXTURE_CHECKLIST,
+        db,
+        runner,
+      });
+
+      expect(result.status).toBe('fail');
+      expect(result.details).toContain('ENOENT');
+
+      const state = readState(db, 'install-homebrew');
+      expect(state?.attempt_count).toBe(1);
+    });
+
+    it('truncates stdout in details to at most 1KB', async () => {
+      const huge = 'a'.repeat(5000);
+      const runner: VerifyRunner = vi.fn().mockResolvedValue({
+        stdout: huge,
+        exitCode: 1,
+        timedOut: false,
+      });
+
+      const result = await runVerify('install-homebrew', {
+        checklist: FIXTURE_CHECKLIST,
+        db,
+        runner,
+      });
+
+      expect(result.status).toBe('fail');
+      // details should not contain the entire 5000-char stdout
+      expect(result.details.length).toBeLessThanOrEqual(2048);
+    });
+
+    it('uses the body verification override when given', async () => {
+      const runner: VerifyRunner = vi.fn().mockResolvedValue({
+        stdout: 'overridden',
+        exitCode: 0,
+        timedOut: false,
+      });
+
+      const result = await runVerify('install-homebrew', {
+        checklist: FIXTURE_CHECKLIST,
+        db,
+        verification: {
+          type: 'command',
+          command: 'echo overridden',
+        },
+        runner,
+      });
+
+      expect(result.status).toBe('pass');
+      expect(runner).toHaveBeenCalledWith('echo overridden');
+    });
+  });
+
+  describe('process_check verification', () => {
+    it('returns pass when pgrep exits 0 and prints a PID', async () => {
+      const runner: VerifyRunner = vi.fn().mockResolvedValue({
+        stdout: '12345\n',
+        exitCode: 0,
+        timedOut: false,
+      });
+      const fixedNow = 1_700_000_000_000;
+
+      const result = await runVerify('install-security-agent', {
+        checklist: FIXTURE_CHECKLIST,
+        db,
+        runner,
+        now: () => fixedNow,
+      });
+
+      expect(result.status).toBe('pass');
+      expect(runner).toHaveBeenCalledWith('pgrep SecurityAgent');
+
+      const state = readState(db, 'install-security-agent');
+      expect(state?.status).toBe('completed');
+      expect(state?.completed_at).toBe(fixedNow);
+      expect(state?.attempt_count).toBe(1);
+    });
+
+    it('returns fail when pgrep exits non-zero', async () => {
+      const runner: VerifyRunner = vi.fn().mockResolvedValue({
+        stdout: '',
+        exitCode: 1,
+        timedOut: false,
+      });
+
+      const result = await runVerify('install-security-agent', {
+        checklist: FIXTURE_CHECKLIST,
+        db,
+        runner,
+      });
+
+      expect(result.status).toBe('fail');
+      expect(result.details).toContain('process');
+
+      const state = readState(db, 'install-security-agent');
+      expect(state?.status).not.toBe('completed');
+      expect(state?.attempt_count).toBe(1);
+    });
+
+    it('returns fail when pgrep exits 0 but stdout is empty', async () => {
+      const runner: VerifyRunner = vi.fn().mockResolvedValue({
+        stdout: '\n',
+        exitCode: 0,
+        timedOut: false,
+      });
+
+      const result = await runVerify('install-security-agent', {
+        checklist: FIXTURE_CHECKLIST,
+        db,
+        runner,
+      });
+
+      expect(result.status).toBe('fail');
+    });
+  });
+
+  describe('errors', () => {
+    it('throws ItemNotFoundError when itemId is not in checklist', async () => {
+      const runner: VerifyRunner = vi.fn();
+      await expect(
+        runVerify('does-not-exist', {
+          checklist: FIXTURE_CHECKLIST,
+          db,
+          runner,
+        }),
+      ).rejects.toBeInstanceOf(ItemNotFoundError);
+      expect(runner).not.toHaveBeenCalled();
+    });
+
+    it('throws VerificationMissingError when item has no verification and no override', async () => {
+      const runner: VerifyRunner = vi.fn();
+      await expect(
+        runVerify('no-verification', {
+          checklist: FIXTURE_CHECKLIST,
+          db,
+          runner,
+        }),
+      ).rejects.toBeInstanceOf(VerificationMissingError);
+      expect(runner).not.toHaveBeenCalled();
+    });
+
+    it('uses override even when item has no yaml verification', async () => {
+      const runner: VerifyRunner = vi.fn().mockResolvedValue({
+        stdout: 'ok',
+        exitCode: 0,
+        timedOut: false,
+      });
+
+      const result = await runVerify('no-verification', {
+        checklist: FIXTURE_CHECKLIST,
+        db,
+        verification: { type: 'command', command: 'echo ok' },
+        runner,
+      });
+
+      expect(result.status).toBe('pass');
+    });
+  });
+});
+
+describe('defaultVerifyRunner', () => {
+  it('exposes a 30-second timeout (AC: command 실행 timeout 30초)', () => {
+    expect(VERIFY_TIMEOUT_MS).toBe(30_000);
+  });
+
+  it('runs a real shell command and returns stdout/exitCode (exit 0)', async () => {
+    const out = await defaultVerifyRunner(
+      'node -e "process.stdout.write(\'hello\')"',
+    );
+    expect(out.exitCode).toBe(0);
+    expect(out.stdout).toContain('hello');
+    expect(out.timedOut).toBe(false);
+  });
+
+  it('returns non-zero exitCode when the command fails', async () => {
+    const out = await defaultVerifyRunner('node -e "process.exit(7)"');
+    expect(out.exitCode).toBe(7);
+    expect(out.timedOut).toBe(false);
+  });
+});
+
+describe('POST /api/verify/run', () => {
+  let tmpDir: string;
+  let db: DatabaseInstance;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'onboarding-p4-verify-route-'));
+    db = openDatabase(join(tmpDir, 'agent.db'));
+    migrate(db);
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function buildApp(opts: {
+    checklist?: ChecklistFile;
+    runner?: VerifyRunner;
+    now?: () => number;
+  } = {}) {
+    return createServer({
+      logger: silentLogger,
+      registerRoutes: (app) => {
+        app.use(
+          createVerifyRouter({
+            checklist: opts.checklist ?? FIXTURE_CHECKLIST,
+            db,
+            runner: opts.runner,
+            now: opts.now,
+            logger: silentLogger,
+          }),
+        );
+      },
+    });
+  }
+
+  it('200 { status: "pass" } when command verification passes (AC-P4-01)', async () => {
+    const runner: VerifyRunner = vi.fn().mockResolvedValue({
+      stdout: 'Homebrew 4.3.0',
+      exitCode: 0,
+      timedOut: false,
+    });
+    const fixedNow = 1_700_000_000_000;
+
+    const app = buildApp({ runner, now: () => fixedNow });
+
+    const res = await request(app)
+      .post('/api/verify/run')
+      .send({ item_id: 'install-homebrew' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('pass');
+    expect(typeof res.body.details).toBe('string');
+
+    const state = readState(db, 'install-homebrew');
+    expect(state?.status).toBe('completed');
+    expect(state?.completed_at).toBe(fixedNow);
+  });
+
+  it('200 { status: "fail", details } when verification fails', async () => {
+    const runner: VerifyRunner = vi.fn().mockResolvedValue({
+      stdout: 'wrong output',
+      exitCode: 1,
+      timedOut: false,
+    });
+
+    const app = buildApp({ runner });
+
+    const res = await request(app)
+      .post('/api/verify/run')
+      .send({ item_id: 'install-homebrew' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('fail');
+    expect(res.body.details).toContain('1');
+
+    const state = readState(db, 'install-homebrew');
+    expect(state?.status).not.toBe('completed');
+    expect(state?.attempt_count).toBe(1);
+  });
+
+  it('uses body.verification override when present', async () => {
+    const runner: VerifyRunner = vi.fn().mockResolvedValue({
+      stdout: '',
+      exitCode: 0,
+      timedOut: false,
+    });
+
+    const app = buildApp({ runner });
+
+    const res = await request(app)
+      .post('/api/verify/run')
+      .send({
+        item_id: 'install-homebrew',
+        verification: { type: 'command', command: 'true' },
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('pass');
+    expect(runner).toHaveBeenCalledWith('true');
+  });
+
+  it('404 item_not_found when item_id is unknown', async () => {
+    const runner: VerifyRunner = vi.fn();
+    const app = buildApp({ runner });
+
+    const res = await request(app)
+      .post('/api/verify/run')
+      .send({ item_id: 'does-not-exist' });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('item_not_found');
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it('400 verification_missing when item has no verification and body has none', async () => {
+    const runner: VerifyRunner = vi.fn();
+    const app = buildApp({ runner });
+
+    const res = await request(app)
+      .post('/api/verify/run')
+      .send({ item_id: 'no-verification' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('verification_missing');
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it('400 validation_error when item_id is missing', async () => {
+    const runner: VerifyRunner = vi.fn();
+    const app = buildApp({ runner });
+
+    const res = await request(app).post('/api/verify/run').send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('validation_error');
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it('400 validation_error when verification override is malformed', async () => {
+    const runner: VerifyRunner = vi.fn();
+    const app = buildApp({ runner });
+
+    const res = await request(app).post('/api/verify/run').send({
+      item_id: 'install-homebrew',
+      verification: { type: 'unknown' },
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('validation_error');
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it('process_check route round-trip (AC: pgrep PID → pass)', async () => {
+    const runner: VerifyRunner = vi.fn().mockResolvedValue({
+      stdout: '4242\n',
+      exitCode: 0,
+      timedOut: false,
+    });
+
+    const app = buildApp({ runner });
+
+    const res = await request(app)
+      .post('/api/verify/run')
+      .send({ item_id: 'install-security-agent' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('pass');
+    expect(runner).toHaveBeenCalledWith('pgrep SecurityAgent');
+  });
+});
+
+describe('verify route is registered via registerApiRoutes', () => {
+  it('POST /api/verify/run goes through registerApiRoutes', async () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'onboarding-verify-routes-'));
+    const db: DatabaseInstance = openDatabase(join(tmpDir, 'agent.db'));
+    migrate(db);
+    try {
+      const runner: VerifyRunner = vi.fn().mockResolvedValue({
+        stdout: 'ok',
+        exitCode: 0,
+        timedOut: false,
+      });
+      const app = createServer({
+        logger: silentLogger,
+        registerRoutes: (a) => {
+          registerApiRoutes(a, {
+            checklist: FIXTURE_CHECKLIST,
+            db,
+            verifyRunner: runner,
+          });
+        },
+      });
+      const res = await request(app)
+        .post('/api/verify/run')
+        .send({ item_id: 'install-homebrew' });
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBe('pass');
+    } finally {
+      db.close();
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
# Code Review — spec-007-daemon-p4-verify

- **검증일**: 2026-05-01
- **브랜치**: `feature/spec-007-daemon-p4-verify` (HEAD `3808dfa`)
- **베이스**: `main`
- **Spec**: [specs/spec-007-daemon-p4-verify.md](../specs/spec-007-daemon-p4-verify.md)
- **PRD**: [docs/PRD-MVP-SLIM.md](../docs/PRD-MVP-SLIM.md) v0.10
- **검증자**: code-reviewer (Claude Opus 4.7)

## 종합 판정

**PASS_WITH_WARN** — spec-007의 모든 AC가 코드와 테스트로 충족되었고, BOUNDARIES.md / PRD §8·§9 / 시크릿·SQL 안전성·신규 의존성 모두 준수. 다만 (a) `shared`의 `VerifyRunRequestSchema`(verification 필수)와 라우트 로컬 스키마(verification optional)가 어긋난 점, (b) `verification.command`가 `execa(shell: true)`로 임의 셸 명령을 실행하는 신뢰 경계 이슈, (c) `markCompleted` SQL이 `current_step`/`started_at`을 NULL로 덮는 문제는 WARN으로 남깁니다. 모두 spec/PRD 의도 범위 내이므로 FAIL은 아닙니다.

| # | 항목 | 판정 |
|---|------|------|
| 1 | AC 정합성 (PRD §10) | PASS |
| 2 | PRD 정합성 | PASS |
| 3 | 데이터 모델 정합성 (PRD §8) | PASS |
| 4 | API 계약 정합성 (PRD §9) | WARN |
| 5 | 보안 점검 | WARN |
| 6 | 코드 품질 | PASS |
| 7 | BOUNDARIES.md 준수 | PASS |
| 8 | 의존성 체크 | PASS |

---

## 1. AC 정합성 (PRD §10) — **PASS**

spec §"Acceptance Criteria"의 10개 항목 + PRD §10.3 AC-P4-01을 모두 코드/테스트가 충족.

| AC | 위치 | 비고 |
|----|------|------|
| AC-P4-01 (`brew --version` exit 0 → PASS, ≠0 → FAIL) | `p4-verify/index.ts:103-143` (`runCommandVerify`), 테스트 `p4-verify.test.ts:97-143`, `:449-492` | 두 케이스(성공/실패) 모두 명시적 단위·라우트 테스트로 검증. |
| PRD §11 verification 형태 모두 처리 (command + expect_contains, process_check) | `p4-verify/index.ts:89-101`, `:103-143`, `:145-178` | command/expect_contains/process_check 분기 모두 구현. yaml의 5개 항목은 이 두 타입 안에서 표현됨. |
| FAIL details에 stdout 일부(≤1KB) + exit code | `p4-verify/index.ts:120-137`, `:180-189` | `stdoutSnippet`이 `STDOUT_DETAILS_MAX_BYTES=1024`로 자르고 `<truncated>` 마킹. 테스트 `:244-261`이 길이 ≤2048 보장. |
| command timeout 30초 + timeout 시 FAIL with `timeout` | `p4-verify/index.ts:7` (`VERIFY_TIMEOUT_MS=30_000`), `:23-34`, `:118-122` / 테스트 `:209-224`, `:392-395` | `defaultVerifyRunner`가 `execa({ timeout: 30_000, reject: false })`로 강제, `timedOut` 플래그 → details에 `timeout` 문구 포함. |
| PASS 시 SQLite item_states 자동 갱신 + attempt_count +1 | `p4-verify/index.ts:80-84`, `:196-209` (UPSERT) / 테스트 `:97-120`, `:286-308`, `:449-470` | `INSERT … ON CONFLICT DO UPDATE`로 status='completed', completed_at=now, attempt_count+1. 신규 row는 attempt_count=1. |
| FAIL 시 attempt_count 증가, 상태 보존 | `p4-verify/index.ts:212-219` / 테스트 `:145-168` (in_progress 보존), `:122-143` | `bumpAttemptCount`는 status를 건드리지 않음. 기존 in_progress + started_at도 보존됨. |
| `pnpm test` 통과 | 122/122 (전체 워크스페이스 빌드 후) | p4-verify.test.ts만 27개 |
| `pnpm build` 통과 | OK | shared/daemon 모두 |
| `pnpm lint`(=tsc) 에러 0 | OK | shared 빌드 후 daemon lint clean |
| 테스트 커버리지 ≥ 80% | OK | p4-verify/index.ts 92.4% line / 87.5% branch / 100% func, routes/verify.ts 97.67% line. 데몬 전체 98.22%. |
| BOUNDARIES.md 준수 | OK | §7 참조 |
| 신규 의존성 없음 | OK | §8 참조 |

> 참고: `pnpm install` 직후 곧장 `pnpm --filter @onboarding/daemon test`를 돌리면 `@onboarding/shared` 엔트리 해석에 실패한다. 루트에서 `pnpm -r build`(또는 `pnpm --filter @onboarding/shared build`)를 먼저 돌려야 통과. 워크스페이스 ordering 이슈일 뿐 spec-007 코드 결함은 아니지만, CI/문서에 build→test 순서가 명시되어 있는지 후행 spec에서 확인 권고.

---

## 2. PRD 정합성 — **PASS**

- PRD §3.1 P4 Auto Verify ("결정론적 검증 (command, process_check) 객관적 판정"): 정확히 두 분기만 구현, AI Vision/polling 등 비범위 침범 없음 (`p4-verify/index.ts:89-101`).
- PRD §7.4 F-P4-01/02/03: `command` exit 0 PASS, `pgrep` PID PASS, FAIL 시 명시적 details — 모두 충족.
- PRD §10 AC-P4-01: 단위 + 라우트 테스트로 dual-coverage.
- PRD §11 5개 항목의 verification 블록(`command` 2건 + `expect_contains` 1건 / `process_check` 1건 / `expect_contains` 추가 1건)은 모두 본 모듈의 두 분기로 표현 가능.
- spec 비범위 ("AI Vision verify, polling, P1 부팅 1회 실행")는 침범 안 함. P1 probes는 재사용 명시였으나 코드 공유 대신 패턴만 차용 — runner 추상화로 대체. 이는 spec "재사용 가능"이라는 표현과 모순되지 않으며, P1과 P4의 트리거 차이를 명확히 분리한 합리적 선택.

---

## 3. 데이터 모델 정합성 (PRD §8) — **PASS**

PRD §8.1 `item_states` 스키마와 일치 (`packages/daemon/src/db/migrations/001_init.sql:11-18`). 본 spec은 컬럼 추가/변경 없음.

`markCompleted`/`bumpAttemptCount` 모두 정의된 컬럼만 사용, 임의 컬럼 삽입 없음 (`p4-verify/index.ts:201-219`).

PRD §8.2 데이터 보존 정책: 본 spec은 캡처 이미지/Vision 호출과 무관하므로 N/A. (위반 없음.)

⚠ 주의 (정보성): `markCompleted`의 `INSERT … VALUES` 절이 `current_step=NULL, started_at=NULL`로 채우고, ON CONFLICT 시에는 status/completed_at/attempt_count만 갱신. 신규 row가 곧바로 'completed'로 들어갈 때 `started_at`이 NULL인 것은 PRD §8.1 스키마(`started_at INTEGER` nullable)에 위배되지 않으나, AC-P1 등에서 자동 완료된 항목과 비교했을 때 `started_at` 의미가 비어 있게 됨. 5번 보안/품질 §에서 다시 다룸.

---

## 4. API 계약 정합성 (PRD §9) — **WARN**

### PASS 부분

- 경로/메서드: `POST /api/verify/run` 정확 (`routes/verify.ts:43-44`).
- 응답 형식: 200 시 `{ status: 'pass'|'fail', details: string }` — PRD §9.1.8 일치.
- 에러: 404 `item_not_found`, 400 `verification_missing`, 400 `validation_error`(zod) — PRD §9.1.8에 명시되지 않은 추가 코드이나 PRD 본문이 에러 코드 화이트리스트를 강제하지 않으므로 신규 라우트 자체가 에러 의미를 합리적으로 정의한 것으로 봄.
- Breaking change 없음: 기존 라우트 6종 (`/api/checklist`, `/api/items/:itemId/start`, `/api/vision/*`, `/api/consents`, `/api/clipboard`)에 손대지 않고 `/api/verify/run`만 추가.

### WARN

**`shared`의 `VerifyRunRequestSchema`와 라우트 로컬 스키마 간 불일치**

- `packages/shared/src/schemas/api.ts:195-200`은 `verification: VerificationSchema`(필수)로 정의.
- `packages/daemon/src/routes/verify.ts:25-30`은 로컬에서 `verification: VerificationSchema.optional()`로 재정의.
- spec-007 §"출력"은 "body의 verification이 명시되면 사용, 없으면 yaml 기본값"이라 명시 → optional이 맞음. 즉 **shared 스키마가 실제 계약과 어긋남**.
- 영향: 외부에서 shared의 `VerifyRunRequestSchema`로 요청을 검증하면 verification 누락 케이스가 실패함. 데몬 내부는 자체 스키마로 받으므로 동작은 OK.
- spec-007의 패키지 경로(`packages/daemon/`) 안에 머물러야 하므로 shared 수정은 본 spec 범위 외 — **고치지 말고 후행 spec 또는 shared spec에 결함 보고**가 BOUNDARIES.md §2에 부합. 따라서 본 리뷰는 "코드를 고치라"가 아니라 "다음 spec에서 shared.VerifyRunRequestSchema를 optional로 정정 필요"로 표시.

PRD §9.1.8 본문 예시는 `verification: {...}`을 보여주지만 "필수"라고 단정한 표현은 없음. spec과 라우트 동작이 일관되므로 PRD 위반은 아님.

---

## 5. 보안 점검 — **WARN**

### PASS 부분

- **시크릿 하드코딩 없음**: `p4-verify/index.ts`, `routes/verify.ts`, `tests/p4-verify.test.ts` 어디에도 API 키/토큰/실제 사내 URL 등 평문 시크릿 없음. 테스트 픽스처의 이메일은 `tao@wrtn.io` 1건이지만 PRD §11 yaml과 동일한 사용자 데이터 형태이며 BOUNDARIES.md §5 "사용자 개인정보(이메일)" 카테고리는 런타임 입력→SQLite 저장이 원칙. 테스트에서 expect_contains 매칭용 더미로 쓰인 것은 시크릿이라기보다 fixture로 분류 가능. (정보성)
- **SQL 인젝션 방지**: 모든 DB 호출이 `db.prepare(...).run({ named: params })` 형태의 prepared statement (`p4-verify/index.ts:201-219`). 문자열 보간으로 SQL을 만들지 않음.
- **캡처 이미지 파기**: 본 spec은 P4(결정론적 검증)이라 화면 캡처/이미지 데이터 발생 없음 → PRD §8.2의 보존 정책 위반 가능성 자체가 없음.

### WARN

**`verification.command`가 임의 셸 명령 실행 경로**

- `defaultVerifyRunner`는 `execa(command, { shell: true })` (`p4-verify/index.ts:23-34`).
- `POST /api/verify/run` body의 `verification.command`는 zod로 형태(string)만 검증되며 화이트리스트가 없음 (`routes/verify.ts:25-30`).
- 결과적으로 localhost:7777에 접근 가능한 임의 프로세스가 임의 shell 명령을 실행시킬 수 있음. `pgrep` 분기도 process_name을 그대로 `pgrep ${processName}` 명령에 보간 (`p4-verify/index.ts:149`).
- 다만:
  - 데몬은 사용자 본인의 머신에서 사용자 권한으로 동작하며, 사용자가 직접 설치한 도구가 OS 셸을 호출하는 것은 P2 클립보드 inject과 동일한 신뢰 모델.
  - PRD §9.1.8 자체가 body로 `verification`을 받도록 설계.
  - 데몬 바인딩(localhost only)은 spec-002/server에서 확립.
- 따라서 spec/PRD에 부합하나, 향후 (i) origin 체크 미들웨어, (ii) `verification.command` 화이트리스트(yaml에 정의된 것만 허용)나 (iii) HTTP 토큰 인증 추가가 Phase 2에서 검토되어야 함. 현 시점은 정보성 WARN.

**`pgrep ${processName}` 보간**

- `process_name`은 `VerificationSchema`에서 string min(1)만 검사. 공백·세미콜론 포함 가능 → `pgrep foo; rm -rf ~`도 실행 가능.
- 동일한 신뢰 경계 논리(localhost+single-user)에 의존하므로 즉시 차단할 필요는 없으나, PRD `process_check`의 본래 의도는 "단순 프로세스명"이므로 `process_name`에 한해 `^[A-Za-z0-9._-]+$` 화이트리스트를 두면 의도 외 사용을 차단할 수 있음. 정보성 WARN.

**`markCompleted`가 신규 row 생성 시 `started_at`을 NULL로 채움**

- `INSERT … VALUES (@item_id, 'completed', NULL, NULL, @now, 1)` (`p4-verify/index.ts:201-209`).
- 즉 verify가 처음으로 호출된 항목은 `started_at`이 비고 곧장 'completed'로 마킹됨. 직접적 보안 이슈는 아니지만, PRD §8.1의 lifecycle("pending → in_progress → completed") 가정과 어긋남.
- ON CONFLICT 분기는 기존 `started_at`을 보존하므로 `POST /api/items/:itemId/start`로 항목을 먼저 시작한 정상 흐름에서는 문제 없음. `start` 없이 곧장 `verify`를 부르는 흐름은 spec-007 범위가 아니지만 테스트 `:97-120`, `:286-308`이 정확히 그 흐름을 검증한다는 점에서 의도적 동작으로 보임.
- 정보성 WARN — Phase 2/통합 시나리오에서 `started_at`이 비어 있으면 분석에 빈 값이 들어갈 가능성.

---

## 6. 코드 품질 — **PASS**

- **함수 길이(50줄 미만)**:
  - `runVerify` 27행 (`:61-87`), `runVerificationProbe` 13행 (`:89-101`), `runCommandVerify` 41행 (`:103-143`), `runProcessCheckVerify` 34행 (`:145-178`), `stdoutSnippet` 10행, `markCompleted`/`bumpAttemptCount` 각 14/8행, `defaultVerifyRunner` 12행, `createVerifyRouter` 39행 (`:40-78`).
  - 모두 50줄 미만. PASS.
- **테스트 커버리지**:
  - p4-verify/index.ts: 92.4% line, 87.5% branch, 100% func.
  - routes/verify.ts: 97.67% line, 87.5% branch, 100% func.
  - 둘 다 80% 이상 충분히 만족.
- **테스트 견고성**:
  - command pass/fail/timeout/expect_contains miss/runner throw/stdout truncation/override (총 9개 단위 시나리오).
  - process_check pass/fail/empty stdout (3개).
  - 에러: ItemNotFoundError, VerificationMissingError, override-only path.
  - 라우트: 200 pass/fail/override/404/400(verification_missing)/400(validation_error item_id 누락)/400(validation_error 잘못된 verification)/process_check round-trip.
  - `registerApiRoutes` 통합 등록까지 마지막 describe로 별도 검증.
- **에러 처리**: runner 예외도 catch해서 details에 메시지를 담아 FAIL 반환 — execa 비정상 spawn에서 500 대신 명확한 진단 가능.
- **타입 안전성**: zod 검증 → 타입드 핸들러로 흐름이 명확. `VerifyRunner` 인터페이스로 테스트 주입성을 확보.
- **로깅**: pino logger 옵셔널 주입, `verify_result` 이벤트로 status만 로그 — stdout/명령 본문이 로그에 들어가지 않으므로 BOUNDARIES.md §5 redact 정책에 부합.

---

## 7. BOUNDARIES.md 준수 — **PASS**

| § | 항목 | 결과 |
|---|------|------|
| 1 | Read-only 파일 무수정 | OK. PRD/BOUNDARIES/spec-template/타 spec 어느 것도 수정 안 함. |
| 2 | spec 외 패키지 경로 무수정 | OK. 본 커밋(`3808dfa`) 변경은 `packages/daemon/src/p4-verify/index.ts`, `packages/daemon/src/routes/index.ts`, `packages/daemon/src/routes/verify.ts`, `packages/daemon/tests/p4-verify.test.ts` 4개. 모두 daemon 내부. |
| 3 | 신규 외부 의존성 사전 허용 목록 | OK. §8 참조. 신규 의존성 0. |
| 4 | API 계약 보호 | OK. 기존 라우트 변경 없음. SQLite 스키마 변경 없음. shared 타입/스키마 export 변경 없음. (단 §4 WARN은 shared가 spec-007 이전부터 가진 불일치이며 본 spec이 만든 것이 아님 — git blame 상 02edc48에서 작성된 형태이거나 그 이전 spec.) |
| 5 | 시크릿 하드코딩 금지 | OK. 본 커밋 변경 파일 grep에 시크릿/실키 없음. |

---

## 8. 의존성 체크 — **PASS**

- 본 커밋(`3808dfa`) `git show --stat`상 `packages/daemon/package.json`/루트 `package.json`/`pnpm-lock.yaml` 변경 없음. → 신규 npm 의존성 0.
- `import` 변경:
  - `execa` (기존 dep, PRD §12 화이트리스트), `pino`(기존, 화이트리스트), `zod`(화이트리스트), `express`(화이트리스트), `@onboarding/shared`(workspace), Node 표준(`node:fs`, `node:os`, `node:path`).
  - 테스트는 `vitest`, `supertest`, `pino` — 모두 화이트리스트.
- BOUNDARIES.md §3 위반 없음.

---

## 위반·차단 사유 (FAIL) — 없음

## 종합 권고

1. **shared.VerifyRunRequestSchema의 verification을 optional로 정정**하는 후행 spec 발의(spec-007 패키지 경계상 본 spec에서 고치면 BOUNDARIES.md §2 위반).
2. **`process_name` 화이트리스트(`^[A-Za-z0-9._-]+$`)** 도입을 Phase 2 보안 spec에 포함 검토. 현재는 단일 사용자 단일 머신 가정으로 위험은 낮지만 명령 인젝션 표면은 존재.
3. **`markCompleted`의 신규 row INSERT 절이 `started_at`을 NULL로 두는 부분**은 통합 시나리오에서 `started_at`/`completed_at` 분석 시 빈 값이 들어갈 가능성이 있음. 정상 흐름(start → verify)이라면 문제없으나, 직진입 케이스(verify 단독)에서는 `started_at = @now`로 채우는 편이 PRD §8.1 lifecycle 가정에 더 부합. 후행 spec에서 검토 권고.
4. **build → test 순서**: 워크스페이스 ordering으로 인해 `pnpm --filter daemon test`만 단독 실행 시 실패. CI/README에 `pnpm -r build` 선행이 명시되어 있는지 확인 필요(spec-002 또는 README 영역).

---

<promise>SPEC_007_DAEMON_P4_VERIFY_REVIEW_PASS_WITH_WARN</promise>
