### PR TITLE
[Ralph] spec-012-daemon-p8-routes

### DIFF
--- a/packages/daemon/src/p8-vision/orchestrator.ts
+++ b/packages/daemon/src/p8-vision/orchestrator.ts
@@ -1,0 +1,430 @@
+import { randomUUID } from 'node:crypto';
+
+import type {
+  ChecklistFile,
+  ChecklistItem,
+  ChecklistStep,
+  VisionGuideResult,
+  VisionVerifyResult,
+} from '@onboarding/shared';
+import type { Logger } from 'pino';
+
+import type { DatabaseInstance } from '../db/index.js';
+import {
+  callGuide,
+  callVerify,
+  type AnthropicClientOptions,
+  type CallGuideResult,
+  type CallVerifyResult,
+} from './anthropic-client.js';
+import {
+  buildCacheKey,
+  type VisionCache,
+  type VisionRequestType,
+} from './cache.js';
+import { captureScreen, type CaptureResult } from './capture.js';
+import { type VisionDebounce } from './debounce.js';
+import { disposeBuffer } from './dispose.js';
+import { type RateLimit } from './rate-limit.js';
+
+// PRD §9.1.3 / §9.1.4 — orchestrator stitches capture + cache + rate-limit +
+// debounce + Anthropic SDK + vision_calls audit row into one call.
+
+export class VisionItemNotFoundError extends Error {
+  readonly code = 'item_not_found';
+  constructor(public readonly itemId: string) {
+    super(`item_not_found: ${itemId}`);
+    this.name = 'VisionItemNotFoundError';
+  }
+}
+
+export class VisionStepNotFoundError extends Error {
+  readonly code = 'step_not_found';
+  constructor(
+    public readonly itemId: string,
+    public readonly stepId: string,
+  ) {
+    super(`step_not_found: ${itemId}/${stepId}`);
+    this.name = 'VisionStepNotFoundError';
+  }
+}
+
+export class RateLimitPausedError extends Error {
+  readonly code = 'rate_limit_paused';
+  constructor(
+    public readonly resetAt: number,
+    public readonly currentHourCalls: number,
+  ) {
+    super('rate_limit_paused');
+    this.name = 'RateLimitPausedError';
+  }
+}
+
+export type CaptureFn = () => Promise<CaptureResult>;
+export type GuideClientFn = typeof callGuide;
+export type VerifyClientFn = typeof callVerify;
+
+export interface VisionGuideResponse {
+  call_id: string;
+  cached: boolean;
+  latency_ms: number;
+  result: VisionGuideResult;
+}
+
+export interface VisionVerifyResponse {
+  call_id: string;
+  cached: boolean;
+  latency_ms: number;
+  result: VisionVerifyResult;
+}
+
+export interface VisionRequestInput {
+  itemId: string;
+  stepId: string;
+}
+
+export interface VisionOrchestratorDeps {
+  checklist: ChecklistFile;
+  db: DatabaseInstance;
+  cache: VisionCache;
+  rateLimit: RateLimit;
+  debounce: VisionDebounce;
+  capture?: CaptureFn;
+  guideClient?: GuideClientFn;
+  verifyClient?: VerifyClientFn;
+  anthropicOptions?: AnthropicClientOptions;
+  now?: () => number;
+  logger?: Logger;
+}
+
+export interface VisionOrchestrator {
+  runGuide(req: VisionRequestInput): Promise<VisionGuideResponse>;
+  runVerify(req: VisionRequestInput): Promise<VisionVerifyResponse>;
+}
+
+interface ResolvedRequest {
+  item: ChecklistItem;
+  step: ChecklistStep;
+}
+
+const SUMMARY_MAX_LEN = 512;
+
+function newCallId(): string {
+  return `vc_${randomUUID()}`;
+}
+
+function summarizeGuide(result: VisionGuideResult): string {
+  const region = result.highlight_region;
+  const regionPart = region
+    ? `region=${region.x},${region.y},${region.width}x${region.height}`
+    : 'region=null';
+  return [result.message, `confidence=${result.confidence}`, regionPart]
+    .join(' | ')
+    .slice(0, SUMMARY_MAX_LEN);
+}
+
+function summarizeVerify(result: VisionVerifyResult): string {
+  const hint = result.next_action_hint ?? '';
+  return `status=${result.status} | ${result.reasoning} | hint=${hint}`.slice(
+    0,
+    SUMMARY_MAX_LEN,
+  );
+}
+
+function pickGuideResult(raw: CallGuideResult): VisionGuideResult {
+  const base: VisionGuideResult = {
+    type: 'guide',
+    message: raw.message,
+    confidence: raw.confidence,
+  };
+  if (raw.highlight_region !== undefined) {
+    base.highlight_region = raw.highlight_region;
+  }
+  return base;
+}
+
+function pickVerifyResult(raw: CallVerifyResult): VisionVerifyResult {
+  const base: VisionVerifyResult = {
+    type: 'verify',
+    status: raw.status,
+    reasoning: raw.reasoning,
+  };
+  if (raw.next_action_hint !== undefined) {
+    base.next_action_hint = raw.next_action_hint;
+  }
+  return base;
+}
+
+function errorCode(err: unknown): string {
+  if (err && typeof err === 'object') {
+    const candidate = (err as { code?: unknown }).code;
+    if (typeof candidate === 'string') return candidate;
+  }
+  if (err instanceof Error) return err.name;
+  return 'unknown';
+}
+
+function markItemCompleted(
+  db: DatabaseInstance,
+  itemId: string,
+  now: number,
+): void {
+  db.prepare(
+    `INSERT INTO item_states
+       (item_id, status, current_step, started_at, completed_at, attempt_count)
+     VALUES (@item_id, 'completed', NULL, NULL, @now, 1)
+     ON CONFLICT(item_id) DO UPDATE SET
+       status        = 'completed',
+       completed_at  = @now,
+       attempt_count = item_states.attempt_count + 1`,
+  ).run({ item_id: itemId, now });
+}
+
+interface InsertVisionCallParams {
+  callId: string;
+  itemId: string;
+  stepId: string;
+  requestType: VisionRequestType;
+  imageHash: string;
+  promptTokens: number | null;
+  outputTokens: number | null;
+  latencyMs: number;
+  cacheHit: boolean;
+  resultSummary: string | null;
+  error: string | null;
+  createdAt: number;
+}
+
+function insertVisionCall(
+  db: DatabaseInstance,
+  params: InsertVisionCallParams,
+): void {
+  db.prepare(
+    `INSERT INTO vision_calls
+       (call_id, item_id, step_id, request_type, image_hash,
+        prompt_tokens, output_tokens, latency_ms, cache_hit,
+        result_summary, error, created_at)
+     VALUES (@call_id, @item_id, @step_id, @request_type, @image_hash,
+             @prompt_tokens, @output_tokens, @latency_ms, @cache_hit,
+             @result_summary, @error, @created_at)`,
+  ).run({
+    call_id: params.callId,
+    item_id: params.itemId,
+    step_id: params.stepId,
+    request_type: params.requestType,
+    image_hash: params.imageHash,
+    prompt_tokens: params.promptTokens,
+    output_tokens: params.outputTokens,
+    latency_ms: params.latencyMs,
+    cache_hit: params.cacheHit ? 1 : 0,
+    result_summary: params.resultSummary,
+    error: params.error,
+    created_at: params.createdAt,
+  });
+}
+
+export function createVisionOrchestrator(
+  deps: VisionOrchestratorDeps,
+): VisionOrchestrator {
+  const now = deps.now ?? Date.now;
+  const captureFn: CaptureFn = deps.capture ?? (() => captureScreen());
+  const guideClient = deps.guideClient ?? callGuide;
+  const verifyClient = deps.verifyClient ?? callVerify;
+  const anthropicOptions: AnthropicClientOptions = deps.anthropicOptions ?? {};
+
+  function resolve(itemId: string, stepId: string): ResolvedRequest {
+    const item = deps.checklist.items.find((i) => i.id === itemId);
+    if (!item) throw new VisionItemNotFoundError(itemId);
+    const step = item.ai_coaching?.steps.find((s) => s.id === stepId);
+    if (!step) throw new VisionStepNotFoundError(itemId, stepId);
+    return { item, step };
+  }
+
+  function gateRateLimit(): void {
+    const result = deps.rateLimit.checkAndIncrement();
+    if (!result.allowed) {
+      throw new RateLimitPausedError(
+        result.reset_at,
+        result.current_hour_calls,
+      );
+    }
+  }
+
+  async function withCapture<T>(
+    fn: (cap: CaptureResult) => Promise<T>,
+  ): Promise<T> {
+    const cap = await captureFn();
+    try {
+      return await fn(cap);
+    } finally {
+      // PRD AC-VIS-07 — wipe the captured image bytes the moment we are done.
+      disposeBuffer(cap.buffer);
+    }
+  }
+
+  return {
+    async runGuide({ itemId, stepId }) {
+      const resolved = resolve(itemId, stepId);
+      const debounceKey = `guide:${itemId}:${stepId}`;
+      deps.debounce.check(debounceKey);
+      gateRateLimit();
+      const startedAt = now();
+      const callId = newCallId();
+
+      return withCapture(async (cap) => {
+        const cacheKey = buildCacheKey({
+          requestType: 'guide',
+          itemId,
+          stepId,
+          imageHash: cap.hash,
+        });
+        const hit = deps.cache.getCached(cacheKey);
+        if (hit && hit.type === 'guide') {
+          return {
+            call_id: callId,
+            cached: true,
+            latency_ms: now() - startedAt,
+            result: hit,
+          };
+        }
+
+        let raw: CallGuideResult;
+        try {
+          raw = await guideClient(
+            { buffer: cap.buffer, item: resolved.item, step: resolved.step },
+            anthropicOptions,
+          );
+        } catch (err) {
+          insertVisionCall(deps.db, {
+            callId,
+            itemId,
+            stepId,
+            requestType: 'guide',
+            imageHash: cap.hash,
+            promptTokens: null,
+            outputTokens: null,
+            latencyMs: now() - startedAt,
+            cacheHit: false,
+            resultSummary: null,
+            error: errorCode(err),
+            createdAt: now(),
+          });
+          deps.logger?.warn(
+            { err, item_id: itemId, step_id: stepId },
+            'vision_guide_call_failed',
+          );
+          throw err;
+        }
+
+        const result = pickGuideResult(raw);
+        deps.cache.setCached(cacheKey, result);
+        const latency = now() - startedAt;
+        insertVisionCall(deps.db, {
+          callId,
+          itemId,
+          stepId,
+          requestType: 'guide',
+          imageHash: cap.hash,
+          promptTokens: null,
+          outputTokens: null,
+          latencyMs: latency,
+          cacheHit: false,
+          resultSummary: summarizeGuide(result),
+          error: null,
+          createdAt: now(),
+        });
+        return {
+          call_id: callId,
+          cached: false,
+          latency_ms: latency,
+          result,
+        };
+      });
+    },
+
+    async runVerify({ itemId, stepId }) {
+      const resolved = resolve(itemId, stepId);
+      const debounceKey = `verify:${itemId}:${stepId}`;
+      deps.debounce.check(debounceKey);
+      gateRateLimit();
+      const startedAt = now();
+      const callId = newCallId();
+
+      const response = await withCapture<VisionVerifyResponse>(async (cap) => {
+        const cacheKey = buildCacheKey({
+          requestType: 'verify',
+          itemId,
+          stepId,
+          imageHash: cap.hash,
+        });
+        const hit = deps.cache.getCached(cacheKey);
+        if (hit && hit.type === 'verify') {
+          return {
+            call_id: callId,
+            cached: true,
+            latency_ms: now() - startedAt,
+            result: hit,
+          };
+        }
+
+        let raw: CallVerifyResult;
+        try {
+          raw = await verifyClient(
+            { buffer: cap.buffer, item: resolved.item, step: resolved.step },
+            anthropicOptions,
+          );
+        } catch (err) {
+          insertVisionCall(deps.db, {
+            callId,
+            itemId,
+            stepId,
+            requestType: 'verify',
+            imageHash: cap.hash,
+            promptTokens: null,
+            outputTokens: null,
+            latencyMs: now() - startedAt,
+            cacheHit: false,
+            resultSummary: null,
+            error: errorCode(err),
+            createdAt: now(),
+          });
+          deps.logger?.warn(
+            { err, item_id: itemId, step_id: stepId },
+            'vision_verify_call_failed',
+          );
+          throw err;
+        }
+
+        const result = pickVerifyResult(raw);
+        deps.cache.setCached(cacheKey, result);
+        const latency = now() - startedAt;
+        insertVisionCall(deps.db, {
+          callId,
+          itemId,
+          stepId,
+          requestType: 'verify',
+          imageHash: cap.hash,
+          promptTokens: null,
+          outputTokens: null,
+          latencyMs: latency,
+          cacheHit: false,
+          resultSummary: summarizeVerify(result),
+          error: null,
+          createdAt: now(),
+        });
+        return {
+          call_id: callId,
+          cached: false,
+          latency_ms: latency,
+          result,
+        };
+      });
+
+      // PRD §10 AC-VIS-02 — when verify says pass, auto-mark the item complete.
+      if (response.result.status === 'pass') {
+        markItemCompleted(deps.db, itemId, now());
+      }
+      return response;
+    },
+  };
+}

--- a/packages/daemon/src/routes/index.ts
+++ b/packages/daemon/src/routes/index.ts
@@ -7,6 +7,17 @@ import type { ProbeRunner } from '../p1-state-probe/probes.js';
 import type { ClipboardRunner } from '../p2-clipboard/index.js';
 import type { VerifyRunner } from '../p4-verify/index.js';
 import type { SystemPanelRunner } from '../p5-system-panel/index.js';
+import type { AnthropicClientOptions } from '../p8-vision/anthropic-client.js';
+import { createVisionCache } from '../p8-vision/cache.js';
+import { createVisionDebounce } from '../p8-vision/debounce.js';
+import {
+  createVisionOrchestrator,
+  type CaptureFn,
+  type GuideClientFn,
+  type VerifyClientFn,
+  type VisionOrchestrator,
+} from '../p8-vision/orchestrator.js';
+import { createRateLimit } from '../p8-vision/rate-limit.js';
 import { createChecklistRouter } from './checklist.js';
 import { createClipboardRouter } from './clipboard.js';
 import { createConsentsRouter } from './consents.js';
@@ -14,6 +25,7 @@ import { createRateLimitRouter } from './rate-limit.js';
 import { createStateProbeRouter } from './state-probe.js';
 import { createSystemPanelRouter } from './system-panel.js';
 import { createVerifyRouter } from './verify.js';
+import { createVisionRouter } from './vision.js';
 
 export interface ApiRoutesDeps {
   checklist: ChecklistFile;
@@ -25,6 +37,11 @@ export interface ApiRoutesDeps {
   verifyRunner?: VerifyRunner;
   systemPanelRunner?: SystemPanelRunner;
   systemPanelPlatform?: NodeJS.Platform;
+  visionOrchestrator?: VisionOrchestrator;
+  visionCapture?: CaptureFn;
+  visionGuideClient?: GuideClientFn;
+  visionVerifyClient?: VerifyClientFn;
+  visionAnthropicOptions?: AnthropicClientOptions;
   logger?: Logger;
 }
 
@@ -63,4 +80,27 @@ export function registerApiRoutes(app: Application, deps: ApiRoutesDeps): void {
     }),
   );
   app.use(createRateLimitRouter({ db: deps.db, now: deps.now }));
+
+  const orchestrator =
+    deps.visionOrchestrator ??
+    createVisionOrchestrator({
+      checklist: deps.checklist,
+      db: deps.db,
+      cache: createVisionCache({ db: deps.db, now: deps.now }),
+      rateLimit: createRateLimit({ db: deps.db, now: deps.now }),
+      debounce: createVisionDebounce({ now: deps.now }),
+      capture: deps.visionCapture,
+      guideClient: deps.visionGuideClient,
+      verifyClient: deps.visionVerifyClient,
+      anthropicOptions: deps.visionAnthropicOptions,
+      now: deps.now,
+      logger: deps.logger,
+    });
+  app.use(
+    createVisionRouter({
+      db: deps.db,
+      orchestrator,
+      logger: deps.logger,
+    }),
+  );
 }

--- a/packages/daemon/src/routes/vision.ts
+++ b/packages/daemon/src/routes/vision.ts
@@ -1,0 +1,135 @@
+import {
+  VisionGuideRequestSchema,
+  VisionVerifyRequestSchema,
+} from '@onboarding/shared';
+import {
+  Router,
+  type NextFunction,
+  type Request,
+  type Response,
+} from 'express';
+import type { Logger } from 'pino';
+
+import { requireConsent } from '../consents/middleware.js';
+import type { DatabaseInstance } from '../db/index.js';
+import {
+  AnthropicAuthError,
+  AnthropicServerError,
+  AnthropicTimeoutError,
+  VisionResponseFormatError,
+} from '../p8-vision/anthropic-client.js';
+import { ScreenRecordingDeniedError } from '../p8-vision/capture.js';
+import { DebounceError } from '../p8-vision/debounce.js';
+import {
+  RateLimitPausedError,
+  VisionItemNotFoundError,
+  VisionStepNotFoundError,
+  type VisionOrchestrator,
+} from '../p8-vision/orchestrator.js';
+
+// PRD §9.1.3 / §9.1.4 — both endpoints share consent and error mapping.
+export interface VisionRouterDeps {
+  db: DatabaseInstance;
+  orchestrator: VisionOrchestrator;
+  logger?: Logger;
+}
+
+export function createVisionRouter(deps: VisionRouterDeps): Router {
+  const router = Router();
+  const consents = requireConsent(
+    deps.db,
+    'screen_recording',
+    'anthropic_transmission',
+  );
+
+  router.post(
+    '/api/vision/guide',
+    consents,
+    (req: Request, res: Response, next: NextFunction) => {
+      const parsed = VisionGuideRequestSchema.safeParse(req.body);
+      if (!parsed.success) {
+        next(parsed.error);
+        return;
+      }
+      deps.orchestrator
+        .runGuide({
+          itemId: parsed.data.item_id,
+          stepId: parsed.data.step_id,
+        })
+        .then((result) => {
+          res.status(200).json(result);
+        })
+        .catch((err: unknown) => handleVisionError(err, res, next));
+    },
+  );
+
+  router.post(
+    '/api/vision/verify',
+    consents,
+    (req: Request, res: Response, next: NextFunction) => {
+      const parsed = VisionVerifyRequestSchema.safeParse(req.body);
+      if (!parsed.success) {
+        next(parsed.error);
+        return;
+      }
+      deps.orchestrator
+        .runVerify({
+          itemId: parsed.data.item_id,
+          stepId: parsed.data.step_id,
+        })
+        .then((result) => {
+          res.status(200).json(result);
+        })
+        .catch((err: unknown) => handleVisionError(err, res, next));
+    },
+  );
+
+  return router;
+}
+
+function handleVisionError(
+  err: unknown,
+  res: Response,
+  next: NextFunction,
+): void {
+  if (err instanceof VisionItemNotFoundError) {
+    res.status(404).json({ error: 'item_not_found' });
+    return;
+  }
+  if (err instanceof VisionStepNotFoundError) {
+    res.status(404).json({ error: 'step_not_found' });
+    return;
+  }
+  if (err instanceof ScreenRecordingDeniedError) {
+    // OS-level preflight (granted=false) — same shape as the consent middleware
+    // so the client treats both the same.
+    res.status(401).json({ error: 'screen_recording_permission_required' });
+    return;
+  }
+  if (err instanceof DebounceError) {
+    // 1s debounce per (request_type, item, step). spec-012 §출력.
+    res.status(429).json({ error: 'rate_limit_exceeded', state: 'throttled' });
+    return;
+  }
+  if (err instanceof RateLimitPausedError) {
+    res.status(429).json({
+      error: 'rate_limit_exceeded',
+      state: 'paused',
+      reset_at: err.resetAt,
+    });
+    return;
+  }
+  if (err instanceof AnthropicTimeoutError) {
+    res.status(503).json({ error: 'vision_api_timeout' });
+    return;
+  }
+  if (err instanceof AnthropicServerError || err instanceof AnthropicAuthError) {
+    res.status(503).json({ error: 'vision_api_error' });
+    return;
+  }
+  if (err instanceof VisionResponseFormatError) {
+    res.status(503).json({ error: 'vision_response_invalid' });
+    return;
+  }
+  next(err);
+}

--- a/packages/daemon/tests/p8-routes.test.ts
+++ b/packages/daemon/tests/p8-routes.test.ts
@@ -1,0 +1,803 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { ChecklistFile } from '@onboarding/shared';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import pino from 'pino';
+import request from 'supertest';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from 'vitest';
+
+import { openDatabase, type DatabaseInstance } from '../src/db/index.js';
+import { migrate } from '../src/db/migrate.js';
+import { ANTHROPIC_VISION_MODEL } from '../src/p8-vision/anthropic-client.js';
+import {
+  bucketIdForHour,
+  hourBoundaryAfter,
+} from '../src/p8-vision/rate-limit.js';
+import { registerApiRoutes } from '../src/routes/index.js';
+import { createServer } from '../src/server.js';
+
+const ANTHROPIC_MESSAGES_URL = 'https://api.anthropic.com/v1/messages';
+const TEST_API_KEY = 'test-key-placeholder';
+
+const silentLogger = pino({ level: 'silent' });
+
+const server = setupServer();
+
+beforeAll(() =>
+  server.listen({
+    onUnhandledRequest: (req, print) => {
+      // supertest talks to a local Express server; only police the Anthropic API.
+      const url = req.url;
+      if (url.includes('127.0.0.1') || url.includes('localhost')) {
+        return;
+      }
+      print.error();
+    },
+  }),
+);
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+beforeEach(() => {
+  process.env.ANTHROPIC_API_KEY = TEST_API_KEY;
+});
+
+const TEST_ITEM_ID = 'install-security-agent';
+const TEST_STEP_ID = 'install';
+
+const TEST_CHECKLIST: ChecklistFile = {
+  version: 2,
+  schema: 'ai-coaching',
+  items: [
+    {
+      id: TEST_ITEM_ID,
+      title: '사내 보안 에이전트 설치',
+      estimated_minutes: 15,
+      ai_coaching: {
+        overall_goal: '사용자가 사내 보안 에이전트를 설치하도록 한다.',
+        steps: [
+          {
+            id: TEST_STEP_ID,
+            intent: '.pkg 파일을 더블클릭해서 설치 마법사를 진행한다.',
+            success_criteria:
+              '/Applications/SecurityAgent.app 디렉토리가 존재한다.',
+            common_mistakes: '잠금 해제 안 한 채 클릭 시도',
+          },
+        ],
+      },
+      verification: {
+        type: 'process_check',
+        process_name: 'SecurityAgent',
+      },
+    },
+  ],
+};
+
+function buildAnthropicMessageBody(text: string): Record<string, unknown> {
+  return {
+    id: 'msg_test_01',
+    type: 'message',
+    role: 'assistant',
+    model: ANTHROPIC_VISION_MODEL,
+    content: [{ type: 'text', text }],
+    stop_reason: 'end_turn',
+    stop_sequence: null,
+    usage: { input_tokens: 100, output_tokens: 50 },
+  };
+}
+
+function jsonBlock(payload: Record<string, unknown>): string {
+  return `<json>${JSON.stringify(payload)}</json>`;
+}
+
+function mockMessagesOnce(
+  responder: (request: Request) => Promise<Response> | Response,
+): void {
+  server.use(
+    http.post(ANTHROPIC_MESSAGES_URL, ({ request: req }) => responder(req), {
+      once: true,
+    }),
+  );
+}
+
+function mockGuideOnce(payload: {
+  message: string;
+  highlight_region:
+    | { x: number; y: number; width: number; height: number }
+    | null;
+  confidence: 'low' | 'medium' | 'high';
+}): void {
+  mockMessagesOnce(() =>
+    HttpResponse.json(buildAnthropicMessageBody(jsonBlock(payload))),
+  );
+}
+
+function mockVerifyOnce(payload: {
+  status: 'pass' | 'fail' | 'unclear';
+  reasoning: string;
+  next_action_hint: string;
+}): void {
+  mockMessagesOnce(() =>
+    HttpResponse.json(buildAnthropicMessageBody(jsonBlock(payload))),
+  );
+}
+
+interface AppCtx {
+  app: ReturnType<typeof createServer>;
+  db: DatabaseInstance;
+  capture: Mock;
+  capturedBuffers: Buffer[];
+  setNow: (n: number) => void;
+  advanceNow: (ms: number) => void;
+  nowFn: () => number;
+  dispose: () => void;
+}
+
+function buildApp(
+  opts: {
+    hashes?: string[];
+    checklist?: ChecklistFile;
+    grantConsents?: Array<'screen_recording' | 'anthropic_transmission'>;
+    initialNow?: number;
+  } = {},
+): AppCtx {
+  const tmpDir = mkdtempSync(join(tmpdir(), 'onboarding-vision-routes-'));
+  const db = openDatabase(join(tmpDir, 'agent.db'));
+  migrate(db);
+
+  const consents = opts.grantConsents ?? [
+    'screen_recording',
+    'anthropic_transmission',
+  ];
+  const grantStmt = db.prepare(
+    `INSERT INTO consents (consent_type, granted, granted_at, revoked_at)
+     VALUES (@type, 1, @now, NULL)
+     ON CONFLICT(consent_type) DO UPDATE SET
+       granted    = 1,
+       granted_at = @now,
+       revoked_at = NULL`,
+  );
+  for (const type of consents) {
+    grantStmt.run({ type, now: opts.initialNow ?? 1 });
+  }
+
+  let cur = opts.initialNow ?? 1_700_000_000_000;
+  const setNow = (n: number): void => {
+    cur = n;
+  };
+  const advanceNow = (ms: number): void => {
+    cur += ms;
+  };
+  const nowFn = (): number => cur;
+
+  const capturedBuffers: Buffer[] = [];
+  const hashes = opts.hashes ?? ['hash-1'];
+  let idx = 0;
+  const capture = vi.fn().mockImplementation(async () => {
+    const hash = hashes[Math.min(idx, hashes.length - 1)] ?? 'hash-fallback';
+    idx += 1;
+    const buffer = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    capturedBuffers.push(buffer);
+    return { buffer, hash, width: 100, height: 80 };
+  });
+
+  const app = createServer({
+    logger: silentLogger,
+    registerRoutes: (a) =>
+      registerApiRoutes(a, {
+        checklist: opts.checklist ?? TEST_CHECKLIST,
+        db,
+        now: nowFn,
+        visionCapture: capture,
+      }),
+  });
+
+  return {
+    app,
+    db,
+    capture,
+    capturedBuffers,
+    setNow,
+    advanceNow,
+    nowFn,
+    dispose: () => {
+      db.close();
+      rmSync(tmpDir, { recursive: true, force: true });
+    },
+  };
+}
+
+describe('POST /api/vision/guide — AC-VIS-01 happy path', () => {
+  let ctx: AppCtx;
+
+  beforeEach(() => {
+    ctx = buildApp();
+  });
+
+  afterEach(() => {
+    ctx.dispose();
+  });
+
+  it('returns the PRD §9.1.3 envelope and writes a vision_calls row', async () => {
+    mockGuideOnce({
+      message: '왼쪽 상단의 잠금 해제 버튼을 누르세요',
+      highlight_region: { x: 12, y: 24, width: 48, height: 40 },
+      confidence: 'high',
+    });
+
+    const res = await request(ctx.app)
+      .post('/api/vision/guide')
+      .send({ item_id: TEST_ITEM_ID, step_id: TEST_STEP_ID });
+
+    expect(res.status).toBe(200);
+    expect(res.body.cached).toBe(false);
+    expect(typeof res.body.call_id).toBe('string');
+    expect(res.body.call_id).toMatch(/^vc_/);
+    expect(typeof res.body.latency_ms).toBe('number');
+    expect(res.body.latency_ms).toBeGreaterThanOrEqual(0);
+    expect(res.body.result.type).toBe('guide');
+    expect(res.body.result.message).toContain('잠금 해제');
+    expect(res.body.result.confidence).toBe('high');
+    expect(res.body.result.highlight_region).toEqual({
+      x: 12,
+      y: 24,
+      width: 48,
+      height: 40,
+    });
+
+    const rows = ctx.db
+      .prepare(
+        'SELECT call_id, item_id, step_id, request_type, image_hash, cache_hit, error FROM vision_calls',
+      )
+      .all() as Array<{
+      call_id: string;
+      item_id: string;
+      step_id: string;
+      request_type: string;
+      image_hash: string;
+      cache_hit: number;
+      error: string | null;
+    }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      call_id: res.body.call_id,
+      item_id: TEST_ITEM_ID,
+      step_id: TEST_STEP_ID,
+      request_type: 'guide',
+      image_hash: 'hash-1',
+      cache_hit: 0,
+      error: null,
+    });
+  });
+
+  it('AC-VIS-07 partial — captured buffer is zeroed after the response', async () => {
+    mockGuideOnce({
+      message: 'ok',
+      highlight_region: null,
+      confidence: 'low',
+    });
+    await request(ctx.app)
+      .post('/api/vision/guide')
+      .send({ item_id: TEST_ITEM_ID, step_id: TEST_STEP_ID });
+    expect(ctx.capturedBuffers).toHaveLength(1);
+    const buf = ctx.capturedBuffers[0]!;
+    expect(buf.every((b) => b === 0)).toBe(true);
+
+    const summaryRow = ctx.db
+      .prepare('SELECT result_summary FROM vision_calls')
+      .get() as { result_summary: string | null };
+    expect(summaryRow.result_summary ?? '').not.toMatch(/iVBOR/i);
+    expect(summaryRow.result_summary ?? '').not.toMatch(
+      /[A-Za-z0-9+/]{200,}/,
+    );
+  });
+
+  it('omits highlight_region when Anthropic returns null', async () => {
+    mockGuideOnce({
+      message: '먼저 다운로드 폴더로 이동하세요',
+      highlight_region: null,
+      confidence: 'medium',
+    });
+    const res = await request(ctx.app)
+      .post('/api/vision/guide')
+      .send({ item_id: TEST_ITEM_ID, step_id: TEST_STEP_ID });
+    expect(res.status).toBe(200);
+    expect(res.body.result.highlight_region).toBeUndefined();
+    expect(res.body.result.confidence).toBe('medium');
+  });
+});
+
+describe('POST /api/vision/verify — AC-VIS-02 / AC-VIS-03', () => {
+  let ctx: AppCtx;
+
+  beforeEach(() => {
+    ctx = buildApp();
+  });
+
+  afterEach(() => {
+    ctx.dispose();
+  });
+
+  it('AC-VIS-02 — verify pass auto-completes the item', async () => {
+    mockVerifyOnce({
+      status: 'pass',
+      reasoning: '/Applications/SecurityAgent.app 가 보입니다.',
+      next_action_hint: '이대로 다음 단계로 진행하세요',
+    });
+
+    const res = await request(ctx.app)
+      .post('/api/vision/verify')
+      .send({ item_id: TEST_ITEM_ID, step_id: TEST_STEP_ID });
+
+    expect(res.status).toBe(200);
+    expect(res.body.result.type).toBe('verify');
+    expect(res.body.result.status).toBe('pass');
+
+    const row = ctx.db
+      .prepare(
+        'SELECT status, completed_at FROM item_states WHERE item_id = ?',
+      )
+      .get(TEST_ITEM_ID) as
+      | { status: string; completed_at: number | null }
+      | undefined;
+    expect(row?.status).toBe('completed');
+    expect(typeof row?.completed_at).toBe('number');
+  });
+
+  it('AC-VIS-03 — verify fail keeps item state non-completed and surfaces hint', async () => {
+    // Pre-seed the item as in_progress (someone called /api/items/:id/start).
+    ctx.db
+      .prepare(
+        `INSERT INTO item_states (item_id, status, current_step, started_at, completed_at, attempt_count)
+         VALUES (?, 'in_progress', NULL, ?, NULL, 1)`,
+      )
+      .run(TEST_ITEM_ID, ctx.nowFn());
+
+    mockVerifyOnce({
+      status: 'fail',
+      reasoning: 'SecurityAgent 가 보이지 않습니다.',
+      next_action_hint: '다시 .pkg 를 더블클릭하세요',
+    });
+
+    const res = await request(ctx.app)
+      .post('/api/vision/verify')
+      .send({ item_id: TEST_ITEM_ID, step_id: TEST_STEP_ID });
+
+    expect(res.status).toBe(200);
+    expect(res.body.result.status).toBe('fail');
+    expect(res.body.result.next_action_hint).toContain('.pkg');
+
+    const row = ctx.db
+      .prepare(
+        'SELECT status, completed_at FROM item_states WHERE item_id = ?',
+      )
+      .get(TEST_ITEM_ID) as { status: string; completed_at: number | null };
+    expect(row.status).toBe('in_progress');
+    expect(row.completed_at).toBeNull();
+  });
+
+  it('verify unclear — same shape, no completion', async () => {
+    mockVerifyOnce({
+      status: 'unclear',
+      reasoning: '화면이 너무 작아 판단 불가',
+      next_action_hint: '창을 최대화하고 다시 시도하세요',
+    });
+
+    const res = await request(ctx.app)
+      .post('/api/vision/verify')
+      .send({ item_id: TEST_ITEM_ID, step_id: TEST_STEP_ID });
+    expect(res.status).toBe(200);
+    expect(res.body.result.status).toBe('unclear');
+
+    const row = ctx.db
+      .prepare(
+        'SELECT status FROM item_states WHERE item_id = ?',
+      )
+      .get(TEST_ITEM_ID) as { status: string } | undefined;
+    expect(row?.status ?? null).not.toBe('completed');
+  });
+});
+
+describe('POST /api/vision/guide — AC-VIS-04 cache hit', () => {
+  let ctx: AppCtx;
+
+  beforeEach(() => {
+    ctx = buildApp({ hashes: ['same-hash', 'same-hash'] });
+  });
+
+  afterEach(() => {
+    ctx.dispose();
+  });
+
+  it('second call within 30s returns cached=true and does not hit Anthropic', async () => {
+    mockGuideOnce({
+      message: '클릭하세요',
+      highlight_region: null,
+      confidence: 'high',
+    });
+
+    const first = await request(ctx.app)
+      .post('/api/vision/guide')
+      .send({ item_id: TEST_ITEM_ID, step_id: TEST_STEP_ID });
+    expect(first.status).toBe(200);
+    expect(first.body.cached).toBe(false);
+
+    // Advance past the 1s debounce window but stay inside the 30s cache TTL.
+    ctx.advanceNow(1500);
+
+    // No mock registered for the second call — msw onUnhandledRequest:'error'
+    // would fail this test if the orchestrator hit the network.
+    const second = await request(ctx.app)
+      .post('/api/vision/guide')
+      .send({ item_id: TEST_ITEM_ID, step_id: TEST_STEP_ID });
+
+    expect(second.status).toBe(200);
+    expect(second.body.cached).toBe(true);
+    expect(second.body.latency_ms).toBeLessThan(100);
+    expect(second.body.result).toEqual(first.body.result);
+
+    // vision_calls only logs the network-going call, not the cache hit.
+    const count = ctx.db
+      .prepare('SELECT COUNT(*) as c FROM vision_calls')
+      .get() as { c: number };
+    expect(count.c).toBe(1);
+  });
+});
+
+describe('POST /api/vision/verify — cache + error paths', () => {
+  let ctx: AppCtx;
+
+  beforeEach(() => {
+    ctx = buildApp({ hashes: ['verify-hash', 'verify-hash'] });
+  });
+
+  afterEach(() => {
+    ctx.dispose();
+  });
+
+  it('second verify call within 30s returns cached=true without an Anthropic round-trip', async () => {
+    mockVerifyOnce({
+      status: 'fail',
+      reasoning: '아직 설치되지 않았습니다.',
+      next_action_hint: '.pkg 를 더블클릭하세요',
+    });
+
+    const first = await request(ctx.app)
+      .post('/api/vision/verify')
+      .send({ item_id: TEST_ITEM_ID, step_id: TEST_STEP_ID });
+    expect(first.status).toBe(200);
+    expect(first.body.cached).toBe(false);
+
+    ctx.advanceNow(1500);
+
+    const second = await request(ctx.app)
+      .post('/api/vision/verify')
+      .send({ item_id: TEST_ITEM_ID, step_id: TEST_STEP_ID });
+    expect(second.status).toBe(200);
+    expect(second.body.cached).toBe(true);
+    expect(second.body.result).toEqual(first.body.result);
+  });
+
+  it('Anthropic error on verify path → 503 vision_api_error and audit row', async () => {
+    mockMessagesOnce(() =>
+      HttpResponse.json(
+        { type: 'error', error: { type: 'api_error' } },
+        { status: 500 },
+      ),
+    );
+    const res = await request(ctx.app)
+      .post('/api/vision/verify')
+      .send({ item_id: TEST_ITEM_ID, step_id: TEST_STEP_ID });
+    expect(res.status).toBe(503);
+    expect(res.body).toEqual({ error: 'vision_api_error' });
+
+    const row = ctx.db
+      .prepare(
+        'SELECT request_type, error FROM vision_calls',
+      )
+      .get() as { request_type: string; error: string | null } | undefined;
+    expect(row?.request_type).toBe('verify');
+    expect(row?.error).toBe('anthropic_server_error');
+  });
+});
+
+describe('POST /api/vision/guide — AC-VIS-05 paused', () => {
+  let ctx: AppCtx;
+  const baseTime = Math.floor(1_700_000_000_000 / 3_600_000) * 3_600_000;
+
+  beforeEach(() => {
+    ctx = buildApp({ initialNow: baseTime });
+    // Pre-seed the bucket as fully exhausted.
+    const bucketId = String(bucketIdForHour(baseTime));
+    ctx.db
+      .prepare(
+        `INSERT INTO rate_limit_buckets (bucket_id, call_count, alert_sent, paused, reset_at)
+         VALUES (?, 200, 1, 1, ?)`,
+      )
+      .run(bucketId, hourBoundaryAfter(baseTime));
+  });
+
+  afterEach(() => {
+    ctx.dispose();
+  });
+
+  it('returns 429 with state=paused and reset_at', async () => {
+    const res = await request(ctx.app)
+      .post('/api/vision/guide')
+      .send({ item_id: TEST_ITEM_ID, step_id: TEST_STEP_ID });
+    expect(res.status).toBe(429);
+    expect(res.body).toEqual({
+      error: 'rate_limit_exceeded',
+      state: 'paused',
+      reset_at: hourBoundaryAfter(baseTime),
+    });
+    // No anthropic call, no capture either.
+    expect(ctx.capture).not.toHaveBeenCalled();
+  });
+
+  it('verify path is paused too', async () => {
+    const res = await request(ctx.app)
+      .post('/api/vision/verify')
+      .send({ item_id: TEST_ITEM_ID, step_id: TEST_STEP_ID });
+    expect(res.status).toBe(429);
+    expect(res.body.state).toBe('paused');
+  });
+});
+
+describe('POST /api/vision/guide — AC-VIS-06 timeout / API error', () => {
+  let ctx: AppCtx;
+
+  beforeEach(() => {
+    ctx = buildApp();
+  });
+
+  afterEach(() => {
+    ctx.dispose();
+  });
+
+  it('Anthropic 504 → 503 vision_api_timeout', async () => {
+    mockMessagesOnce(() =>
+      HttpResponse.json(
+        { type: 'error', error: { type: 'timeout' } },
+        { status: 504 },
+      ),
+    );
+    const res = await request(ctx.app)
+      .post('/api/vision/guide')
+      .send({ item_id: TEST_ITEM_ID, step_id: TEST_STEP_ID });
+    expect(res.status).toBe(503);
+    expect(res.body).toEqual({ error: 'vision_api_timeout' });
+
+    // Failure still goes into vision_calls so /admin can see it.
+    const row = ctx.db
+      .prepare(
+        'SELECT request_type, error, cache_hit FROM vision_calls',
+      )
+      .get() as
+      | { request_type: string; error: string | null; cache_hit: number }
+      | undefined;
+    expect(row).toBeDefined();
+    expect(row?.error).toBe('anthropic_timeout_error');
+    expect(row?.cache_hit).toBe(0);
+  });
+
+  it('Anthropic 500 → 503 vision_api_error', async () => {
+    mockMessagesOnce(() =>
+      HttpResponse.json(
+        { type: 'error', error: { type: 'api_error' } },
+        { status: 500 },
+      ),
+    );
+    const res = await request(ctx.app)
+      .post('/api/vision/guide')
+      .send({ item_id: TEST_ITEM_ID, step_id: TEST_STEP_ID });
+    expect(res.status).toBe(503);
+    expect(res.body).toEqual({ error: 'vision_api_error' });
+  });
+
+  it('Anthropic 401 → 503 vision_api_error', async () => {
+    mockMessagesOnce(() =>
+      HttpResponse.json(
+        { type: 'error', error: { type: 'authentication_error' } },
+        { status: 401 },
+      ),
+    );
+    const res = await request(ctx.app)
+      .post('/api/vision/guide')
+      .send({ item_id: TEST_ITEM_ID, step_id: TEST_STEP_ID });
+    expect(res.status).toBe(503);
+    expect(res.body).toEqual({ error: 'vision_api_error' });
+  });
+
+  it('malformed model output → 503 vision_response_invalid', async () => {
+    mockMessagesOnce(() =>
+      HttpResponse.json(
+        buildAnthropicMessageBody('I cannot help with that.'),
+      ),
+    );
+    const res = await request(ctx.app)
+      .post('/api/vision/guide')
+      .send({ item_id: TEST_ITEM_ID, step_id: TEST_STEP_ID });
+    expect(res.status).toBe(503);
+    expect(res.body).toEqual({ error: 'vision_response_invalid' });
+  });
+});
+
+describe('POST /api/vision/guide — debounce 429 throttled', () => {
+  let ctx: AppCtx;
+
+  beforeEach(() => {
+    ctx = buildApp({ hashes: ['hash-a', 'hash-b'] });
+  });
+
+  afterEach(() => {
+    ctx.dispose();
+  });
+
+  it('two calls within 1s for the same step return throttled', async () => {
+    mockGuideOnce({
+      message: 'first',
+      highlight_region: null,
+      confidence: 'high',
+    });
+
+    const first = await request(ctx.app)
+      .post('/api/vision/guide')
+      .send({ item_id: TEST_ITEM_ID, step_id: TEST_STEP_ID });
+    expect(first.status).toBe(200);
+
+    // Stay under the 1s debounce window.
+    ctx.advanceNow(500);
+
+    const second = await request(ctx.app)
+      .post('/api/vision/guide')
+      .send({ item_id: TEST_ITEM_ID, step_id: TEST_STEP_ID });
+    expect(second.status).toBe(429);
+    expect(second.body).toEqual({
+      error: 'rate_limit_exceeded',
+      state: 'throttled',
+    });
+  });
+});
+
+describe('consent gating', () => {
+  it('missing screen_recording consent → 401 screen_recording_permission_required', async () => {
+    const ctx = buildApp({ grantConsents: ['anthropic_transmission'] });
+    try {
+      const res = await request(ctx.app)
+        .post('/api/vision/guide')
+        .send({ item_id: TEST_ITEM_ID, step_id: TEST_STEP_ID });
+      expect(res.status).toBe(401);
+      expect(res.body).toEqual({
+        error: 'screen_recording_permission_required',
+      });
+    } finally {
+      ctx.dispose();
+    }
+  });
+
+  it('missing anthropic_transmission consent → 403 consent_required', async () => {
+    const ctx = buildApp({ grantConsents: ['screen_recording'] });
+    try {
+      const res = await request(ctx.app)
+        .post('/api/vision/guide')
+        .send({ item_id: TEST_ITEM_ID, step_id: TEST_STEP_ID });
+      expect(res.status).toBe(403);
+      expect(res.body.error).toBe('consent_required');
+      expect(res.body.missing).toContain('anthropic_transmission');
+    } finally {
+      ctx.dispose();
+    }
+  });
+
+  it('verify path also gates on both consents', async () => {
+    const ctx = buildApp({ grantConsents: [] });
+    try {
+      const res = await request(ctx.app)
+        .post('/api/vision/verify')
+        .send({ item_id: TEST_ITEM_ID, step_id: TEST_STEP_ID });
+      // SR missing wins per consents/middleware.ts contract.
+      expect(res.status).toBe(401);
+    } finally {
+      ctx.dispose();
+    }
+  });
+});
+
+describe('item / step / body validation', () => {
+  let ctx: AppCtx;
+
+  beforeEach(() => {
+    ctx = buildApp();
+  });
+
+  afterEach(() => {
+    ctx.dispose();
+  });
+
+  it('400 when item_id is missing from the body', async () => {
+    const res = await request(ctx.app)
+      .post('/api/vision/guide')
+      .send({ step_id: TEST_STEP_ID });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('validation_error');
+  });
+
+  it('400 on extra unknown field (strict zod object)', async () => {
+    const res = await request(ctx.app)
+      .post('/api/vision/guide')
+      .send({
+        item_id: TEST_ITEM_ID,
+        step_id: TEST_STEP_ID,
+        extra: 'nope',
+      });
+    expect(res.status).toBe(400);
+  });
+
+  it('404 when item_id is not in the checklist', async () => {
+    const res = await request(ctx.app)
+      .post('/api/vision/guide')
+      .send({ item_id: 'no-such-item', step_id: TEST_STEP_ID });
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'item_not_found' });
+    expect(ctx.capture).not.toHaveBeenCalled();
+  });
+
+  it('404 when step_id is unknown for the item', async () => {
+    const res = await request(ctx.app)
+      .post('/api/vision/guide')
+      .send({ item_id: TEST_ITEM_ID, step_id: 'no-such-step' });
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'step_not_found' });
+    expect(ctx.capture).not.toHaveBeenCalled();
+  });
+
+  it('verify route — 404 when item missing', async () => {
+    const res = await request(ctx.app)
+      .post('/api/vision/verify')
+      .send({ item_id: 'no-such-item', step_id: TEST_STEP_ID });
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'item_not_found' });
+  });
+});
+
+describe('rate-limit accounting from /api/vision/guide hits', () => {
+  let ctx: AppCtx;
+
+  beforeEach(() => {
+    ctx = buildApp();
+  });
+
+  afterEach(() => {
+    ctx.dispose();
+  });
+
+  it('successful guide call increments the hour bucket', async () => {
+    mockGuideOnce({
+      message: 'ok',
+      highlight_region: null,
+      confidence: 'low',
+    });
+    await request(ctx.app)
+      .post('/api/vision/guide')
+      .send({ item_id: TEST_ITEM_ID, step_id: TEST_STEP_ID });
+
+    const status = await request(ctx.app).get('/api/vision/rate-limit');
+    expect(status.status).toBe(200);
+    expect(status.body.current_hour_calls).toBe(1);
+    expect(status.body.state).toBe('normal');
+  });
+});


### PR DESCRIPTION
# Review — spec-012-daemon-p8-routes

- **Spec**: `specs/spec-012-daemon-p8-routes.md`
- **Branch**: `feature/spec-012-daemon-p8-routes`
- **Diff range**: `main...HEAD` (commit `70e8171` on top of `4e860b9`)
- **Files added/modified by this spec** (`HEAD~1..HEAD`):
  - `packages/daemon/src/p8-vision/orchestrator.ts` (+430)
  - `packages/daemon/src/routes/index.ts` (+40 net, wires P8 router)
  - `packages/daemon/src/routes/vision.ts` (+135)
  - `packages/daemon/tests/p8-routes.test.ts` (+803)

검증 결과 한 문장 요약: **모든 PRD §10 AC가 테스트로 충족되고 보안·계약·BOUNDARIES 준수가 확인되며, 한 항목(코드 품질 — 함수 길이)만 WARN으로 남는다.**

최종 판정: **PASS_WITH_WARN**.

---

## 1. AC 정합성 (PRD §10) — **PASS**

모든 AC-VIS-01 ~ AC-VIS-06과 AC-VIS-07 partial이 본 spec 책임 범위 내에서 코드/테스트로 충족된다.

| AC | 충족 위치 (코드) | 충족 위치 (테스트) |
|----|------------------|--------------------|
| **AC-VIS-01** 정상 흐름 + vision_calls 메타 기록 + 이미지 미잔존 | `orchestrator.ts:266-343` (runGuide), `:198-224` (insertVisionCall), `:253-263` (withCapture finally → disposeBuffer) | `p8-routes.test.ts:234-284` (envelope + row), `:286-306` (buffer zeroed + summary base64 없음) |
| **AC-VIS-02** verify pass → item completed | `orchestrator.ts:423-426` + `markItemCompleted` `:167-181` (UPSERT into `item_states`) | `p8-routes.test.ts:334-358` (status 'pass' → row.status='completed', completed_at 숫자) |
| **AC-VIS-03** verify fail → in_progress 유지 + next_action_hint | `orchestrator.ts:424` 가드 (`status === 'pass'`만 갱신), `pickVerifyResult` `:146-156`이 hint 통과 | `p8-routes.test.ts:360-390` (status='fail' 이후 row.status='in_progress', completed_at NULL, hint 포함) |
| **AC-VIS-04** 동일 화면 재호출 cached=true, latency<100ms, Anthropic 미호출 | `orchestrator.ts:281-289` (guide 캐시 hit 즉시 반환), `:360-368` (verify 동일) | `p8-routes.test.ts:425-457` (msw `onUnhandledRequest:'error'`로 미호출 보증, latency<100ms, 캐시 row 미증가), `:471-492` (verify) |
| **AC-VIS-05** 201번째 호출 → 429 paused | `orchestrator.ts:243-251` (`gateRateLimit` → `RateLimitPausedError`), 라우트 `vision.ts:114-121` (429 + state=paused + reset_at) | `p8-routes.test.ts:517-558` (bucket 200/paused 시드 후 429+reset_at, capture 미호출) |
| **AC-VIS-06** Anthropic 실패 → 503 | `vision.ts:122-133` (timeout/server/auth → 503) | `p8-routes.test.ts:571-595` (504→vision_api_timeout), `:597-609` (500→vision_api_error), `:611-623` (401→vision_api_error), `:625-636` (malformed→vision_response_invalid). 실패 시에도 `vision_calls`에 audit row 기록 확인 |
| **AC-VIS-07 partial** (이미지 데이터 파기) | `dispose.ts` + `withCapture` finally | `p8-routes.test.ts:286-306` (buffer 0 채움 + summary `iVBOR`/장문 base64 미포함) |
| 동의 미부여 시 401/403 분기 | `vision.ts:39-43` (`requireConsent`), `consents/middleware.ts:36-43` (SR 우선) | `p8-routes.test.ts:677-718` |

추가로 spec이 명시한 debounce throttled 분기도 `:639-674`에서 검증됨.

`pnpm test`(291/291), `pnpm build`, `pnpm lint`(타입체크) 모두 통과. spec의 "테스트 커버리지 ≥ 80%" 조건은 daemon 전체 97.7% / `orchestrator.ts` 98.99% / `vision.ts` 91.39%로 만족.

---

## 2. PRD 정합성 — **PASS**

- §9.1.3 / §9.1.4의 의도 — "캡처 + Anthropic + 캐시 + 가드레일 + 동의 미들웨어 + audit row를 한 라우트에 묶기" — 가 `orchestrator.ts`/`vision.ts`로 그대로 구현됨.
- spec 비범위 항목(프롬프트 작성, 캐시 알고리즘, 캡처 메커니즘 등)은 **건드리지 않음**: `orchestrator.ts`는 `cache`, `rateLimit`, `debounce`, `captureScreen`, `callGuide`/`callVerify`를 모두 외부 모듈에서 import 하여 조립만 수행.
- 한 가지 디자인 결정(spec 본문 4-5번 단계와 일치): rate-limit 게이트가 캡처/캐시 조회보다 **앞에** 위치하여 캐시 hit도 시간당 200회 버킷을 증가시킨다. PRD가 cache-hit를 rate-limit에서 제외하라고 명시하지 않으므로 **위반은 아님**, spec 본문 흐름과 일치.

---

## 3. 데이터 모델 정합성 (PRD §8.1) — **PASS**

orchestrator가 사용하는 SQLite 스키마는 모두 PRD §8.1과 동일한 `001_init.sql`에 이미 존재하며, 본 spec 변경분에 **새 컬럼·새 테이블·새 마이그레이션이 없다**.

- `vision_calls` INSERT 컬럼 12개 (`call_id`, `item_id`, `step_id`, `request_type`, `image_hash`, `prompt_tokens`, `output_tokens`, `latency_ms`, `cache_hit`, `result_summary`, `error`, `created_at`)는 PRD §8.1 정의와 정확히 일치 (`orchestrator.ts:198-224`).
- `item_states` UPSERT는 `status`, `current_step`, `started_at`, `completed_at`, `attempt_count` 5개 컬럼만 사용 (PRD §8.1 동일).
- `cache_hit`은 PRD `INTEGER`에 맞춰 `boolean ? 1 : 0` 변환 (`:219`) — 정상.
- 임의 타입 추가 없음.

참고: 현재 `prompt_tokens` / `output_tokens`는 항상 `null`로 기록된다 (`orchestrator.ts:303-305, 327-329`). PRD §8.1은 두 컬럼을 `INTEGER NULL`로 정의하므로 스키마 위반은 아니지만, spec-010 `anthropic-client.ts`의 `usage`(`input_tokens`/`output_tokens`)를 surface 하지 않아 미래의 비용 분석에 공백이 남는다 — 별도 spec 보강 후보 (FYI, 본 spec AC와 무관).

---

## 4. API 계약 정합성 (PRD §9) — **PASS**

- 라우트 경로/메서드: `POST /api/vision/guide`, `POST /api/vision/verify` — PRD §9.1.3/§9.1.4와 동일 (`vision.ts:45-85`).
- 요청 zod 스키마(`VisionGuideRequestSchema`/`VisionVerifyRequestSchema`)는 `{ item_id, step_id }`로 PRD와 일치 (`shared/src/schemas/api.ts:102-124`).
- 응답 envelope `{ call_id, cached, latency_ms, result }` — PRD §9.1.3과 동일. PRD §9.1.4 verify는 `{ call_id, result }`만 명시하나 `cached`/`latency_ms`는 shared zod에서 optional로 정의되어 있어 추가 필드 노출은 backward-compatible (BOUNDARIES §4의 "필드 이름·타입·필수 여부 변경" 금지 항목에 해당하지 않음).
- 상태 코드 매핑 (`vision.ts:90-135`):
  - 401 `screen_recording_permission_required` (consents middleware + ScreenRecordingDeniedError)
  - 403 `consent_required`
  - 429 `rate_limit_exceeded` + `state: throttled | paused (+ reset_at)`
  - 503 `vision_api_timeout` / `vision_api_error` / `vision_response_invalid`
  - 모두 PRD §9.1.3/spec-012 §출력의 매핑과 정확히 일치.
- 추가로 404 `item_not_found` / `step_not_found`을 신설 — PRD §9.1.3는 404를 명시하지 않으나, **추가는 backward-compatible**이며 잘못된 입력에 대한 합리적 응답이다. 기존 200/401/403/429/503의 의미를 바꾸지 않으므로 BOUNDARIES §4 위반 아님.
- Breaking change 없음.

---

## 5. 보안 점검 — **PASS**

- **시크릿 하드코딩 없음**: 테스트 픽스처는 BOUNDARIES §5의 가이드대로 `'test-key-placeholder'` 사용 (`p8-routes.test.ts:33`). 코드에는 `ANTHROPIC_API_KEY`를 직접 박지 않고 spec-010의 client가 `process.env`에서 읽음.
- **SQL 인젝션 방지**: 본 spec이 추가한 모든 INSERT/UPSERT는 `db.prepare(...).run({@named})` named parameter로 바인딩 (`orchestrator.ts:172-180, 202-223`). 사용자 입력(itemId, stepId)도 모두 파라미터로 전달되며 문자열 보간 SQL 없음.
- **캡처 이미지 데이터 파기 (PRD §8.2 / AC-VIS-07)**:
  - `withCapture`의 `finally`에서 `disposeBuffer(cap.buffer)` 무조건 실행 (`orchestrator.ts:259-262`) → 정상/에러 양 경로 모두 0으로 채움.
  - `result_summary`는 `summarizeGuide`/`summarizeVerify`로 텍스트만 추출하고 512자로 truncate (`:110, 116-132`) — 이미지/base64 유출 경로 없음.
  - 테스트가 buffer 0 채움 + summary에 `iVBOR`/200자 이상 base64 미포함을 명시적으로 검증 (`p8-routes.test.ts:295-305`).
- **로깅 안전성**: `logger.warn({ err, item_id, step_id }, ...)`만 기록, 캡처 버퍼/이미지 hash는 메시지에 포함되지 않음. pino redact는 본 spec 범위 외(공통 logger).

---

## 6. 코드 품질 — **WARN (함수 50줄 미만 미달 2건)**

- **테스트 커버리지**: orchestrator.ts 98.99% / vision.ts 91.39% / 패키지 평균 97.7% — spec 80% 기준 충족. ✅
- **함수 길이 50줄 기준 위반**:
  - `runGuide` (orchestrator.ts:266-343) — **78 lines**
  - `runVerify` (orchestrator.ts:345-428) — **84 lines**
  - 둘 다 캐시 lookup → Anthropic 호출 → 성공/실패 audit row → 결과 매핑이 한 함수에 인라인. 두 함수 사이에 거의 동일한 try/catch + `insertVisionCall` 블록이 반복되어 `runOnce(requestType, runClient, summarize)` 같은 헬퍼로 중복 제거 가능.
  - 다른 함수들은 모두 50줄 미만: `markItemCompleted`(15), `insertVisionCall`(27), `summarizeGuide`(9), `summarizeVerify`(7), `pickGuideResult`(11), `pickVerifyResult`(11), `errorCode`(8), `resolve`(7), `gateRateLimit`(9), `withCapture`(11).
- **그 외**: 명명·타입·zod 활용·에러 클래스 분리 모두 깨끗. spec이 요구한 `code` 필드를 가진 도메인 에러(`VisionItemNotFoundError`, `RateLimitPausedError` 등)와 `instanceof` 기반 에러 매핑이 깔끔히 분리됨.

이 WARN은 동작 결함이 아니라 가독성·중복성 측면이며, 추후 정리 spec 후보.

---

## 7. BOUNDARIES.md 준수 — **PASS**

- spec-012 커밋(`70e8171`)은 정확히 4개 파일만 변경:
  - `packages/daemon/src/p8-vision/orchestrator.ts` (신규)
  - `packages/daemon/src/routes/vision.ts` (신규)
  - `packages/daemon/src/routes/index.ts` (수정 — vision 라우터/오케스트레이터 wiring)
  - `packages/daemon/tests/p8-routes.test.ts` (신규)
- 모두 spec 명시 패키지 경로 `packages/daemon/` 내부. ✅ (BOUNDARIES §2)
- `docs/PRD-MVP-SLIM.md`, `BOUNDARIES.md`, `spec-template.md`, 다른 spec 파일, 다른 패키지(`packages/shared/`, `packages/cli/` 등) 무손상. ✅ (BOUNDARIES §1)
- `tsconfig.base.json`, 루트 `package.json`, CI 설정 무수정. ✅
- `routes/index.ts`는 spec 출력 §의 wiring 책임에 해당하므로 같은 spec이 수정해도 무방 (BOUNDARIES §2의 "선행 spec 산출물 내부 구현 변경 금지"는 다른 spec이 만든 라우트 핸들러를 함부로 고치지 말라는 취지인데, 여기서는 단지 새 라우터를 `app.use`에 추가하는 통합 hook이므로 합리적 범위).
- API 계약 변경 없음 (§4 항목 참고).

---

## 8. 의존성 체크 — **PASS**

- spec-012 커밋은 **`package.json`을 수정하지 않음** (`git diff HEAD~1..HEAD -- packages/daemon/package.json` empty).
- `vision.ts`/`orchestrator.ts`/테스트가 새로 import 하는 외부 라이브러리 점검:
  - `@onboarding/shared` (workspace), `pino`, `express`, `zod` (간접), `@anthropic-ai/sdk` (간접), `msw` (test), `supertest` (test), `vitest` — 모두 PRD §12 화이트리스트.
- 신규 외부 의존성 0개. ✅

---

## 종합 판정

| 항목 | 결과 |
|------|------|
| 1. AC 정합성 | **PASS** |
| 2. PRD 정합성 | **PASS** |
| 3. 데이터 모델 정합성 | **PASS** |
| 4. API 계약 정합성 | **PASS** |
| 5. 보안 점검 | **PASS** |
| 6. 코드 품질 | **WARN** (`runGuide` 78줄, `runVerify` 84줄 — 50줄 기준 초과, 두 메서드 중복 로직) |
| 7. BOUNDARIES.md 준수 | **PASS** |
| 8. 의존성 체크 | **PASS** |

**최종**: PASS_WITH_WARN — spec AC는 모두 충족되고 보안·계약·경계는 깨끗하나, 오케스트레이터 두 메서드의 길이/중복은 후속 정리 권장.

<promise>SPEC_012_DAEMON_P8_ROUTES_REVIEW_PASS_WITH_WARN</promise>
