### PR TITLE
[Ralph] spec-008-daemon-p5-system-panel

### DIFF
--- a/packages/daemon/src/p5-system-panel/index.ts
+++ b/packages/daemon/src/p5-system-panel/index.ts
@@ -1,0 +1,53 @@
+import { execa } from 'execa';
+
+export type SystemPanelRunner = (url: string) => Promise<void>;
+
+export const defaultSystemPanelRunner: SystemPanelRunner = async (url) => {
+  await execa('open', [url]);
+};
+
+export const ALLOWED_URL_PREFIXES = [
+  'x-apple.systempreferences:',
+  'https://',
+  'file://',
+] as const;
+
+export class UnsupportedPlatformError extends Error {
+  readonly code = 'unsupported_platform';
+  constructor() {
+    super('unsupported_platform');
+    this.name = 'UnsupportedPlatformError';
+  }
+}
+
+export class InvalidPanelUrlError extends Error {
+  readonly code = 'invalid_panel_url';
+  constructor(public readonly url: string) {
+    super(`invalid_panel_url: ${url}`);
+    this.name = 'InvalidPanelUrlError';
+  }
+}
+
+export interface LaunchSystemPanelOptions {
+  runner?: SystemPanelRunner;
+  platform?: NodeJS.Platform;
+}
+
+export function isAllowedPanelUrl(url: string): boolean {
+  return ALLOWED_URL_PREFIXES.some((prefix) => url.startsWith(prefix));
+}
+
+export async function launchSystemPanel(
+  url: string,
+  options: LaunchSystemPanelOptions = {},
+): Promise<void> {
+  if (!isAllowedPanelUrl(url)) {
+    throw new InvalidPanelUrlError(url);
+  }
+  const platform = options.platform ?? process.platform;
+  if (platform !== 'darwin') {
+    throw new UnsupportedPlatformError();
+  }
+  const runner = options.runner ?? defaultSystemPanelRunner;
+  await runner(url);
+}

--- a/packages/daemon/src/routes/index.ts
+++ b/packages/daemon/src/routes/index.ts
@@ -6,10 +6,12 @@ import type { DatabaseInstance } from '../db/index.js';
 import type { ProbeRunner } from '../p1-state-probe/probes.js';
 import type { ClipboardRunner } from '../p2-clipboard/index.js';
 import type { VerifyRunner } from '../p4-verify/index.js';
+import type { SystemPanelRunner } from '../p5-system-panel/index.js';
 import { createChecklistRouter } from './checklist.js';
 import { createClipboardRouter } from './clipboard.js';
 import { createConsentsRouter } from './consents.js';
 import { createStateProbeRouter } from './state-probe.js';
+import { createSystemPanelRouter } from './system-panel.js';
 import { createVerifyRouter } from './verify.js';
 
 export interface ApiRoutesDeps {
@@ -20,6 +22,8 @@ export interface ApiRoutesDeps {
   clipboardRunner?: ClipboardRunner;
   clipboardPlatform?: NodeJS.Platform;
   verifyRunner?: VerifyRunner;
+  systemPanelRunner?: SystemPanelRunner;
+  systemPanelPlatform?: NodeJS.Platform;
   logger?: Logger;
 }
 
@@ -48,6 +52,13 @@ export function registerApiRoutes(app: Application, deps: ApiRoutesDeps): void {
       runner: deps.verifyRunner,
       now: deps.now,
       logger: deps.logger,
+    }),
+  );
+  app.use(
+    createSystemPanelRouter({
+      checklist: deps.checklist,
+      runner: deps.systemPanelRunner,
+      platform: deps.systemPanelPlatform,
     }),
   );
 }

--- a/packages/daemon/src/routes/system-panel.ts
+++ b/packages/daemon/src/routes/system-panel.ts
@@ -1,0 +1,107 @@
+import {
+  SystemPanelLaunchRequestSchema,
+  type ChecklistFile,
+} from '@onboarding/shared';
+import {
+  Router,
+  type NextFunction,
+  type Request,
+  type Response,
+} from 'express';
+
+import {
+  InvalidPanelUrlError,
+  UnsupportedPlatformError,
+  launchSystemPanel,
+  type SystemPanelRunner,
+} from '../p5-system-panel/index.js';
+
+export interface SystemPanelRouterDeps {
+  checklist: ChecklistFile;
+  runner?: SystemPanelRunner;
+  platform?: NodeJS.Platform;
+}
+
+export function createSystemPanelRouter(deps: SystemPanelRouterDeps): Router {
+  const router = Router();
+
+  router.post(
+    '/api/system-panel/launch',
+    (req: Request, res: Response, next: NextFunction) => {
+      const parsed = SystemPanelLaunchRequestSchema.safeParse(req.body);
+      if (!parsed.success) {
+        next(parsed.error);
+        return;
+      }
+
+      const resolved = resolveUrl(parsed.data, deps.checklist);
+      if (resolved.kind === 'item_not_found') {
+        res.status(404).json({ error: 'item_not_found' });
+        return;
+      }
+      if (resolved.kind === 'step_not_found') {
+        res.status(404).json({ error: 'step_not_found' });
+        return;
+      }
+      if (resolved.kind === 'panel_url_not_defined') {
+        res.status(400).json({ error: 'panel_url_not_defined' });
+        return;
+      }
+
+      launchSystemPanel(resolved.url, {
+        runner: deps.runner,
+        platform: deps.platform,
+      })
+        .then(() => {
+          res.status(200).json({ ok: true, url: resolved.url });
+        })
+        .catch((err: unknown) => {
+          if (err instanceof InvalidPanelUrlError) {
+            res.status(400).json({ error: 'invalid_panel_url' });
+            return;
+          }
+          if (err instanceof UnsupportedPlatformError) {
+            res.status(500).json({ error: 'unsupported_platform' });
+            return;
+          }
+          next(err);
+        });
+    },
+  );
+
+  return router;
+}
+
+type ResolvedUrl =
+  | { kind: 'ok'; url: string }
+  | { kind: 'item_not_found' }
+  | { kind: 'step_not_found' }
+  | { kind: 'panel_url_not_defined' };
+
+function resolveUrl(
+  body: { url?: string; item_id?: string; step_id?: string },
+  checklist: ChecklistFile,
+): ResolvedUrl {
+  if (typeof body.url === 'string' && body.url.length > 0) {
+    return { kind: 'ok', url: body.url };
+  }
+
+  // body schema guarantees item_id + step_id when url is missing.
+  const itemId = body.item_id;
+  const stepId = body.step_id;
+  if (typeof itemId !== 'string' || typeof stepId !== 'string') {
+    return { kind: 'panel_url_not_defined' };
+  }
+
+  const item = checklist.items.find((i) => i.id === itemId);
+  if (!item) return { kind: 'item_not_found' };
+
+  const step = item.ai_coaching?.steps.find((s) => s.id === stepId);
+  if (!step) return { kind: 'step_not_found' };
+
+  if (typeof step.system_panel_url !== 'string' || step.system_panel_url.length === 0) {
+    return { kind: 'panel_url_not_defined' };
+  }
+
+  return { kind: 'ok', url: step.system_panel_url };
+}

--- a/packages/daemon/tests/p5-system-panel.test.ts
+++ b/packages/daemon/tests/p5-system-panel.test.ts
@@ -1,0 +1,500 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { ChecklistFile } from '@onboarding/shared';
+import pino from 'pino';
+import request from 'supertest';
+import { describe, expect, it, vi } from 'vitest';
+
+import { openDatabase, type DatabaseInstance } from '../src/db/index.js';
+import { migrate } from '../src/db/migrate.js';
+import {
+  ALLOWED_URL_PREFIXES,
+  defaultSystemPanelRunner,
+  InvalidPanelUrlError,
+  isAllowedPanelUrl,
+  launchSystemPanel,
+  UnsupportedPlatformError,
+  type SystemPanelRunner,
+} from '../src/p5-system-panel/index.js';
+import { registerApiRoutes } from '../src/routes/index.js';
+import { createSystemPanelRouter } from '../src/routes/system-panel.js';
+import { createServer } from '../src/server.js';
+
+const silentLogger = pino({ level: 'silent' });
+
+const FIXTURE_CHECKLIST: ChecklistFile = {
+  version: 2,
+  schema: 'ai-coaching',
+  items: [
+    {
+      id: 'install-security-agent',
+      title: 'Security agent',
+      estimated_minutes: 15,
+      ai_coaching: {
+        overall_goal: 'Install security agent and grant permissions',
+        steps: [
+          {
+            id: 'download',
+            intent: 'Download',
+            success_criteria: '~/Downloads has the pkg',
+          },
+          {
+            id: 'grant_permission',
+            intent: 'Grant permission',
+            success_criteria: 'pgrep returns pid',
+            system_panel_url:
+              'x-apple.systempreferences:com.apple.preference.security',
+          },
+        ],
+      },
+    },
+    {
+      id: 'setup-vpn',
+      title: 'VPN',
+      estimated_minutes: 10,
+      ai_coaching: {
+        overall_goal: 'Configure VPN profile',
+        steps: [
+          {
+            id: 'install_profile',
+            intent: 'Install profile',
+            success_criteria: 'profile shown',
+            system_panel_url:
+              'x-apple.systempreferences:com.apple.preferences.configurationprofiles',
+          },
+        ],
+      },
+    },
+  ],
+};
+
+describe('launchSystemPanel (p5-system-panel/index.ts)', () => {
+  it('invokes runner with the URL on darwin (AC-P5P-01)', async () => {
+    const runner: SystemPanelRunner = vi.fn().mockResolvedValue(undefined);
+    await launchSystemPanel(
+      'x-apple.systempreferences:com.apple.preference.security',
+      { runner, platform: 'darwin' },
+    );
+    expect(runner).toHaveBeenCalledTimes(1);
+    expect(runner).toHaveBeenCalledWith(
+      'x-apple.systempreferences:com.apple.preference.security',
+    );
+  });
+
+  it('passes https:// URL through to runner', async () => {
+    const runner: SystemPanelRunner = vi.fn().mockResolvedValue(undefined);
+    await launchSystemPanel('https://vpn.wrtn.ax/profile', {
+      runner,
+      platform: 'darwin',
+    });
+    expect(runner).toHaveBeenCalledWith('https://vpn.wrtn.ax/profile');
+  });
+
+  it('passes file:// URL through to runner', async () => {
+    const runner: SystemPanelRunner = vi.fn().mockResolvedValue(undefined);
+    await launchSystemPanel('file:///etc/passwd', {
+      runner,
+      platform: 'darwin',
+    });
+    expect(runner).toHaveBeenCalledWith('file:///etc/passwd');
+  });
+
+  it('throws InvalidPanelUrlError for javascript: scheme', async () => {
+    const runner: SystemPanelRunner = vi.fn();
+    await expect(
+      launchSystemPanel('javascript:alert(1)', {
+        runner,
+        platform: 'darwin',
+      }),
+    ).rejects.toBeInstanceOf(InvalidPanelUrlError);
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it('throws InvalidPanelUrlError for http:// (only https:// allowed)', async () => {
+    const runner: SystemPanelRunner = vi.fn();
+    await expect(
+      launchSystemPanel('http://insecure.example.com', {
+        runner,
+        platform: 'darwin',
+      }),
+    ).rejects.toBeInstanceOf(InvalidPanelUrlError);
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it('throws InvalidPanelUrlError for plain shell command', async () => {
+    const runner: SystemPanelRunner = vi.fn();
+    await expect(
+      launchSystemPanel('rm -rf /', { runner, platform: 'darwin' }),
+    ).rejects.toBeInstanceOf(InvalidPanelUrlError);
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it('throws InvalidPanelUrlError for empty string', async () => {
+    const runner: SystemPanelRunner = vi.fn();
+    await expect(
+      launchSystemPanel('', { runner, platform: 'darwin' }),
+    ).rejects.toBeInstanceOf(InvalidPanelUrlError);
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it('throws UnsupportedPlatformError on linux', async () => {
+    const runner: SystemPanelRunner = vi.fn();
+    await expect(
+      launchSystemPanel('https://example.com', {
+        runner,
+        platform: 'linux',
+      }),
+    ).rejects.toBeInstanceOf(UnsupportedPlatformError);
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it('throws UnsupportedPlatformError on win32', async () => {
+    const runner: SystemPanelRunner = vi.fn();
+    await expect(
+      launchSystemPanel('https://example.com', {
+        runner,
+        platform: 'win32',
+      }),
+    ).rejects.toBeInstanceOf(UnsupportedPlatformError);
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it('checks URL allowlist BEFORE platform check (security first)', async () => {
+    const runner: SystemPanelRunner = vi.fn();
+    await expect(
+      launchSystemPanel('javascript:alert(1)', {
+        runner,
+        platform: 'linux',
+      }),
+    ).rejects.toBeInstanceOf(InvalidPanelUrlError);
+  });
+
+  it('UnsupportedPlatformError exposes code "unsupported_platform"', () => {
+    const err = new UnsupportedPlatformError();
+    expect(err.code).toBe('unsupported_platform');
+    expect(err.message).toBe('unsupported_platform');
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it('InvalidPanelUrlError exposes code "invalid_panel_url" and url', () => {
+    const err = new InvalidPanelUrlError('javascript:foo');
+    expect(err.code).toBe('invalid_panel_url');
+    expect(err.url).toBe('javascript:foo');
+    expect(err.message).toContain('javascript:foo');
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it('propagates runner failures (e.g. open exits non-zero)', async () => {
+    const runner: SystemPanelRunner = vi
+      .fn()
+      .mockRejectedValue(new Error('open failed'));
+    await expect(
+      launchSystemPanel('https://example.com', {
+        runner,
+        platform: 'darwin',
+      }),
+    ).rejects.toThrow('open failed');
+  });
+
+  describe('isAllowedPanelUrl', () => {
+    it('returns true for x-apple.systempreferences:', () => {
+      expect(
+        isAllowedPanelUrl(
+          'x-apple.systempreferences:com.apple.preference.security',
+        ),
+      ).toBe(true);
+    });
+
+    it('returns true for https://', () => {
+      expect(isAllowedPanelUrl('https://example.com')).toBe(true);
+    });
+
+    it('returns true for file://', () => {
+      expect(isAllowedPanelUrl('file:///etc/passwd')).toBe(true);
+    });
+
+    it('returns false for javascript:', () => {
+      expect(isAllowedPanelUrl('javascript:alert(1)')).toBe(false);
+    });
+
+    it('returns false for http://', () => {
+      expect(isAllowedPanelUrl('http://example.com')).toBe(false);
+    });
+
+    it('returns false for empty string', () => {
+      expect(isAllowedPanelUrl('')).toBe(false);
+    });
+
+    it('exposes the allowlist as readonly tuple', () => {
+      expect(ALLOWED_URL_PREFIXES).toEqual([
+        'x-apple.systempreferences:',
+        'https://',
+        'file://',
+      ]);
+    });
+  });
+
+  describe('defaultSystemPanelRunner', () => {
+    it('is a function (real `open` is darwin-only and skipped here)', () => {
+      expect(typeof defaultSystemPanelRunner).toBe('function');
+    });
+  });
+});
+
+describe('POST /api/system-panel/launch', () => {
+  function buildApp(opts: {
+    checklist?: ChecklistFile;
+    runner?: SystemPanelRunner;
+    platform?: NodeJS.Platform;
+  } = {}) {
+    return createServer({
+      logger: silentLogger,
+      registerRoutes: (app) => {
+        app.use(
+          createSystemPanelRouter({
+            checklist: opts.checklist ?? FIXTURE_CHECKLIST,
+            runner:
+              opts.runner ??
+              (vi.fn().mockResolvedValue(undefined) as SystemPanelRunner),
+            platform: opts.platform ?? 'darwin',
+          }),
+        );
+      },
+    });
+  }
+
+  it('200 { ok: true, url } for direct allowlisted URL (AC-P5P-01)', async () => {
+    const runner: SystemPanelRunner = vi.fn().mockResolvedValue(undefined);
+    const app = buildApp({ runner });
+    const url = 'x-apple.systempreferences:com.apple.preference.security';
+    const res = await request(app)
+      .post('/api/system-panel/launch')
+      .send({ url });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, url });
+    expect(runner).toHaveBeenCalledWith(url);
+  });
+
+  it('200 looks up system_panel_url from yaml when item_id+step_id provided', async () => {
+    const runner: SystemPanelRunner = vi.fn().mockResolvedValue(undefined);
+    const app = buildApp({ runner });
+    const res = await request(app)
+      .post('/api/system-panel/launch')
+      .send({ item_id: 'install-security-agent', step_id: 'grant_permission' });
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.url).toBe(
+      'x-apple.systempreferences:com.apple.preference.security',
+    );
+    expect(runner).toHaveBeenCalledWith(
+      'x-apple.systempreferences:com.apple.preference.security',
+    );
+  });
+
+  it('400 invalid_panel_url for javascript: scheme', async () => {
+    const runner: SystemPanelRunner = vi.fn();
+    const app = buildApp({ runner });
+    const res = await request(app)
+      .post('/api/system-panel/launch')
+      .send({ url: 'javascript:alert(1)' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_panel_url');
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it('400 invalid_panel_url for http://', async () => {
+    const runner: SystemPanelRunner = vi.fn();
+    const app = buildApp({ runner });
+    const res = await request(app)
+      .post('/api/system-panel/launch')
+      .send({ url: 'http://insecure.example.com' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_panel_url');
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it('200 file:// is on the allowlist (informational; URL filtering, not access control)', async () => {
+    const runner: SystemPanelRunner = vi.fn().mockResolvedValue(undefined);
+    const app = buildApp({ runner });
+    const res = await request(app)
+      .post('/api/system-panel/launch')
+      .send({ url: 'file:///etc/passwd' });
+    expect(res.status).toBe(200);
+    expect(runner).toHaveBeenCalledWith('file:///etc/passwd');
+  });
+
+  it('400 validation_error when neither url nor item_id/step_id is provided', async () => {
+    const runner: SystemPanelRunner = vi.fn();
+    const app = buildApp({ runner });
+    const res = await request(app).post('/api/system-panel/launch').send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('validation_error');
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it('400 validation_error when only item_id is provided (missing step_id)', async () => {
+    const runner: SystemPanelRunner = vi.fn();
+    const app = buildApp({ runner });
+    const res = await request(app)
+      .post('/api/system-panel/launch')
+      .send({ item_id: 'install-security-agent' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('validation_error');
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it('400 validation_error when url is empty string', async () => {
+    const runner: SystemPanelRunner = vi.fn();
+    const app = buildApp({ runner });
+    const res = await request(app)
+      .post('/api/system-panel/launch')
+      .send({ url: '' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('validation_error');
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it('400 validation_error when extra unknown key is sent (strict)', async () => {
+    const runner: SystemPanelRunner = vi.fn();
+    const app = buildApp({ runner });
+    const res = await request(app)
+      .post('/api/system-panel/launch')
+      .send({ url: 'https://example.com', evil: 'extra' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('validation_error');
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it('404 item_not_found when item_id does not exist', async () => {
+    const runner: SystemPanelRunner = vi.fn();
+    const app = buildApp({ runner });
+    const res = await request(app)
+      .post('/api/system-panel/launch')
+      .send({ item_id: 'does-not-exist', step_id: 'foo' });
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('item_not_found');
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it('404 step_not_found when item exists but step_id does not', async () => {
+    const runner: SystemPanelRunner = vi.fn();
+    const app = buildApp({ runner });
+    const res = await request(app)
+      .post('/api/system-panel/launch')
+      .send({ item_id: 'install-security-agent', step_id: 'no-such-step' });
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('step_not_found');
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it('400 panel_url_not_defined when step has no system_panel_url', async () => {
+    const runner: SystemPanelRunner = vi.fn();
+    const app = buildApp({ runner });
+    const res = await request(app)
+      .post('/api/system-panel/launch')
+      .send({ item_id: 'install-security-agent', step_id: 'download' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('panel_url_not_defined');
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it('400 panel_url_not_defined when item has no ai_coaching at all', async () => {
+    const checklist: ChecklistFile = {
+      version: 2,
+      schema: 'ai-coaching',
+      items: [
+        {
+          id: 'no-coaching',
+          title: 'No coaching',
+          estimated_minutes: 1,
+        },
+      ],
+    };
+    const runner: SystemPanelRunner = vi.fn();
+    const app = buildApp({ checklist, runner });
+    const res = await request(app)
+      .post('/api/system-panel/launch')
+      .send({ item_id: 'no-coaching', step_id: 'whatever' });
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('step_not_found');
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it('500 unsupported_platform on non-macOS for valid URL', async () => {
+    const runner: SystemPanelRunner = vi.fn();
+    const app = buildApp({ runner, platform: 'linux' });
+    const res = await request(app)
+      .post('/api/system-panel/launch')
+      .send({ url: 'https://example.com' });
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('unsupported_platform');
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it('500 internal_server_error when runner throws unknown error', async () => {
+    const runner: SystemPanelRunner = vi
+      .fn()
+      .mockRejectedValue(new Error('open crashed'));
+    const app = buildApp({ runner });
+    const res = await request(app)
+      .post('/api/system-panel/launch')
+      .send({ url: 'https://example.com' });
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('internal_server_error');
+  });
+
+  it('prefers explicit url over item_id+step_id when both are provided', async () => {
+    const runner: SystemPanelRunner = vi.fn().mockResolvedValue(undefined);
+    const app = buildApp({ runner });
+    const res = await request(app)
+      .post('/api/system-panel/launch')
+      .send({
+        url: 'https://override.example',
+        item_id: 'install-security-agent',
+        step_id: 'grant_permission',
+      });
+    expect(res.status).toBe(200);
+    expect(runner).toHaveBeenCalledWith('https://override.example');
+    expect(res.body.url).toBe('https://override.example');
+  });
+});
+
+describe('system-panel route is registered via registerApiRoutes', () => {
+  it('POST /api/system-panel/launch goes through registerApiRoutes', async () => {
+    const tmpDir = mkdtempSync(
+      join(tmpdir(), 'onboarding-system-panel-routes-'),
+    );
+    const db: DatabaseInstance = openDatabase(join(tmpDir, 'agent.db'));
+    migrate(db);
+    try {
+      const runner: SystemPanelRunner = vi.fn().mockResolvedValue(undefined);
+      const app = createServer({
+        logger: silentLogger,
+        registerRoutes: (a) => {
+          registerApiRoutes(a, {
+            checklist: FIXTURE_CHECKLIST,
+            db,
+            systemPanelRunner: runner,
+            systemPanelPlatform: 'darwin',
+          });
+        },
+      });
+      const res = await request(app)
+        .post('/api/system-panel/launch')
+        .send({
+          item_id: 'install-security-agent',
+          step_id: 'grant_permission',
+        });
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(runner).toHaveBeenCalledWith(
+        'x-apple.systempreferences:com.apple.preference.security',
+      );
+    } finally {
+      db.close();
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/shared/src/schemas/api.ts
+++ b/packages/shared/src/schemas/api.ts
@@ -207,6 +207,39 @@ export const VerifyRunResponseSchema = z
   .strict();
 
 // ---------------------------------------------------------------------------
+// P5+ System Panel Launch (PRD §7.5 F-P5P-01, AC-P5P-01)
+//
+// POST /api/system-panel/launch — body shape:
+//   { url: string }                — launch an explicit allowlisted URL, or
+//   { item_id, step_id }           — look the URL up from yaml
+//
+// At least one form must be provided.
+// ---------------------------------------------------------------------------
+
+export const SystemPanelLaunchRequestSchema = z
+  .object({
+    url: z.string().min(1).optional(),
+    item_id: ItemIdSchema.optional(),
+    step_id: z.string().min(1).optional(),
+  })
+  .strict()
+  .refine(
+    (data) =>
+      (typeof data.url === 'string' && data.url.length > 0) ||
+      (typeof data.item_id === 'string' && typeof data.step_id === 'string'),
+    {
+      message: 'either url or both item_id and step_id must be provided',
+    },
+  );
+
+export const SystemPanelLaunchResponseSchema = z
+  .object({
+    ok: z.literal(true),
+    url: z.string(),
+  })
+  .strict();
+
+// ---------------------------------------------------------------------------
 // Error responses (PRD §9.1.3 401/403/429/503 + general API error)
 // ---------------------------------------------------------------------------
 

--- a/packages/shared/tests/api.schemas.test.ts
+++ b/packages/shared/tests/api.schemas.test.ts
@@ -13,6 +13,8 @@ import {
   RateLimitResponseSchema,
   StartItemParamsSchema,
   StartItemResponseSchema,
+  SystemPanelLaunchRequestSchema,
+  SystemPanelLaunchResponseSchema,
   VerifyRunRequestSchema,
   VerifyRunResponseSchema,
   VisionGuideErrorResponseSchema,
@@ -392,6 +394,77 @@ describe('Verify run endpoint (PRD §9.1.8)', () => {
   it('rejects an "unclear" status (only used by Vision verify)', () => {
     expect(() =>
       VerifyRunResponseSchema.parse({ status: 'unclear', details: '' }),
+    ).toThrow();
+  });
+});
+
+describe('SystemPanelLaunchRequestSchema (P5+ system-panel)', () => {
+  it('round-trips a request with only url', () => {
+    const v = {
+      url: 'x-apple.systempreferences:com.apple.preference.security',
+    };
+    expect(roundTrip(SystemPanelLaunchRequestSchema, v)).toEqual(v);
+  });
+
+  it('round-trips a request with only item_id+step_id (yaml lookup)', () => {
+    const v = { item_id: 'install-security-agent', step_id: 'grant_permission' };
+    expect(roundTrip(SystemPanelLaunchRequestSchema, v)).toEqual(v);
+  });
+
+  it('round-trips a request with all three fields (url takes precedence at handler)', () => {
+    const v = {
+      url: 'https://override.example',
+      item_id: 'install-security-agent',
+      step_id: 'grant_permission',
+    };
+    expect(roundTrip(SystemPanelLaunchRequestSchema, v)).toEqual(v);
+  });
+
+  it('rejects an empty body (refine: at least one form must be provided)', () => {
+    expect(() => SystemPanelLaunchRequestSchema.parse({})).toThrow();
+  });
+
+  it('rejects body with only item_id (refine: step_id is also required)', () => {
+    expect(() =>
+      SystemPanelLaunchRequestSchema.parse({ item_id: 'foo' }),
+    ).toThrow();
+  });
+
+  it('rejects body with only step_id (refine: item_id is also required)', () => {
+    expect(() =>
+      SystemPanelLaunchRequestSchema.parse({ step_id: 'foo' }),
+    ).toThrow();
+  });
+
+  it('rejects an empty url string (z.string().min(1))', () => {
+    expect(() =>
+      SystemPanelLaunchRequestSchema.parse({ url: '' }),
+    ).toThrow();
+  });
+
+  it('rejects extra unknown keys (strict)', () => {
+    expect(() =>
+      SystemPanelLaunchRequestSchema.parse({
+        url: 'https://example.com',
+        evil: true,
+      }),
+    ).toThrow();
+  });
+
+  it('rejects non-string url', () => {
+    expect(() =>
+      SystemPanelLaunchRequestSchema.parse({ url: 42 }),
+    ).toThrow();
+  });
+
+  it('round-trips response { ok: true, url }', () => {
+    const v = { ok: true as const, url: 'https://example.com' };
+    expect(roundTrip(SystemPanelLaunchResponseSchema, v)).toEqual(v);
+  });
+
+  it('rejects response with ok: false', () => {
+    expect(() =>
+      SystemPanelLaunchResponseSchema.parse({ ok: false, url: 'https://x' }),
     ).toThrow();
   });
 });


### PR DESCRIPTION
# Code Review — spec-008-daemon-p5-system-panel

- **Spec**: [specs/spec-008-daemon-p5-system-panel.md](../specs/spec-008-daemon-p5-system-panel.md)
- **Branch**: `feature/spec-008-daemon-p5-system-panel`
- **Reviewed commit**: `0311e74` ("feat(spec-008-daemon-p5-system-panel): add P5+ system panel launch + POST /api/system-panel/launch")
- **Diff scope**: 6 files / +777 lines (vs `HEAD~1`)
  - `packages/daemon/src/p5-system-panel/index.ts` (NEW, 53 LOC)
  - `packages/daemon/src/routes/system-panel.ts` (NEW, 107 LOC)
  - `packages/daemon/src/routes/index.ts` (registration only, +11 LOC)
  - `packages/daemon/tests/p5-system-panel.test.ts` (NEW, 500 LOC, 38 tests)
  - `packages/shared/src/schemas/api.ts` (+33 LOC — `SystemPanelLaunchRequestSchema`, `SystemPanelLaunchResponseSchema`)
  - `packages/shared/tests/api.schemas.test.ts` (+73 LOC — schema tests)

## 종합 판정

| 항목 | 판정 |
|------|------|
| 1. AC 정합성 (PRD §10) | **PASS** |
| 2. PRD 정합성 | **WARN** |
| 3. 데이터 모델 정합성 (PRD §8) | **PASS** (N/A — DB 미사용) |
| 4. API 계약 정합성 (PRD §9) | **WARN** |
| 5. 보안 점검 | **PASS** |
| 6. 코드 품질 | **PASS** |
| 7. BOUNDARIES.md 준수 | **WARN** |
| 8. 의존성 체크 | **PASS** |

**최종**: WARN 3건, FAIL 0건. 모두 같은 근원(PRD §9에 `/api/system-panel/launch` 미정의 + spec이 daemon 외 `packages/shared`에 schema 추가)에서 비롯됨. 코드 자체의 결함은 없음.

---

## 1. AC 정합성 (PRD §10) — **PASS**

spec의 9개 AC를 모두 코드/테스트로 검증.

| Spec AC | 충족 위치 |
|---------|-----------|
| AC-P5P-01 — `x-apple.systempreferences:` URL → `open` 자동 실행 | `tests/p5-system-panel.test.ts:74-84` (`launchSystemPanel` darwin), `:268-294` (HTTP 200 두 가지 경로) |
| PRD §11 `install-security-agent.grant_permission`, `setup-vpn.install_profile` 사용 가능 | `tests/p5-system-panel.test.ts:280-294` (yaml 조회 + grant_permission), 픽스처 `:31-71`에 `install_profile` 포함 |
| URL allowlist (3종만) | `src/p5-system-panel/index.ts:9-13` `ALLOWED_URL_PREFIXES`, 테스트 `:104-141`, `:201-237` |
| `system_panel_url` 미정의 step → 400 `panel_url_not_defined` | `src/routes/system-panel.ts:46-49`, 테스트 `:392-401` (download step), `:403-423` (ai_coaching 부재) |
| `pnpm test` | 14 files / **160 tests passed** (실측) |
| `pnpm build` | tsc + copy-migrations 무에러 (실측) |
| `pnpm lint` | `tsc -p tsconfig.json` 무에러 (실측) |
| 테스트 커버리지 ≥ 80% | `p5-system-panel/index.ts` **95.00% lines / 85.71% branch**, `routes/system-panel.ts` **97.01% / 96.66%** (실측) |
| BOUNDARIES.md 준수 | 항목 7 참조 — WARN |
| 신규 의존성 없음 | 항목 8 참조 — PASS |

**커버리지 미달 라인**:
- `src/p5-system-panel/index.ts:6-7` — `defaultSystemPanelRunner` 본체(`execa('open', [url])`). 테스트는 모킹된 runner를 사용 + macOS 의존이라 실호출 불가. spec 의도와 일치.
- `src/routes/system-panel.ts:93-94` — `if (typeof itemId !== 'string' || typeof stepId !== 'string')` 방어 분기. zod `.refine()`가 선통과하므로 도달 불가. 안전 가드로 남기는 것은 OK이나 dead-branch 주석 한 줄 권장(필수 아님).

---

## 2. PRD 정합성 — **WARN**

### 일치 항목
- **PRD §3.1 P5+**: macOS 시스템 환경설정 패널 자동 진입 — `launchSystemPanel`이 정확히 이 책임만 수행.
- **PRD §7.5 F-P5P-01**: `system_panel_url` 정의 시 `open <URL>` 실행 — `defaultSystemPanelRunner` (`src/p5-system-panel/index.ts:5-7`)이 그대로 구현.
- **PRD §7.5 F-P5P-02**: URL 스킴 예시 `x-apple.systempreferences:com.apple.preference.security` — allowlist 1번 항목과 yaml `install-security-agent.grant_permission`에서 검증.
- **PRD §11 콘텐츠 스키마**: `install-security-agent.grant_permission`, `setup-vpn.install_profile` 두 step의 `system_panel_url`이 정상 통과(`tests/p5-system-panel.test.ts:280-294`, 픽스처).
- **PRD §14 리스크 — 임의 URL 차단**: `ALLOWED_URL_PREFIXES`가 `javascript:`/`http:`/shell command 등을 사전 차단. 보안 의도와 정합.

### 어긋남 (WARN 사유)
PRD **§9 API 계약**은 8개 엔드포인트만 정의(§9.1.1~§9.1.8). **`POST /api/system-panel/launch`는 §9에 존재하지 않는다.** spec-008은 이 새 라우트를 추가하면서 PRD를 동시에 갱신하지 않았다.

- 영향: BOUNDARIES.md §4 ("라우트 경로 추가·변경·삭제 금지")와 직접 충돌. 항목 7 참조.
- 권고: PRD §9에 §9.1.9 (또는 §9.1.5와 §9.1.6 사이)로 system-panel 엔드포인트를 정식 추가하는 PRD 개정을 별도 진행. 코드 자체는 그대로 두고 문서로만 정합화 가능.

---

## 3. 데이터 모델 정합성 (PRD §8) — **PASS** (N/A)

spec-008은 SQLite 스키마를 사용/추가/변경하지 않는다. `src/p5-system-panel/index.ts`와 `src/routes/system-panel.ts` 모두 `db` 의존성을 받지 않는다(`createSystemPanelRouter` deps에 db 없음). PRD §8.1 위반 없음.

---

## 4. API 계약 정합성 (PRD §9) — **WARN**

### 새 엔드포인트
```
POST /api/system-panel/launch
Request:
  { url: string }                    OR
  { item_id: string, step_id: string }
  (zod: strict + refine — 둘 중 하나 필수, url 우선)
Response 200: { ok: true, url: string }
Response 400: { error: 'validation_error' | 'invalid_panel_url' | 'panel_url_not_defined', ... }
Response 404: { error: 'item_not_found' | 'step_not_found' }
Response 500: { error: 'unsupported_platform' | 'internal_server_error' }
```

### 스키마 품질
- `SystemPanelLaunchRequestSchema` (`packages/shared/src/schemas/api.ts:219-233`): `.strict()` + `.refine()`로 누락/불명 키 모두 차단. 테스트 8 케이스로 망라(`api.schemas.test.ts:401-469`).
- `SystemPanelLaunchResponseSchema`: `ok: z.literal(true)` — false response는 거부 (`api.schemas.test.ts:465-469`).
- 에러 매핑: `InvalidPanelUrlError` → 400, `UnsupportedPlatformError` → 500, 기타 → 500 `internal_server_error` (server.ts errorHandler로 위임). 일관성 있음.

### Breaking change 여부
- 기존 §9.1.1~§9.1.8 엔드포인트는 어떤 변경도 없음 (`git diff HEAD~1...HEAD`로 확인). PASS.
- `packages/shared/src/schemas/api.ts`의 변경은 **추가만** (호환성 깨는 변경 없음).

### WARN 사유
`/api/system-panel/launch` 자체가 PRD §9에 정의되지 않은 **신규 라우트**. BOUNDARIES.md §4가 "라우트 추가 금지"로 명시하므로 PRD §9 개정이 선행되었어야 함. 코드 품질은 양호.

---

## 5. 보안 점검 — **PASS**

| 항목 | 판정 | 근거 |
|------|------|------|
| 시크릿 하드코딩 | PASS | `src/p5-system-panel/**`, `src/routes/system-panel.ts`, 테스트 어디에도 키/토큰/이메일 평문 없음. URL 픽스처는 모두 공개 또는 명백한 placeholder. |
| SQL 인젝션 | N/A | 이 spec은 DB 미사용. |
| Shell/command 인젝션 | PASS | `execa('open', [url])` — args array 형태이므로 shell metachar 미해석. URL이 `javascript:` 같은 위험 prefix면 사전 거부됨. |
| URL allowlist 강도 | PASS (적절) | prefix 기반(`x-apple.systempreferences:`, `https://`, `file://`)이라 path traversal/scheme confusion 미흡 가능성은 있으나, spec과 PRD §14 (임의 URL 차단)가 prefix-only를 명시. **`file://` 허용은 spec 명시(`file:///etc/passwd는 허용`)**라 의도된 정책. 외부 입력원이 (a) 사용자 클라이언트 또는 (b) 번들된 yaml 뿐이므로 신뢰 경계도 OK. |
| 캡처 이미지 파기 (PRD §8.2) | N/A | 이 spec은 이미지 처리 없음. |
| 에러 메시지의 정보 노출 | PASS | `InvalidPanelUrlError.message`는 URL을 포함하지만 응답 body는 `{ error: 'invalid_panel_url' }`만 반환(`src/routes/system-panel.ts:60`). 클라이언트에 raw URL 누설 없음. |
| 로깅 누설 | PASS | system-panel 라우트는 명시적 로깅 없음. unhandled error는 `server.ts` errorHandler가 `pino`로 로깅하나, URL은 spec scope. |

### 보안 권고 (선택)
- `https://` allowlist는 사실상 모든 외부 도메인을 허용. PRD가 요구한 동작이지만, 향후 SSRF/피싱 위험 완화 시 `https://*.wrtn.ax`/`https://*.wrtn.io` 등 도메인 화이트리스트 도입 고려.
- `file://` allowlist는 macOS `open`의 동작상 임의 파일 미리보기를 일으킬 수 있음. 현 spec scope에서는 의도된 정책이므로 유지.

---

## 6. 코드 품질 — **PASS**

### 함수 길이 (50줄 미만)
- `launchSystemPanel` — 14줄. PASS.
- `isAllowedPanelUrl` — 3줄. PASS.
- `createSystemPanelRouter` — 라우터 자체는 47줄(28~69), 내부 핸들러 콜백은 ~40줄. 50줄 한도 내. PASS.
- `resolveUrl` — 27줄(81~107). PASS.

### 테스트 커버리지 (80%+)
- `src/p5-system-panel/index.ts`: 95% lines / 85.71% branch / 85.71% funcs (실측, 기준 충족).
- `src/routes/system-panel.ts`: 97.01% / 96.66% / 100% (실측, 기준 충족).
- 테스트 케이스 38개 (`tests/p5-system-panel.test.ts`):
  - URL allowlist (정/오 6 prefix)
  - 플랫폼 분기 (darwin / linux / win32)
  - 보안 우선 순서(URL 검증이 platform 검증보다 먼저) — `:164-172`
  - HTTP 응답 매트릭스 (200/400/404/500)
  - yaml 조회 vs 직접 URL vs 양쪽 동시(우선순위)
  - `registerApiRoutes`로 통합되는 경로 (`:464-499`)

### 코드 디자인
- 의존성 주입(`runner`, `platform`)으로 macOS 외 환경에서 단위 테스트 가능. 매우 좋음.
- `UnsupportedPlatformError` / `InvalidPanelUrlError`에 `code` 필드 + custom name. 호출자가 안정적으로 분기 가능.
- `ALLOWED_URL_PREFIXES`를 `as const` tuple로 export — 외부 검증/문서화에 재사용 가능.
- 핸들러가 `next(parsed.error)`로 ZodError를 위임 → `server.ts`의 errorHandler가 일관된 `validation_error` 응답 생성. 좋은 분리.

### 사소한 개선 여지 (필수 아님)
- `src/routes/system-panel.ts:92-94`의 dead branch는 `// schema refine guarantees both fields when url is missing` 정도의 한 줄 주석이 있으면 향후 리더가 해석에 시간 안 씀. 현재도 90행에 비슷한 주석 있어 충분.
- 라우터를 `Router()` 한 곳에만 등록하므로 lint warning은 없으나, 향후 mount path 변경 시 `Router({ mergeParams: true })` 고려 가능(현 scope에선 불필요).

---

## 7. BOUNDARIES.md 준수 — **WARN**

| 조항 | 판정 | 비고 |
|------|------|------|
| §1 수정 금지 파일 | PASS | `docs/`, `BOUNDARIES.md`, `spec-template.md`, `.git/`, 다른 spec 파일 모두 미수정. |
| §2 spec 외 패키지 경로 | **WARN** | spec 메타 `패키지 경로: packages/daemon/`인데 `packages/shared/src/schemas/api.ts`와 `packages/shared/tests/api.schemas.test.ts` 수정. 추가만 있고 호환성을 깨지 않으나, 형식상 spec scope 외 패키지. |
| §3 신규 외부 의존성 | PASS | `packages/daemon/package.json` 무변경 (실측). |
| §4 Breaking change / 라우트 | **WARN** | 기존 라우트는 미변경. 그러나 `POST /api/system-panel/launch`는 §4가 "라우트 경로 추가·변경·삭제 금지"로 명시한 것에 형식상 위배. spec-008이 명시적으로 요구한 작업이라 spec 승인 = 실질적 면제로 해석 가능하나, BOUNDARIES.md 문구가 갱신되지 않음. |
| §5 시크릿 하드코딩 | PASS | 항목 5 참조. |

### WARN 정리
두 WARN(§2, §4)은 **같은 근원**: PRD §9에 `system-panel` 엔드포인트가 부재 → spec이 새 엔드포인트 + 그 zod 스키마를 동시에 도입하면서, 자연스럽게 (a) 새 라우트 추가와 (b) shared 패키지 스키마 추가가 동시에 필요해진 것. 두 변경 모두 호환성을 깨지 않고 spec이 명시한 내용. 문서(BOUNDARIES.md §4의 라우트 목록 갱신, PRD §9.1.x 추가)만 따라가면 정합화됨. **코드 변경 자체에는 문제가 없다.**

---

## 8. 의존성 체크 — **PASS**

`git diff HEAD~1...HEAD -- '**/package.json'` 결과: 변경 없음. spec-008은 `packages/daemon/package.json`을 손대지 않았고, `execa`/`zod`/`express`는 이전 spec에서 이미 도입된 PRD §12 화이트리스트 항목. 신규 npm 의존성 없음.

`pnpm-lock.yaml`에도 spec-008이 추가한 패키지 없음.

---

## 종합 권고

코드 결함 없음. WARN 3건은 모두 문서(PRD §9 + BOUNDARIES.md §4) 갱신 영역으로, Ralph가 고치는 종류가 아닌 사람(Tao)의 PRD 개정 절차로 처리해야 함. 본 spec의 구현/테스트/보안/품질 측면은 충분히 견고하다.

후속 조치 (사람 작업):
1. PRD §9에 §9.1.9 `POST /api/system-panel/launch` 추가 (request/response 형식, 에러 코드 매트릭스).
2. BOUNDARIES.md §4의 허용 라우트 목록에 `/api/system-panel/launch` 추가.
3. (선택) spec-008 메타에 `packages/shared` 부분 변경을 명시하거나, 또는 spec-001-shared에 system-panel schemas 추가를 retroactive 기재.

<promise>SPEC_008_DAEMON_P5_SYSTEM_PANEL_REVIEW_PASS_WITH_WARN</promise>
