### PR TITLE
[Ralph] spec-010-daemon-p8-anthropic-client

### DIFF
--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -19,6 +19,7 @@
     "typecheck": "tsc -p tsconfig.json"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.30.0",
     "@onboarding/shared": "workspace:*",
     "better-sqlite3": "^11.0.0",
     "execa": "^9.0.0",
@@ -34,6 +35,7 @@
     "@types/node": "^22.0.0",
     "@types/supertest": "^6.0.2",
     "@vitest/coverage-v8": "^2.1.0",
+    "msw": "^2.4.0",
     "supertest": "^7.0.0",
     "typescript": "^5.5.4",
     "vitest": "^2.1.0"

--- a/packages/daemon/src/p8-vision/anthropic-client.ts
+++ b/packages/daemon/src/p8-vision/anthropic-client.ts
@@ -1,0 +1,291 @@
+import Anthropic, { APIError } from '@anthropic-ai/sdk';
+import type { Message } from '@anthropic-ai/sdk/resources/messages';
+import {
+  type ChecklistItem,
+  type ChecklistStep,
+  HighlightRegionSchema,
+  VisionConfidenceSchema,
+  VisionGuideResultSchema,
+  VisionVerifyResultSchema,
+  VisionVerifyStatusSchema,
+  type VisionGuideResult,
+  type VisionVerifyResult,
+} from '@onboarding/shared';
+import { z } from 'zod';
+
+import {
+  buildGuideUserPrompt,
+  GUIDE_SYSTEM_PROMPT,
+} from './prompts/guide.js';
+import {
+  buildVerifyUserPrompt,
+  VERIFY_SYSTEM_PROMPT,
+} from './prompts/verify.js';
+
+// PRD §6.3 (Claude 3.5 Sonnet Vision API). spec-010 메타.
+export const ANTHROPIC_VISION_MODEL = 'claude-3-5-sonnet-latest';
+export const ANTHROPIC_REQUEST_TIMEOUT_MS = 30_000;
+export const ANTHROPIC_MAX_TOKENS = 1024;
+
+export class AnthropicAuthError extends Error {
+  readonly code = 'anthropic_auth_error';
+  constructor(message = 'anthropic_auth_error', readonly status?: number) {
+    super(message);
+    this.name = 'AnthropicAuthError';
+  }
+}
+
+export class AnthropicTimeoutError extends Error {
+  readonly code = 'anthropic_timeout_error';
+  constructor(message = 'anthropic_timeout_error') {
+    super(message);
+    this.name = 'AnthropicTimeoutError';
+  }
+}
+
+export class AnthropicServerError extends Error {
+  readonly code = 'anthropic_server_error';
+  constructor(message = 'anthropic_server_error', readonly status?: number) {
+    super(message);
+    this.name = 'AnthropicServerError';
+  }
+}
+
+export class VisionResponseFormatError extends Error {
+  readonly code = 'vision_response_format_error';
+  constructor(
+    message = 'vision_response_format_error',
+    readonly raw?: string,
+  ) {
+    super(message);
+    this.name = 'VisionResponseFormatError';
+  }
+}
+
+export interface CallVisionInput {
+  buffer: Buffer;
+  item: ChecklistItem;
+  step: ChecklistStep;
+}
+
+// AC-VIS-08 부분 충족: latency 측정.
+export interface CallGuideResult extends VisionGuideResult {
+  latency_ms: number;
+}
+
+export interface CallVerifyResult extends VisionVerifyResult {
+  latency_ms: number;
+}
+
+export interface AnthropicClientOptions {
+  client?: Anthropic;
+  apiKey?: string;
+  baseURL?: string;
+}
+
+function getClient(options: AnthropicClientOptions = {}): Anthropic {
+  if (options.client) return options.client;
+  const apiKey = options.apiKey ?? process.env.ANTHROPIC_API_KEY;
+  if (!apiKey || apiKey.length === 0) {
+    throw new AnthropicAuthError('anthropic_api_key_missing');
+  }
+  return new Anthropic({
+    apiKey,
+    baseURL: options.baseURL,
+    timeout: ANTHROPIC_REQUEST_TIMEOUT_MS,
+    maxRetries: 0,
+  });
+}
+
+function extractText(message: Message): string {
+  const parts: string[] = [];
+  for (const block of message.content) {
+    if (block.type === 'text') {
+      parts.push(block.text);
+    }
+  }
+  return parts.join('\n');
+}
+
+const JSON_BLOCK_RE = /<json>([\s\S]*?)<\/json>/i;
+
+function extractJsonBlock(raw: string): unknown {
+  const match = JSON_BLOCK_RE.exec(raw);
+  if (!match || match[1] === undefined) {
+    throw new VisionResponseFormatError(
+      'vision_response_format_error: missing <json> block',
+      raw,
+    );
+  }
+  const body = match[1].trim();
+  try {
+    return JSON.parse(body);
+  } catch {
+    throw new VisionResponseFormatError(
+      'vision_response_format_error: invalid json',
+      raw,
+    );
+  }
+}
+
+// 응답 JSON: { message, highlight_region: {x,y,width,height} | null, confidence }
+const GuideResponseSchema = z
+  .object({
+    message: z.string().min(1),
+    highlight_region: HighlightRegionSchema.nullish(),
+    confidence: VisionConfidenceSchema,
+  })
+  .strict();
+
+// 응답 JSON: { status, reasoning, next_action_hint }
+const VerifyResponseSchema = z
+  .object({
+    status: VisionVerifyStatusSchema,
+    reasoning: z.string().min(1),
+    next_action_hint: z.string().min(1),
+  })
+  .strict();
+
+function bufferToBase64(buffer: Buffer): string {
+  return buffer.toString('base64');
+}
+
+function mapApiError(err: unknown): never {
+  // SDK timeout (no status) maps to AnthropicTimeoutError.
+  if (err instanceof APIError) {
+    const status = err.status;
+    if (status === undefined) {
+      throw new AnthropicTimeoutError(`anthropic_timeout_error: ${err.message}`);
+    }
+    if (status === 408 || status === 504) {
+      throw new AnthropicTimeoutError(
+        `anthropic_timeout_error: status=${status}`,
+      );
+    }
+    if (status >= 500) {
+      throw new AnthropicServerError(
+        `anthropic_server_error: status=${status}`,
+        status,
+      );
+    }
+    if (status === 401 || status === 403 || status === 429) {
+      throw new AnthropicAuthError(
+        `anthropic_auth_error: status=${status}`,
+        status,
+      );
+    }
+    if (status >= 400 && status < 500) {
+      throw new AnthropicAuthError(
+        `anthropic_auth_error: status=${status}`,
+        status,
+      );
+    }
+  }
+  if (err instanceof Error && /timeout|aborted/i.test(err.message)) {
+    throw new AnthropicTimeoutError(`anthropic_timeout_error: ${err.message}`);
+  }
+  throw err;
+}
+
+async function callMessages(
+  client: Anthropic,
+  systemPrompt: string,
+  userPrompt: string,
+  buffer: Buffer,
+): Promise<{ message: Message; latencyMs: number }> {
+  const startedAt = Date.now();
+  try {
+    const message = await client.messages.create({
+      model: ANTHROPIC_VISION_MODEL,
+      max_tokens: ANTHROPIC_MAX_TOKENS,
+      system: systemPrompt,
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'image',
+              source: {
+                type: 'base64',
+                media_type: 'image/png',
+                data: bufferToBase64(buffer),
+              },
+            },
+            {
+              type: 'text',
+              text: userPrompt,
+            },
+          ],
+        },
+      ],
+    });
+    return { message, latencyMs: Date.now() - startedAt };
+  } catch (err) {
+    mapApiError(err);
+  }
+}
+
+export async function callGuide(
+  input: CallVisionInput,
+  options: AnthropicClientOptions = {},
+): Promise<CallGuideResult> {
+  const client = getClient(options);
+  const userPrompt = buildGuideUserPrompt({ item: input.item, step: input.step });
+  const { message, latencyMs } = await callMessages(
+    client,
+    GUIDE_SYSTEM_PROMPT,
+    userPrompt,
+    input.buffer,
+  );
+  const text = extractText(message);
+  const json = extractJsonBlock(text);
+  const parsed = GuideResponseSchema.safeParse(json);
+  if (!parsed.success) {
+    throw new VisionResponseFormatError(
+      `vision_response_format_error: ${parsed.error.message}`,
+      text,
+    );
+  }
+  const highlightRegion = parsed.data.highlight_region ?? undefined;
+  const result: VisionGuideResult = {
+    type: 'guide',
+    message: parsed.data.message,
+    confidence: parsed.data.confidence,
+    ...(highlightRegion ? { highlight_region: highlightRegion } : {}),
+  };
+  // Round-trip through the canonical shared schema so the daemon and the rest
+  // of the pipeline never disagree on shape.
+  VisionGuideResultSchema.parse(result);
+  return { ...result, latency_ms: latencyMs };
+}
+
+export async function callVerify(
+  input: CallVisionInput,
+  options: AnthropicClientOptions = {},
+): Promise<CallVerifyResult> {
+  const client = getClient(options);
+  const userPrompt = buildVerifyUserPrompt({ item: input.item, step: input.step });
+  const { message, latencyMs } = await callMessages(
+    client,
+    VERIFY_SYSTEM_PROMPT,
+    userPrompt,
+    input.buffer,
+  );
+  const text = extractText(message);
+  const json = extractJsonBlock(text);
+  const parsed = VerifyResponseSchema.safeParse(json);
+  if (!parsed.success) {
+    throw new VisionResponseFormatError(
+      `vision_response_format_error: ${parsed.error.message}`,
+      text,
+    );
+  }
+  const result: VisionVerifyResult = {
+    type: 'verify',
+    status: parsed.data.status,
+    reasoning: parsed.data.reasoning,
+    next_action_hint: parsed.data.next_action_hint,
+  };
+  VisionVerifyResultSchema.parse(result);
+  return { ...result, latency_ms: latencyMs };
+}

--- a/packages/daemon/src/p8-vision/prompts/guide.ts
+++ b/packages/daemon/src/p8-vision/prompts/guide.ts
@@ -1,0 +1,48 @@
+import type { ChecklistItem, ChecklistStep } from '@onboarding/shared';
+
+// PRD §7.7 F-P8-03 (별도 프롬프트 사용), §11 (step 객체 intent / success_criteria
+// / common_mistakes를 그대로 프롬프트에 옮긴다).
+export const GUIDE_SYSTEM_PROMPT = `You are an onboarding coach for a new employee on macOS.
+The user has just sent a screenshot of their current screen.
+Your job is to look at the screenshot and tell the user the *next* concrete action they should take to make progress on the current step.
+
+Output requirements (strict):
+- Reply with a single fenced JSON block: <json>{ ... }</json>.
+- Schema: { "message": string, "highlight_region": { "x": number, "y": number, "width": number, "height": number } | null, "confidence": "high" | "medium" | "low" }.
+- "message" must be a short, friendly Korean sentence telling the user what to do next.
+- "highlight_region" should point at the UI element the user must click / look at, in pixel coordinates of the supplied screenshot. Use null when no region is appropriate.
+- "confidence" reports how sure you are.
+- Do not output anything outside the <json>...</json> block.`;
+
+export interface GuidePromptInput {
+  item: ChecklistItem;
+  step: ChecklistStep;
+}
+
+export function buildGuideUserPrompt({ item, step }: GuidePromptInput): string {
+  const lines: string[] = [];
+  lines.push(`# Onboarding item: ${item.title} (id=${item.id})`);
+  if (item.ai_coaching?.overall_goal) {
+    lines.push('');
+    lines.push('## Overall goal');
+    lines.push(item.ai_coaching.overall_goal.trim());
+  }
+  lines.push('');
+  lines.push(`## Current step: ${step.id}`);
+  lines.push('');
+  lines.push('### Intent');
+  lines.push(step.intent.trim());
+  lines.push('');
+  lines.push('### Success criteria');
+  lines.push(step.success_criteria.trim());
+  if (step.common_mistakes && step.common_mistakes.trim().length > 0) {
+    lines.push('');
+    lines.push('### Common mistakes');
+    lines.push(step.common_mistakes.trim());
+  }
+  lines.push('');
+  lines.push(
+    'Look at the attached screenshot and tell me, in Korean, the single next action I should take. Reply only with the <json>...</json> block.',
+  );
+  return lines.join('\n');
+}

--- a/packages/daemon/src/p8-vision/prompts/verify.ts
+++ b/packages/daemon/src/p8-vision/prompts/verify.ts
@@ -1,0 +1,53 @@
+import type { ChecklistItem, ChecklistStep } from '@onboarding/shared';
+
+// PRD §7.7 F-P8-05 — Vision이 PASS / FAIL / UNCLEAR 직접 판정.
+// PRD §11 step 객체 — success_criteria / common_mistakes 를 프롬프트로 옮긴다.
+export const VERIFY_SYSTEM_PROMPT = `You are an onboarding verifier for a new employee on macOS.
+The user has just finished what they believe to be the current step and has sent a screenshot.
+Your job is to look at the screenshot and decide whether the step's success_criteria are visually satisfied.
+
+Output requirements (strict):
+- Reply with a single fenced JSON block: <json>{ ... }</json>.
+- Schema: { "status": "pass" | "fail" | "unclear", "reasoning": string, "next_action_hint": string }.
+- "pass" → success criteria are clearly met on the screenshot.
+- "fail" → success criteria are clearly NOT met. Tell the user, in "next_action_hint", what to do next (Korean).
+- "unclear" → the screenshot does not contain enough evidence either way. Use "next_action_hint" to tell the user what view to bring up.
+- "reasoning" is a short Korean explanation of how you decided.
+- "next_action_hint" must always be a non-empty Korean sentence (use "이대로 다음 단계로 진행하세요" when status is "pass").
+- Do not output anything outside the <json>...</json> block.`;
+
+export interface VerifyPromptInput {
+  item: ChecklistItem;
+  step: ChecklistStep;
+}
+
+export function buildVerifyUserPrompt({
+  item,
+  step,
+}: VerifyPromptInput): string {
+  const lines: string[] = [];
+  lines.push(`# Onboarding item: ${item.title} (id=${item.id})`);
+  if (item.ai_coaching?.overall_goal) {
+    lines.push('');
+    lines.push('## Overall goal');
+    lines.push(item.ai_coaching.overall_goal.trim());
+  }
+  lines.push('');
+  lines.push(`## Step under verification: ${step.id}`);
+  lines.push('');
+  lines.push('### Intent');
+  lines.push(step.intent.trim());
+  lines.push('');
+  lines.push('### Success criteria (verify against this)');
+  lines.push(step.success_criteria.trim());
+  if (step.common_mistakes && step.common_mistakes.trim().length > 0) {
+    lines.push('');
+    lines.push('### Common mistakes the user might make');
+    lines.push(step.common_mistakes.trim());
+  }
+  lines.push('');
+  lines.push(
+    'Decide pass / fail / unclear from the screenshot. Reply only with the <json>...</json> block.',
+  );
+  return lines.join('\n');
+}

--- a/packages/daemon/tests/p8-anthropic-client.test.ts
+++ b/packages/daemon/tests/p8-anthropic-client.test.ts
@@ -1,0 +1,590 @@
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+
+import type { ChecklistItem, ChecklistStep } from '@onboarding/shared';
+
+import {
+  ANTHROPIC_MAX_TOKENS,
+  ANTHROPIC_REQUEST_TIMEOUT_MS,
+  ANTHROPIC_VISION_MODEL,
+  AnthropicAuthError,
+  AnthropicServerError,
+  AnthropicTimeoutError,
+  callGuide,
+  callVerify,
+  VisionResponseFormatError,
+} from '../src/p8-vision/anthropic-client.js';
+import {
+  buildGuideUserPrompt,
+  GUIDE_SYSTEM_PROMPT,
+} from '../src/p8-vision/prompts/guide.js';
+import {
+  buildVerifyUserPrompt,
+  VERIFY_SYSTEM_PROMPT,
+} from '../src/p8-vision/prompts/verify.js';
+
+const ANTHROPIC_MESSAGES_URL = 'https://api.anthropic.com/v1/messages';
+const TEST_API_KEY = 'test-key-placeholder';
+
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+beforeEach(() => {
+  process.env.ANTHROPIC_API_KEY = TEST_API_KEY;
+});
+
+const STEP: ChecklistStep = {
+  id: 'install',
+  intent: '.pkg 파일을 더블클릭해서 설치 마법사를 진행한다.',
+  success_criteria: '/Applications/SecurityAgent.app 디렉토리가 존재한다.',
+  common_mistakes: '잠금 해제 안 한 채 클릭 시도',
+};
+
+const ITEM: ChecklistItem = {
+  id: 'install-security-agent',
+  title: '사내 보안 에이전트 설치',
+  estimated_minutes: 15,
+  ai_coaching: {
+    overall_goal: '사용자가 사내 보안 에이전트를 설치하도록 한다.',
+    steps: [STEP],
+  },
+};
+
+function pngBuffer(): Buffer {
+  return Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+}
+
+function mockMessagesOnce(
+  responder: (request: Request) => Promise<Response> | Response,
+): void {
+  server.use(http.post(ANTHROPIC_MESSAGES_URL, ({ request }) => responder(request), { once: true }));
+}
+
+function buildAnthropicMessageBody(text: string): Record<string, unknown> {
+  return {
+    id: 'msg_test_01',
+    type: 'message',
+    role: 'assistant',
+    model: ANTHROPIC_VISION_MODEL,
+    content: [{ type: 'text', text }],
+    stop_reason: 'end_turn',
+    stop_sequence: null,
+    usage: { input_tokens: 100, output_tokens: 50 },
+  };
+}
+
+describe('prompts/guide', () => {
+  it('GUIDE_SYSTEM_PROMPT mentions the json envelope', () => {
+    expect(GUIDE_SYSTEM_PROMPT).toMatch(/<json>/);
+    expect(GUIDE_SYSTEM_PROMPT).toMatch(/highlight_region/);
+    expect(GUIDE_SYSTEM_PROMPT).toMatch(/confidence/);
+  });
+
+  it('user prompt includes intent / success_criteria / common_mistakes', () => {
+    const text = buildGuideUserPrompt({ item: ITEM, step: STEP });
+    expect(text).toContain(STEP.intent.trim());
+    expect(text).toContain(STEP.success_criteria.trim());
+    expect(text).toContain(STEP.common_mistakes!.trim());
+    expect(text).toContain(ITEM.title);
+  });
+
+  it('user prompt omits common_mistakes section when not provided', () => {
+    const stepNoMistakes: ChecklistStep = {
+      id: 'simple',
+      intent: 'do a thing',
+      success_criteria: 'thing done',
+    };
+    const text = buildGuideUserPrompt({ item: ITEM, step: stepNoMistakes });
+    expect(text).not.toMatch(/Common mistakes/);
+  });
+});
+
+describe('prompts/verify', () => {
+  it('VERIFY_SYSTEM_PROMPT mentions pass / fail / unclear', () => {
+    expect(VERIFY_SYSTEM_PROMPT).toMatch(/pass/);
+    expect(VERIFY_SYSTEM_PROMPT).toMatch(/fail/);
+    expect(VERIFY_SYSTEM_PROMPT).toMatch(/unclear/);
+    expect(VERIFY_SYSTEM_PROMPT).toMatch(/<json>/);
+  });
+
+  it('user prompt mentions success_criteria as the verification target', () => {
+    const text = buildVerifyUserPrompt({ item: ITEM, step: STEP });
+    expect(text).toContain(STEP.success_criteria.trim());
+    expect(text).toContain(STEP.intent.trim());
+    expect(text).toMatch(/verify/i);
+  });
+
+  it('user prompt omits common_mistakes when missing', () => {
+    const stepNoMistakes: ChecklistStep = {
+      id: 'simple',
+      intent: 'do a thing',
+      success_criteria: 'thing done',
+    };
+    const text = buildVerifyUserPrompt({ item: ITEM, step: stepNoMistakes });
+    expect(text).not.toMatch(/Common mistakes/);
+  });
+
+  it('omits overall_goal block when item has no ai_coaching', () => {
+    const itemNoCoaching: ChecklistItem = {
+      id: 'no-coaching',
+      title: 'no coaching',
+      estimated_minutes: 1,
+    };
+    const text = buildVerifyUserPrompt({ item: itemNoCoaching, step: STEP });
+    expect(text).not.toMatch(/Overall goal/);
+  });
+});
+
+describe('callGuide — happy path (msw)', () => {
+  it('parses <json> block into VisionGuideResult and reports latency_ms', async () => {
+    const seen: Array<Record<string, unknown>> = [];
+    mockMessagesOnce(async (request) => {
+      const body = (await request.json()) as Record<string, unknown>;
+      seen.push(body);
+      const text = `Sure!\n<json>${JSON.stringify({
+        message: '왼쪽 상단의 잠금 해제 버튼을 누르세요',
+        highlight_region: { x: 12, y: 24, width: 48, height: 40 },
+        confidence: 'high',
+      })}</json>\n`;
+      return HttpResponse.json(buildAnthropicMessageBody(text));
+    });
+
+    const result = await callGuide({
+      buffer: pngBuffer(),
+      item: ITEM,
+      step: STEP,
+    });
+
+    expect(result.type).toBe('guide');
+    expect(result.message).toContain('잠금 해제');
+    expect(result.confidence).toBe('high');
+    expect(result.highlight_region).toEqual({
+      x: 12,
+      y: 24,
+      width: 48,
+      height: 40,
+    });
+    expect(typeof result.latency_ms).toBe('number');
+    expect(result.latency_ms).toBeGreaterThanOrEqual(0);
+
+    expect(seen).toHaveLength(1);
+    const sent = seen[0]!;
+    expect(sent.model).toBe(ANTHROPIC_VISION_MODEL);
+    expect(sent.max_tokens).toBe(ANTHROPIC_MAX_TOKENS);
+    expect(typeof sent.system).toBe('string');
+    const messages = sent.messages as Array<{
+      role: string;
+      content: Array<{ type: string; source?: { type: string; media_type: string; data: string }; text?: string }>;
+    }>;
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.role).toBe('user');
+    const blocks = messages[0]?.content ?? [];
+    const imageBlock = blocks.find((b) => b.type === 'image');
+    expect(imageBlock?.source?.type).toBe('base64');
+    expect(imageBlock?.source?.media_type).toBe('image/png');
+    expect(imageBlock?.source?.data).toBe(pngBuffer().toString('base64'));
+    expect(blocks.find((b) => b.type === 'text')).toBeDefined();
+  });
+
+  it('accepts highlight_region: null and produces a result without that field', async () => {
+    mockMessagesOnce(() =>
+      HttpResponse.json(
+        buildAnthropicMessageBody(
+          `<json>${JSON.stringify({
+            message: '먼저 다운로드 폴더로 이동하세요',
+            highlight_region: null,
+            confidence: 'medium',
+          })}</json>`,
+        ),
+      ),
+    );
+
+    const result = await callGuide({
+      buffer: pngBuffer(),
+      item: ITEM,
+      step: STEP,
+    });
+    expect(result.highlight_region).toBeUndefined();
+    expect(result.confidence).toBe('medium');
+  });
+});
+
+describe('callVerify — happy path (msw)', () => {
+  it('parses status: pass with reasoning and next_action_hint', async () => {
+    mockMessagesOnce(() =>
+      HttpResponse.json(
+        buildAnthropicMessageBody(
+          `<json>${JSON.stringify({
+            status: 'pass',
+            reasoning: '/Applications/SecurityAgent.app 가 보입니다.',
+            next_action_hint: '이대로 다음 단계로 진행하세요',
+          })}</json>`,
+        ),
+      ),
+    );
+    const result = await callVerify({
+      buffer: pngBuffer(),
+      item: ITEM,
+      step: STEP,
+    });
+    expect(result.type).toBe('verify');
+    expect(result.status).toBe('pass');
+    expect(result.reasoning).toContain('SecurityAgent');
+    expect(result.next_action_hint).toContain('진행하세요');
+    expect(typeof result.latency_ms).toBe('number');
+  });
+
+  it('parses status: fail and surfaces next_action_hint', async () => {
+    mockMessagesOnce(() =>
+      HttpResponse.json(
+        buildAnthropicMessageBody(
+          `<json>${JSON.stringify({
+            status: 'fail',
+            reasoning: 'SecurityAgent 가 보이지 않습니다.',
+            next_action_hint: '다시 .pkg 를 더블클릭하세요',
+          })}</json>`,
+        ),
+      ),
+    );
+    const result = await callVerify({
+      buffer: pngBuffer(),
+      item: ITEM,
+      step: STEP,
+    });
+    expect(result.status).toBe('fail');
+    expect(result.next_action_hint).toContain('.pkg');
+  });
+
+  it('parses status: unclear', async () => {
+    mockMessagesOnce(() =>
+      HttpResponse.json(
+        buildAnthropicMessageBody(
+          `<json>${JSON.stringify({
+            status: 'unclear',
+            reasoning: '화면이 너무 작아 판단 불가',
+            next_action_hint: '창을 최대화하고 다시 시도하세요',
+          })}</json>`,
+        ),
+      ),
+    );
+    const result = await callVerify({
+      buffer: pngBuffer(),
+      item: ITEM,
+      step: STEP,
+    });
+    expect(result.status).toBe('unclear');
+  });
+
+  it('uses VERIFY_SYSTEM_PROMPT (not the guide system prompt)', async () => {
+    let captured: Record<string, unknown> | undefined;
+    mockMessagesOnce(async (request) => {
+      captured = (await request.json()) as Record<string, unknown>;
+      return HttpResponse.json(
+        buildAnthropicMessageBody(
+          `<json>${JSON.stringify({
+            status: 'pass',
+            reasoning: 'ok',
+            next_action_hint: 'ok',
+          })}</json>`,
+        ),
+      );
+    });
+    await callVerify({ buffer: pngBuffer(), item: ITEM, step: STEP });
+    expect(captured?.system).toBe(VERIFY_SYSTEM_PROMPT);
+  });
+});
+
+describe('callGuide — error mapping', () => {
+  it('throws VisionResponseFormatError when no <json> block is present', async () => {
+    mockMessagesOnce(() =>
+      HttpResponse.json(buildAnthropicMessageBody('I cannot do that.')),
+    );
+    await expect(
+      callGuide({ buffer: pngBuffer(), item: ITEM, step: STEP }),
+    ).rejects.toBeInstanceOf(VisionResponseFormatError);
+  });
+
+  it('throws VisionResponseFormatError when JSON inside the block is malformed', async () => {
+    mockMessagesOnce(() =>
+      HttpResponse.json(
+        buildAnthropicMessageBody('<json>{not json at all}</json>'),
+      ),
+    );
+    await expect(
+      callGuide({ buffer: pngBuffer(), item: ITEM, step: STEP }),
+    ).rejects.toBeInstanceOf(VisionResponseFormatError);
+  });
+
+  it('throws VisionResponseFormatError when zod schema rejects the payload', async () => {
+    mockMessagesOnce(() =>
+      HttpResponse.json(
+        buildAnthropicMessageBody(
+          `<json>${JSON.stringify({
+            message: '',
+            highlight_region: null,
+            confidence: 'sky-high',
+          })}</json>`,
+        ),
+      ),
+    );
+    await expect(
+      callGuide({ buffer: pngBuffer(), item: ITEM, step: STEP }),
+    ).rejects.toBeInstanceOf(VisionResponseFormatError);
+  });
+
+  it('throws VisionResponseFormatError when highlight_region has non-positive width', async () => {
+    mockMessagesOnce(() =>
+      HttpResponse.json(
+        buildAnthropicMessageBody(
+          `<json>${JSON.stringify({
+            message: 'hi',
+            highlight_region: { x: 1, y: 1, width: 0, height: 10 },
+            confidence: 'low',
+          })}</json>`,
+        ),
+      ),
+    );
+    await expect(
+      callGuide({ buffer: pngBuffer(), item: ITEM, step: STEP }),
+    ).rejects.toBeInstanceOf(VisionResponseFormatError);
+  });
+
+  it('maps Anthropic 401 to AnthropicAuthError', async () => {
+    mockMessagesOnce(() =>
+      HttpResponse.json(
+        {
+          type: 'error',
+          error: { type: 'authentication_error', message: 'invalid x-api-key' },
+        },
+        { status: 401 },
+      ),
+    );
+    await expect(
+      callGuide({ buffer: pngBuffer(), item: ITEM, step: STEP }),
+    ).rejects.toBeInstanceOf(AnthropicAuthError);
+  });
+
+  it('maps Anthropic 504 to AnthropicTimeoutError', async () => {
+    mockMessagesOnce(() =>
+      HttpResponse.json(
+        { type: 'error', error: { type: 'timeout', message: 'gateway timeout' } },
+        { status: 504 },
+      ),
+    );
+    await expect(
+      callGuide({ buffer: pngBuffer(), item: ITEM, step: STEP }),
+    ).rejects.toBeInstanceOf(AnthropicTimeoutError);
+  });
+
+  it('maps Anthropic 500 to AnthropicServerError', async () => {
+    mockMessagesOnce(() =>
+      HttpResponse.json(
+        { type: 'error', error: { type: 'api_error', message: 'oops' } },
+        { status: 500 },
+      ),
+    );
+    await expect(
+      callGuide({ buffer: pngBuffer(), item: ITEM, step: STEP }),
+    ).rejects.toBeInstanceOf(AnthropicServerError);
+  });
+
+  it('maps 429 to AnthropicAuthError (auth/quota bucket per spec)', async () => {
+    mockMessagesOnce(() =>
+      HttpResponse.json(
+        {
+          type: 'error',
+          error: { type: 'rate_limit_error', message: 'too many' },
+        },
+        { status: 429 },
+      ),
+    );
+    await expect(
+      callGuide({ buffer: pngBuffer(), item: ITEM, step: STEP }),
+    ).rejects.toBeInstanceOf(AnthropicAuthError);
+  });
+
+  it('throws AnthropicAuthError when ANTHROPIC_API_KEY is unset', async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    await expect(
+      callGuide({ buffer: pngBuffer(), item: ITEM, step: STEP }),
+    ).rejects.toBeInstanceOf(AnthropicAuthError);
+  });
+});
+
+describe('callVerify — error mapping', () => {
+  it('throws VisionResponseFormatError when status is not in the enum', async () => {
+    mockMessagesOnce(() =>
+      HttpResponse.json(
+        buildAnthropicMessageBody(
+          `<json>${JSON.stringify({
+            status: 'maybe',
+            reasoning: 'unsure',
+            next_action_hint: 'try again',
+          })}</json>`,
+        ),
+      ),
+    );
+    await expect(
+      callVerify({ buffer: pngBuffer(), item: ITEM, step: STEP }),
+    ).rejects.toBeInstanceOf(VisionResponseFormatError);
+  });
+
+  it('maps 401 to AnthropicAuthError on the verify path too', async () => {
+    mockMessagesOnce(() =>
+      HttpResponse.json(
+        { type: 'error', error: { type: 'authentication_error' } },
+        { status: 401 },
+      ),
+    );
+    await expect(
+      callVerify({ buffer: pngBuffer(), item: ITEM, step: STEP }),
+    ).rejects.toBeInstanceOf(AnthropicAuthError);
+  });
+});
+
+describe('AC-VIS-08 partial — latency_ms is reported', () => {
+  it('latency_ms increases with simulated server delay', async () => {
+    server.use(
+      http.post(ANTHROPIC_MESSAGES_URL, async () => {
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        return HttpResponse.json(
+          buildAnthropicMessageBody(
+            `<json>${JSON.stringify({
+              message: 'ok',
+              highlight_region: null,
+              confidence: 'low',
+            })}</json>`,
+          ),
+        );
+      }),
+    );
+    const result = await callGuide({
+      buffer: pngBuffer(),
+      item: ITEM,
+      step: STEP,
+    });
+    expect(result.latency_ms).toBeGreaterThanOrEqual(20);
+  });
+});
+
+describe('Constants (AC-VIS contract)', () => {
+  it('uses claude-3-5-sonnet-latest (PRD §6.3)', () => {
+    expect(ANTHROPIC_VISION_MODEL).toBe('claude-3-5-sonnet-latest');
+  });
+
+  it('uses 30 second timeout per spec', () => {
+    expect(ANTHROPIC_REQUEST_TIMEOUT_MS).toBe(30_000);
+  });
+
+  it('uses max_tokens=1024 per spec', () => {
+    expect(ANTHROPIC_MAX_TOKENS).toBe(1024);
+  });
+});
+
+describe('Error class identity', () => {
+  it('AnthropicAuthError exposes code anthropic_auth_error', () => {
+    const err = new AnthropicAuthError();
+    expect(err.code).toBe('anthropic_auth_error');
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('AnthropicAuthError');
+  });
+
+  it('AnthropicTimeoutError exposes code anthropic_timeout_error', () => {
+    const err = new AnthropicTimeoutError();
+    expect(err.code).toBe('anthropic_timeout_error');
+    expect(err.name).toBe('AnthropicTimeoutError');
+  });
+
+  it('AnthropicServerError exposes code anthropic_server_error', () => {
+    const err = new AnthropicServerError();
+    expect(err.code).toBe('anthropic_server_error');
+    expect(err.name).toBe('AnthropicServerError');
+  });
+
+  it('VisionResponseFormatError exposes code vision_response_format_error and raw text', () => {
+    const err = new VisionResponseFormatError(
+      'vision_response_format_error',
+      'raw response',
+    );
+    expect(err.code).toBe('vision_response_format_error');
+    expect(err.raw).toBe('raw response');
+    expect(err.name).toBe('VisionResponseFormatError');
+  });
+});
+
+describe('AC: caller is responsible for buffer disposal', () => {
+  it('callGuide does not retain a reference to the input buffer', async () => {
+    mockMessagesOnce(() =>
+      HttpResponse.json(
+        buildAnthropicMessageBody(
+          `<json>${JSON.stringify({
+            message: 'ok',
+            highlight_region: null,
+            confidence: 'low',
+          })}</json>`,
+        ),
+      ),
+    );
+    const buffer = pngBuffer();
+    await callGuide({ buffer, item: ITEM, step: STEP });
+    // Caller still owns the buffer and is free to mutate (zero) it.
+    buffer.fill(0);
+    expect(buffer.every((b) => b === 0)).toBe(true);
+  });
+});
+
+describe('SDK injection — supports a pre-built Anthropic instance', () => {
+  it('uses an injected client mock instead of creating a new one', async () => {
+    const create = vi.fn().mockResolvedValue({
+      id: 'msg_inj',
+      type: 'message',
+      role: 'assistant',
+      model: ANTHROPIC_VISION_MODEL,
+      content: [
+        {
+          type: 'text',
+          text: `<json>${JSON.stringify({
+            message: 'injected',
+            highlight_region: null,
+            confidence: 'low',
+          })}</json>`,
+        },
+      ],
+      stop_reason: 'end_turn',
+      stop_sequence: null,
+      usage: { input_tokens: 1, output_tokens: 1 },
+    });
+    const fakeClient = { messages: { create } } as unknown as Parameters<
+      typeof callGuide
+    >[1] extends infer O
+      ? O extends { client?: infer C }
+        ? C
+        : never
+      : never;
+
+    const result = await callGuide(
+      { buffer: pngBuffer(), item: ITEM, step: STEP },
+      { client: fakeClient as unknown as import('@anthropic-ai/sdk').default },
+    );
+    expect(result.message).toBe('injected');
+    expect(create).toHaveBeenCalledTimes(1);
+    const args = create.mock.calls[0]![0];
+    expect(args.model).toBe(ANTHROPIC_VISION_MODEL);
+    expect(args.max_tokens).toBe(ANTHROPIC_MAX_TOKENS);
+    expect(args.messages[0].content[0].type).toBe('image');
+    expect(args.messages[0].content[1].type).toBe('text');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,9 @@ importers:
 
   packages/daemon:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.30.0
+        version: 0.30.1
       '@onboarding/shared':
         specifier: workspace:*
         version: link:../shared
@@ -49,7 +52,10 @@ importers:
         version: 6.0.3
       '@vitest/coverage-v8':
         specifier: ^2.1.0
-        version: 2.1.9(vitest@2.1.9(@types/node@22.19.17))
+        version: 2.1.9(vitest@2.1.9(@types/node@22.19.17)(msw@2.14.2(@types/node@22.19.17)(typescript@5.9.3)))
+      msw:
+        specifier: ^2.4.0
+        version: 2.14.2(@types/node@22.19.17)(typescript@5.9.3)
       supertest:
         specifier: ^7.0.0
         version: 7.2.2
@@ -58,7 +64,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.0
-        version: 2.1.9(@types/node@22.19.17)
+        version: 2.1.9(@types/node@22.19.17)(msw@2.14.2(@types/node@22.19.17)(typescript@5.9.3))
 
   packages/shared:
     dependencies:
@@ -68,19 +74,22 @@ importers:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: ^2.1.0
-        version: 2.1.9(vitest@2.1.9(@types/node@22.19.17))
+        version: 2.1.9(vitest@2.1.9(@types/node@22.19.17)(msw@2.14.2(@types/node@22.19.17)(typescript@5.9.3)))
       typescript:
         specifier: ^5.5.4
         version: 5.9.3
       vitest:
         specifier: ^2.1.0
-        version: 2.1.9(@types/node@22.19.17)
+        version: 2.1.9(@types/node@22.19.17)(msw@2.14.2(@types/node@22.19.17)(typescript@5.9.3))
 
 packages:
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@anthropic-ai/sdk@0.30.1':
+    resolution: {integrity: sha512-nuKvp7wOIz6BFei8WrTdhmSsx5mwnArYyJgh4+vYu3V4J0Ltb8Xm3odPm51n1aSI0XxNCrDl7O88cxCtUdAkaw==}
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
@@ -360,6 +369,41 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@inquirer/ansi@2.0.5':
+    resolution: {integrity: sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+
+  '@inquirer/confirm@6.0.12':
+    resolution: {integrity: sha512-h9FgGun3QwVYNj5TWIZZ+slii73bMoBFjPfVIGtnFuL4t8gBiNDV9PcSfIzkuxvgquJKt9nr1QzszpBzTbH8Og==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@11.1.9':
+    resolution: {integrity: sha512-BDE4fG22uYh1bGSifcj7JSx119TVYNViMhMu85usp4Fswrzh6M0DV3yld64jA98uOAa2GSQ4Bg4bZRm2d2cwSg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@2.0.5':
+    resolution: {integrity: sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+
+  '@inquirer/type@4.0.5':
+    resolution: {integrity: sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -381,9 +425,25 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@mswjs/interceptors@0.41.7':
+    resolution: {integrity: sha512-D0nkS5+sx87mYpxFqASImCineYoEl9wGlUPrzkuS0ohzG8wfophLpE+I76qGJ0slLAVI19do5SI9pWJNCVf4fg==}
+    engines: {node: '>=18'}
+
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@open-draft/deferred-promise@2.2.0':
+    resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+
+  '@open-draft/deferred-promise@3.0.0':
+    resolution: {integrity: sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==}
+
+  '@open-draft/logger@0.3.0':
+    resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
+
+  '@open-draft/until@2.1.0':
+    resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
@@ -570,6 +630,12 @@ packages:
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
 
+  '@types/node-fetch@2.6.13':
+    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
+
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
+
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
@@ -587,6 +653,12 @@ packages:
 
   '@types/serve-static@1.15.10':
     resolution: {integrity: sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==}
+
+  '@types/set-cookie-parser@2.4.10':
+    resolution: {integrity: sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==}
+
+  '@types/statuses@2.0.6':
+    resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
 
   '@types/superagent@8.1.9':
     resolution: {integrity: sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==}
@@ -632,9 +704,17 @@ packages:
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
+
+  agentkeepalive@4.6.0:
+    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
+    engines: {node: '>= 8.0.0'}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -729,6 +809,14 @@ packages:
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -768,6 +856,10 @@ packages:
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   cookiejar@2.1.4:
     resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
@@ -871,6 +963,10 @@ packages:
     engines: {node: '>=12'}
     hasBin: true
 
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
@@ -880,6 +976,10 @@ packages:
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
+
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
 
   execa@9.6.1:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
@@ -900,6 +1000,15 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
+  fast-wrap-ansi@0.2.0:
+    resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
+
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
     engines: {node: '>=18'}
@@ -915,9 +1024,16 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
+  form-data-encoder@1.7.2:
+    resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
+
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
+
+  formdata-node@4.4.1:
+    resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
+    engines: {node: '>= 12.20'}
 
   formidable@3.5.4:
     resolution: {integrity: sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==}
@@ -941,6 +1057,10 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -966,6 +1086,10 @@ packages:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
+  graphql@16.13.2:
+    resolution: {integrity: sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -982,6 +1106,9 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
+  headers-polyfill@5.0.1:
+    resolution: {integrity: sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -992,6 +1119,9 @@ packages:
   human-signals@8.0.1:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
     engines: {node: '>=18.18.0'}
+
+  humanize-ms@1.2.1:
+    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -1016,6 +1146,9 @@ packages:
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
+
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
 
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
@@ -1128,6 +1261,20 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  msw@2.14.2:
+    resolution: {integrity: sha512-D2bTe0tpuf9nw4DA39wFaqUD/hRPKj0DKpo2lAqu+A47Ifg4+h0hbfn6QxVOsiUY2uhgEN6TTpGSHDsc+ysYNg==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>= 4.8.x'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  mute-stream@3.0.0:
+    resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -1143,6 +1290,20 @@ packages:
   node-abi@3.89.0:
     resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
     engines: {node: '>=10'}
+
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
 
   npm-run-path@6.0.0:
     resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
@@ -1162,6 +1323,9 @@ packages:
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  outvariant@1.4.3:
+    resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
@@ -1188,6 +1352,9 @@ packages:
 
   path-to-regexp@0.1.13:
     resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
@@ -1264,6 +1431,13 @@ packages:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
 
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  rettime@0.11.8:
+    resolution: {integrity: sha512-0fERGXktJTyJ+h8fBEiPxHPEFOu0h15JY7JtwrOVqR5K+vb99ho6IyOo7ekLS3h4sJCzIDy4VWKIbZUfe9njmg==}
+
   rollup@4.60.2:
     resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -1291,6 +1465,9 @@ packages:
   serve-static@1.16.3:
     resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
     engines: {node: '>= 0.8.0'}
+
+  set-cookie-parser@3.1.0:
+    resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -1360,6 +1537,9 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  strict-event-emitter@0.5.1:
+    resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -1399,6 +1579,10 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
   tar-fs@2.1.4:
     resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
 
@@ -1431,15 +1615,33 @@ packages:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.0.29:
+    resolution: {integrity: sha512-W99NuU7b1DcG3uJ3v9k9VztCH3WialNbBkBft5wCs8V8mexu0XQqaZEYb9l9RNNzK8+3EJ9PKWB0/RUtTQ/o+Q==}
+
+  tldts@7.0.29:
+    resolution: {integrity: sha512-JIXCerhudr/N6OWLwLF1HVsTTUo7ry6qHa5eWZEkiMuxsIiAACL55tGLfqfHfoH7QaMQUW8fngD7u7TxWexYQg==}
+    hasBin: true
+
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
+  type-fest@5.6.0:
+    resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
+    engines: {node: '>=20'}
 
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
@@ -1449,6 +1651,9 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -1460,6 +1665,9 @@ packages:
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
+
+  until-async@3.0.2:
+    resolution: {integrity: sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -1533,6 +1741,16 @@ packages:
       jsdom:
         optional: true
 
+  web-streams-polyfill@4.0.0-beta.3:
+    resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
+    engines: {node: '>= 14'}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -1554,10 +1772,22 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yaml@2.8.3:
     resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
     engines: {node: '>= 14.6'}
     hasBin: true
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
 
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
@@ -1572,6 +1802,18 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
+
+  '@anthropic-ai/sdk@0.30.1':
+    dependencies:
+      '@types/node': 18.19.130
+      '@types/node-fetch': 2.6.13
+      abort-controller: 3.0.0
+      agentkeepalive: 4.6.0
+      form-data-encoder: 1.7.2
+      formdata-node: 4.4.1
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
 
   '@babel/helper-string-parser@7.27.1': {}
 
@@ -1737,6 +1979,33 @@ snapshots:
   '@img/sharp-win32-x64@0.33.5':
     optional: true
 
+  '@inquirer/ansi@2.0.5': {}
+
+  '@inquirer/confirm@6.0.12(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/core': 11.1.9(@types/node@22.19.17)
+      '@inquirer/type': 4.0.5(@types/node@22.19.17)
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/core@11.1.9(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/ansi': 2.0.5
+      '@inquirer/figures': 2.0.5
+      '@inquirer/type': 4.0.5(@types/node@22.19.17)
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.0
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/figures@2.0.5': {}
+
+  '@inquirer/type@4.0.5(@types/node@22.19.17)':
+    optionalDependencies:
+      '@types/node': 22.19.17
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -1762,7 +2031,27 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@mswjs/interceptors@0.41.7':
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/logger': 0.3.0
+      '@open-draft/until': 2.1.0
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      strict-event-emitter: 0.5.1
+
   '@noble/hashes@1.8.0': {}
+
+  '@open-draft/deferred-promise@2.2.0': {}
+
+  '@open-draft/deferred-promise@3.0.0': {}
+
+  '@open-draft/logger@0.3.0':
+    dependencies:
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+
+  '@open-draft/until@2.1.0': {}
 
   '@paralleldrive/cuid2@2.3.1':
     dependencies:
@@ -1889,6 +2178,15 @@ snapshots:
 
   '@types/mime@1.3.5': {}
 
+  '@types/node-fetch@2.6.13':
+    dependencies:
+      '@types/node': 22.19.17
+      form-data: 4.0.5
+
+  '@types/node@18.19.130':
+    dependencies:
+      undici-types: 5.26.5
+
   '@types/node@22.19.17':
     dependencies:
       undici-types: 6.21.0
@@ -1912,6 +2210,12 @@ snapshots:
       '@types/node': 22.19.17
       '@types/send': 0.17.6
 
+  '@types/set-cookie-parser@2.4.10':
+    dependencies:
+      '@types/node': 22.19.17
+
+  '@types/statuses@2.0.6': {}
+
   '@types/superagent@8.1.9':
     dependencies:
       '@types/cookiejar': 2.1.5
@@ -1924,7 +2228,7 @@ snapshots:
       '@types/methods': 1.1.4
       '@types/superagent': 8.1.9
 
-  '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@22.19.17))':
+  '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@22.19.17)(msw@2.14.2(@types/node@22.19.17)(typescript@5.9.3)))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -1938,7 +2242,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 1.2.0
-      vitest: 2.1.9(@types/node@22.19.17)
+      vitest: 2.1.9(@types/node@22.19.17)(msw@2.14.2(@types/node@22.19.17)(typescript@5.9.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -1949,12 +2253,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.19.17))':
+  '@vitest/mocker@2.1.9(msw@2.14.2(@types/node@22.19.17)(typescript@5.9.3))(vite@5.4.21(@types/node@22.19.17))':
     dependencies:
       '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
+      msw: 2.14.2(@types/node@22.19.17)(typescript@5.9.3)
       vite: 5.4.21(@types/node@22.19.17)
 
   '@vitest/pretty-format@2.1.9':
@@ -1982,10 +2287,18 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 1.2.0
 
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
   accepts@1.3.8:
     dependencies:
       mime-types: 2.1.35
       negotiator: 0.6.3
+
+  agentkeepalive@4.6.0:
+    dependencies:
+      humanize-ms: 1.2.1
 
   ansi-regex@5.0.1: {}
 
@@ -2084,6 +2397,14 @@ snapshots:
 
   chownr@1.1.4: {}
 
+  cli-width@4.1.0: {}
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -2117,6 +2438,8 @@ snapshots:
   cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
+
+  cookie@1.1.1: {}
 
   cookiejar@2.1.4: {}
 
@@ -2218,6 +2541,8 @@ snapshots:
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
 
+  escalade@3.2.0: {}
+
   escape-html@1.0.3: {}
 
   estree-walker@3.0.3:
@@ -2225,6 +2550,8 @@ snapshots:
       '@types/estree': 1.0.8
 
   etag@1.8.1: {}
+
+  event-target-shim@5.0.1: {}
 
   execa@9.6.1:
     dependencies:
@@ -2283,6 +2610,16 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
+  fast-wrap-ansi@0.2.0:
+    dependencies:
+      fast-string-width: 3.0.2
+
   figures@6.1.0:
     dependencies:
       is-unicode-supported: 2.1.0
@@ -2306,6 +2643,8 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  form-data-encoder@1.7.2: {}
+
   form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
@@ -2313,6 +2652,11 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.3
       mime-types: 2.1.35
+
+  formdata-node@4.4.1:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 4.0.0-beta.3
 
   formidable@3.5.4:
     dependencies:
@@ -2330,6 +2674,8 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  get-caller-file@2.0.5: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -2367,6 +2713,8 @@ snapshots:
 
   gopd@1.2.0: {}
 
+  graphql@16.13.2: {}
+
   has-flag@4.0.0: {}
 
   has-symbols@1.1.0: {}
@@ -2379,6 +2727,11 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  headers-polyfill@5.0.1:
+    dependencies:
+      '@types/set-cookie-parser': 2.4.10
+      set-cookie-parser: 3.1.0
+
   html-escaper@2.0.2: {}
 
   http-errors@2.0.1:
@@ -2390,6 +2743,10 @@ snapshots:
       toidentifier: 1.0.1
 
   human-signals@8.0.1: {}
+
+  humanize-ms@1.2.1:
+    dependencies:
+      ms: 2.1.3
 
   iconv-lite@0.4.24:
     dependencies:
@@ -2406,6 +2763,8 @@ snapshots:
   is-arrayish@0.3.4: {}
 
   is-fullwidth-code-point@3.0.0: {}
+
+  is-node-process@1.2.0: {}
 
   is-plain-obj@4.1.0: {}
 
@@ -2498,6 +2857,33 @@ snapshots:
 
   ms@2.1.3: {}
 
+  msw@2.14.2(@types/node@22.19.17)(typescript@5.9.3):
+    dependencies:
+      '@inquirer/confirm': 6.0.12(@types/node@22.19.17)
+      '@mswjs/interceptors': 0.41.7
+      '@open-draft/deferred-promise': 3.0.0
+      '@types/statuses': 2.0.6
+      cookie: 1.1.1
+      graphql: 16.13.2
+      headers-polyfill: 5.0.1
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.11.8
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.1
+      type-fest: 5.6.0
+      until-async: 3.0.2
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/node'
+
+  mute-stream@3.0.0: {}
+
   nanoid@3.3.12: {}
 
   napi-build-utils@2.0.0: {}
@@ -2507,6 +2893,12 @@ snapshots:
   node-abi@3.89.0:
     dependencies:
       semver: 7.7.4
+
+  node-domexception@1.0.0: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
 
   npm-run-path@6.0.0:
     dependencies:
@@ -2525,6 +2917,8 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  outvariant@1.4.3: {}
+
   package-json-from-dist@1.0.1: {}
 
   parse-ms@4.0.0: {}
@@ -2541,6 +2935,8 @@ snapshots:
       minipass: 7.1.3
 
   path-to-regexp@0.1.13: {}
+
+  path-to-regexp@6.3.0: {}
 
   pathe@1.1.2: {}
 
@@ -2639,6 +3035,10 @@ snapshots:
 
   real-require@0.2.0: {}
 
+  require-directory@2.1.1: {}
+
+  rettime@0.11.8: {}
+
   rollup@4.60.2:
     dependencies:
       '@types/estree': 1.0.8
@@ -2704,6 +3104,8 @@ snapshots:
       send: 0.19.2
     transitivePeerDependencies:
       - supports-color
+
+  set-cookie-parser@3.1.0: {}
 
   setprototypeof@1.2.0: {}
 
@@ -2797,6 +3199,8 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  strict-event-emitter@0.5.1: {}
+
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
@@ -2851,6 +3255,8 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  tagged-tag@1.0.0: {}
+
   tar-fs@2.1.4:
     dependencies:
       chownr: 1.1.4
@@ -2886,7 +3292,19 @@ snapshots:
 
   tinyspy@3.0.2: {}
 
+  tldts-core@7.0.29: {}
+
+  tldts@7.0.29:
+    dependencies:
+      tldts-core: 7.0.29
+
   toidentifier@1.0.1: {}
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.0.29
+
+  tr46@0.0.3: {}
 
   tslib@2.8.1:
     optional: true
@@ -2895,6 +3313,10 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  type-fest@5.6.0:
+    dependencies:
+      tagged-tag: 1.0.0
+
   type-is@1.6.18:
     dependencies:
       media-typer: 0.3.0
@@ -2902,11 +3324,15 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  undici-types@5.26.5: {}
+
   undici-types@6.21.0: {}
 
   unicorn-magic@0.3.0: {}
 
   unpipe@1.0.0: {}
+
+  until-async@3.0.2: {}
 
   util-deprecate@1.0.2: {}
 
@@ -2941,10 +3367,10 @@ snapshots:
       '@types/node': 22.19.17
       fsevents: 2.3.3
 
-  vitest@2.1.9(@types/node@22.19.17):
+  vitest@2.1.9(@types/node@22.19.17)(msw@2.14.2(@types/node@22.19.17)(typescript@5.9.3)):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.17))
+      '@vitest/mocker': 2.1.9(msw@2.14.2(@types/node@22.19.17)(typescript@5.9.3))(vite@5.4.21(@types/node@22.19.17))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9
@@ -2976,6 +3402,15 @@ snapshots:
       - supports-color
       - terser
 
+  web-streams-polyfill@4.0.0-beta.3: {}
+
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -2999,7 +3434,21 @@ snapshots:
 
   wrappy@1.0.2: {}
 
+  y18n@5.0.8: {}
+
   yaml@2.8.3: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
 
   yoctocolors@2.1.2: {}
 


### PR DESCRIPTION
# Code Review — spec-010-daemon-p8-anthropic-client

- **검증 대상 spec**: `specs/spec-010-daemon-p8-anthropic-client.md`
- **브랜치**: `feature/spec-010-daemon-p8-anthropic-client` (HEAD `dc14c57`)
- **권위 PRD**: `docs/PRD-MVP-SLIM.md` v0.10
- **검증 일시**: 2026-05-01
- **종합 판정**: **PASS_WITH_WARN**

## 0. 변경 범위

`dc14c57` 단일 커밋에서 spec-010이 생성/수정한 파일:

| 파일 | 변경 | 비고 |
|------|------|------|
| `packages/daemon/package.json` | `+@anthropic-ai/sdk@^0.30.0`, `+msw@^2.4.0` | PRD §12 화이트리스트 내 |
| `packages/daemon/src/p8-vision/anthropic-client.ts` | 신규 (291줄) | SDK 클라이언트 + 에러 매핑 + zod 파싱 |
| `packages/daemon/src/p8-vision/prompts/guide.ts` | 신규 (48줄) | guide system/user 프롬프트 |
| `packages/daemon/src/p8-vision/prompts/verify.ts` | 신규 (53줄) | verify system/user 프롬프트 |
| `packages/daemon/tests/p8-anthropic-client.test.ts` | 신규 (590줄, 34 테스트) | msw 기반 |
| `pnpm-lock.yaml` | 자동 갱신 | — |

스펙 외 패키지 변경 없음.

## 1. AC 정합성 (PRD §10) — **PASS**

spec-010은 PRD AC 중 **AC-VIS-08(P95≤5초) 부분 충족** 및 AC-VIS-01의 **응답 파싱 부분**만 책임진다 (HTTP 라우터/캐시/rate-limit/DB 기록은 비범위).

| spec AC | 충족 위치 | 판정 |
|---------|----------|------|
| AC-VIS-08 부분: latency 측정 | `anthropic-client.ts:196,222` (`Date.now()` 차이를 `latency_ms`로 반환) + `tests:152-200,225-308,458-481` (`latency_ms` 타입/단조성 검증) | PASS |
| step.intent / success_criteria / common_mistakes 프롬프트 포함 | `prompts/guide.ts:22-48` + `prompts/verify.ts:24-53` (모두 `step.intent.trim()`, `success_criteria.trim()`, optional `common_mistakes`) + `tests:96-148` | PASS |
| highlight_region zod 검증 (x≥0, y≥0, width>0, height>0) | `GuideResponseSchema`(L132-138) → `HighlightRegionSchema`(@onboarding/shared) + `tests:348-363` | PASS (단, 좌표 하한은 §3 WARN 참조) |
| verify status ∈ {pass, fail, unclear} | `VerifyResponseSchema`(L141-147) → `VisionVerifyStatusSchema` + `tests:225-308,427-443` | PASS |
| msw 5가지 시나리오 (정상 guide / 정상 verify / 포맷 오류 / auth / timeout) | `tests:151-481` (실제로는 정상 guide·verify pass/fail/unclear, 포맷 오류 4종, 401, 504, 500, 429, key missing — 11+ 시나리오) | PASS (요구치 초과) |
| caller 가 buffer dispose 책임 | `tests:528-547` — 호출 직후 `buffer.fill(0)` 후 모든 바이트가 0인지 확인. `anthropic-client.ts`는 `bufferToBase64()` 즉시 변환만 하고 보관 안 함 | PASS |
| `pnpm test` 통과 | 16/16 파일, 222/222 테스트 (실측: 본 spec 34 테스트) | PASS |
| `pnpm build` 통과 | tsc 통과 (실측) | PASS |
| `pnpm lint` 에러 0 | tsc `tsconfig.json` 통과 (실측) | PASS |
| 테스트 커버리지 ≥ 80% | `src/p8-vision/anthropic-client.ts`: stmts 95.13 / branch 89.58 / func 100 / line 95.13. `prompts/guide.ts`·`prompts/verify.ts`: 100/100/100/100 | PASS |

## 2. PRD 정합성 — **PASS**

- PRD §3.1 P8(MVP 핵심): Claude 3.5 Sonnet Vision 호출 — `ANTHROPIC_VISION_MODEL = 'claude-3-5-sonnet-latest'` (anthropic-client.ts:26) 일치.
- PRD §6.3: Vision 모델 선택 일치.
- PRD §7.7 F-P8-02: Claude Vision API 호출 — 일치.
- PRD §7.7 F-P8-03: 두 버튼은 별도 프롬프트 — `GUIDE_SYSTEM_PROMPT` ≠ `VERIFY_SYSTEM_PROMPT` (test L291-307이 verify 경로의 system prompt 일치성 검증).
- PRD §7.7 F-P8-09: API 실패 폴백 — `mapApiError`가 4xx/timeout/5xx를 분기해 명시적 예외로 throw, 라우터(SPEC-012)가 503으로 매핑하는 계약 명확.
- 비범위 준수: HTTP 라우터·캐시·rate-limit·`vision_calls` 기록·키 keychain 로직 모두 미포함.

## 3. 데이터 모델 정합성 (PRD §8) — **PASS_WITH_WARN**

- 본 spec은 SQLite 스키마를 수정하지 않는다(비범위 §). 테이블 추가/변경 없음.
- 응답 타입은 `@onboarding/shared`의 `VisionGuideResult`/`VisionVerifyResult`를 그대로 사용 (anthropic-client.ts:11-12). 임의 타입 추가 없음.
- 캡처 buffer는 base64로만 송신되며 메모리에서 SDK가 가져간 후 별도 보관 없음(PRD §8.2 보존 정책 부합 — 본 spec 책임 범위 내).

**WARN**: spec 본문은 `highlight_region` 검증을 "x≥0, y≥0, width>0, height>0"로 명시(spec L48). 그러나 코드가 사용하는 `HighlightRegionSchema`(@onboarding/shared, `schemas/api.ts:30-37`)는 **네 좌표 모두 `z.number().positive()`** 라 `x=0`/`y=0`도 거절한다. 이는 spec-001/shared에서 결정된 사항이며 spec-010은 BOUNDARIES §1에 따라 shared 스키마를 변경할 수 없으므로 본 spec의 책임은 아니다. 다만 PRD 의도(정확한 픽셀 0,0 가능)를 정확히 반영하려면 shared 스키마 보정이 별도 spec에서 필요하다는 점을 기록한다.

## 4. API 계약 정합성 (PRD §9) — **PASS**

- 본 spec은 HTTP 라우트를 추가/변경하지 않는다(SPEC-012가 담당, 비범위 명시).
- `callGuide`·`callVerify`의 반환 타입은 PRD §9.1.3·§9.1.4의 `result` 페이로드와 호환:
  - guide → `{ type:'guide', message, highlight_region?, confidence }` + `latency_ms`
  - verify → `{ type:'verify', status, reasoning, next_action_hint }` + `latency_ms`
- 함수 내부에서 한번 더 `VisionGuideResultSchema.parse(result)` / `VisionVerifyResultSchema.parse(result)`로 round-trip 검증(L258, L289) → shared 스키마와 절대 어긋날 수 없음.
- Anthropic SDK 4xx → `AnthropicAuthError`, timeout(undefined status·408·504) → `AnthropicTimeoutError`, 5xx → `AnthropicServerError`. 라우터에서 모두 503 (`vision_api_timeout`)으로 매핑되는 spec 명세와 일치. PRD §9.1.3의 401/403/429/503 의미(screen_recording/consent/local rate-limit/vision_api_timeout)는 daemon→client 계약이며 Anthropic→daemon 결과를 누설하지 않음(상위 라우터 책임).
- Breaking change 없음.

## 5. 보안 점검 — **PASS**

- **시크릿 하드코딩**: 없음. `process.env.ANTHROPIC_API_KEY` 만 사용(L88). 미설정 시 `AnthropicAuthError('anthropic_api_key_missing')` throw — 키가 평문/주석/예시로 박제된 곳 없음. 테스트는 `'test-key-placeholder'` 사용(BOUNDARIES §5 권고치 그대로).
- **SQL 인젝션**: 본 spec은 DB I/O 없음 → 해당 없음.
- **캡처 이미지 데이터 파기 (PRD §8.2 / AC-VIS-07)**:
  - `bufferToBase64(buffer)` 호출 후 함수가 buffer 참조를 보관하지 않음.
  - 호출자가 buffer 소유권을 유지함을 테스트가 명시(`tests:528-547`).
  - 디스크 쓰기/SQLite 저장 없음.
  - SDK에 base64 문자열로 전달 후 함수 종료 시 GC 대상.
  - 다만 base64 문자열이 SDK 응답 후 즉시 0-fill 되지는 않는다 — JS GC에 의존. 이는 PRD §8.2 "API 응답 후 즉시 파기" 의도에 부합(메모리 보관 안 함). 디스크/DB 누출 경로 없음.
- **로그 누설**: `pino` 로깅이 본 모듈에 없음. SDK 자체 로깅 없음. 키/이미지/이메일이 흐를 통로 없음.
- **에러 메시지에 raw 응답 노출**: `VisionResponseFormatError.raw`가 응답 텍스트(이미지 아님) 보관. 디버깅 목적이며 BOUNDARIES §5 시크릿 분류와 무관(이미지 binary가 아닌 모델 텍스트). PASS.

## 6. 코드 품질 — **PASS**

함수 길이(전부 50줄 미만):

| 함수 | 라인 수 |
|------|---------|
| `getClient` | 13 |
| `extractText` | 9 |
| `extractJsonBlock` | 18 |
| `bufferToBase64` | 3 |
| `mapApiError` | 36 |
| `callMessages` | 37 |
| `callGuide` | 33 |
| `callVerify` | 30 |
| `buildGuideUserPrompt` | 27 |
| `buildVerifyUserPrompt` | 30 |

테스트 커버리지 (실측 `pnpm test`):
- `anthropic-client.ts` — 95.13% lines / 89.58% branches / 100% funcs (요구치 80% 충족)
- `prompts/guide.ts` — 100/100/100
- `prompts/verify.ts` — 100/100/100

기타:
- 외부 SDK 주입(`AnthropicClientOptions.client`)으로 테스트 가능성 확보.
- 에러 클래스에 일관된 `code` 필드(L31,39,47,55) — 라우터/로깅에서 분기 안전.
- 타입 안전: `Message` 타입 import + zod safeParse 후 round-trip 검증.
- 주석은 의도/PRD 참조에 한정(L25, L131, L140, L256-257).

## 7. BOUNDARIES.md 준수 — **PASS**

- §1 Read-only 파일: docs/PRD/BOUNDARIES/spec-template/다른 spec — 모두 변경 없음.
- §2 패키지 경로: 모든 변경이 `packages/daemon/` 내부 (`src/p8-vision/`, `tests/`, `package.json`).
- §3 외부 의존성: `@anthropic-ai/sdk@^0.30.0`(PRD §12 daemon용), `msw@^2.4.0`(PRD §12 daemon 테스트) — 둘 다 화이트리스트.
- §4 API 계약 보호: 라우트/SQLite 스키마/shared export 호환성 — 모두 변경 없음.
- §5 시크릿: §5 검토 통과.

## 8. 의존성 체크 — **PASS**

`packages/daemon/package.json` 추가분:

| 패키지 | 추가 버전 | PRD §12 표 | 위치 매칭 |
|--------|-----------|------------|-----------|
| `@anthropic-ai/sdk` | `^0.30.0` | `^0.30` daemon | OK |
| `msw` | `^2.4.0` | `^2.4` daemon (테스트) | OK (devDependencies) |

신규 의존성 없음. 메이저 변경 없음.

## 종합

| 항목 | 판정 |
|------|------|
| 1. AC 정합성 | **PASS** |
| 2. PRD 정합성 | **PASS** |
| 3. 데이터 모델 정합성 | **PASS_WITH_WARN** (highlight_region 좌표 하한 — shared 스키마 이슈, 본 spec 책임 외) |
| 4. API 계약 정합성 | **PASS** |
| 5. 보안 점검 | **PASS** |
| 6. 코드 품질 | **PASS** |
| 7. BOUNDARIES.md 준수 | **PASS** |
| 8. 의존성 체크 | **PASS** |

**최종 판정: PASS_WITH_WARN**

WARN 1건은 spec-001/shared에서 결정된 `HighlightRegionSchema`의 좌표 하한이 PRD/spec 의도(0 허용)보다 보수적이라는 점이며, BOUNDARIES §1·§4에 의해 본 spec이 수정할 수 없는 영역이다. 후속 shared 패키지 보정 spec에서 다루면 된다.

<promise>SPEC_010_DAEMON_P8_ANTHROPIC_CLIENT_REVIEW_PASS_WITH_WARN</promise>
