### PR TITLE
[Ralph] spec-013-daemon-cli-install

### DIFF
--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -5,13 +5,16 @@
   "description": "Onboarding Agent local daemon (Express + better-sqlite3 + pino) (PRD-MVP-SLIM v0.10 §6.2 B)",
   "type": "module",
   "main": "./dist/index.js",
+  "bin": {
+    "onboarding": "./dist/cli/index.js"
+  },
   "files": [
     "dist",
     "src",
     "content"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.build.json && node scripts/copy-migrations.mjs",
+    "build": "tsc -p tsconfig.build.json && node scripts/copy-migrations.mjs && node scripts/cli-shebang.mjs",
     "dev": "pnpm build && node dist/index.js",
     "start": "node dist/index.js",
     "test": "vitest run --coverage",
@@ -20,10 +23,14 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.30.0",
+    "@inquirer/prompts": "^5.0.0",
     "@onboarding/shared": "workspace:*",
     "better-sqlite3": "^11.0.0",
+    "commander": "^12.0.0",
     "execa": "^9.0.0",
     "express": "^4.19.2",
+    "ora": "^8.0.0",
+    "picocolors": "^1.0.0",
     "pino": "^9.0.0",
     "sharp": "^0.33.5",
     "yaml": "^2.4.0",

--- a/packages/daemon/scripts/cli-shebang.mjs
+++ b/packages/daemon/scripts/cli-shebang.mjs
@@ -1,0 +1,19 @@
+import { chmodSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const cliFile = join(here, '..', 'dist', 'cli', 'index.js');
+
+if (!existsSync(cliFile)) {
+  console.error(`[cli-shebang] cli not found: ${cliFile}`);
+  process.exit(1);
+}
+
+const SHEBANG = '#!/usr/bin/env node\n';
+const contents = readFileSync(cliFile, 'utf-8');
+if (!contents.startsWith('#!')) {
+  writeFileSync(cliFile, SHEBANG + contents, 'utf-8');
+}
+chmodSync(cliFile, 0o755);
+console.log(`[cli-shebang] prepared ${cliFile}`);

--- a/packages/daemon/src/cli/index.ts
+++ b/packages/daemon/src/cli/index.ts
@@ -1,0 +1,153 @@
+import { spawn as nodeSpawn } from 'node:child_process';
+
+import { confirm, input } from '@inquirer/prompts';
+import { Command } from 'commander';
+import ora from 'ora';
+import pc from 'picocolors';
+
+import { openDatabase } from '../db/index.js';
+import { migrate } from '../db/migrate.js';
+import {
+  defaultDbFilePath,
+  defaultPidFilePath,
+  DEFAULT_BASE_URL,
+} from './paths.js';
+import { runReset } from './reset.js';
+import { runStart, type SpawnFn, type SpawnedProcess } from './start.js';
+import { fetchDaemonStatus, renderStatus, runStatus } from './status.js';
+import { runStop } from './stop.js';
+import { runWizard, type WizardResult } from './wizard.js';
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+const spawnFn: SpawnFn = (command, args, options) => {
+  const child = nodeSpawn(command, args, options);
+  return { pid: child.pid, unref: () => child.unref() } satisfies SpawnedProcess;
+};
+
+async function waitForReady(baseUrl: string): Promise<boolean> {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`${baseUrl}/api/checklist`);
+      if (res.ok) return true;
+    } catch {
+      /* daemon still booting */
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  return false;
+}
+
+async function pressEnter(q: { message: string }): Promise<void> {
+  await input({ message: `${q.message} (ENTER)` });
+}
+
+async function startCommand(): Promise<void> {
+  await runStart({
+    pidFilePath: defaultPidFilePath(),
+    dbFilePath: defaultDbFilePath(),
+    spawn: spawnFn,
+    runWizard: async ({ dbFilePath }): Promise<WizardResult> => {
+      const db = openDatabase(dbFilePath);
+      try {
+        migrate(db);
+        return await runWizard({
+          db,
+          baseUrl: DEFAULT_BASE_URL,
+          promptInput: input,
+          promptConfirm: confirm,
+          promptPress: pressEnter,
+        });
+      } finally {
+        db.close();
+      }
+    },
+    isProcessAlive,
+    waitForReady,
+    now: Date.now,
+  });
+}
+
+async function statusCommand(): Promise<void> {
+  const spinner = ora({ text: '데몬 상태 확인 중...' }).start();
+  try {
+    const snapshot = await fetchDaemonStatus({ baseUrl: DEFAULT_BASE_URL });
+    spinner.stop();
+    renderStatus(snapshot, (line) => console.log(line));
+  } catch (err) {
+    spinner.stop();
+    // Re-render to print the failure log line through runStatus error path.
+    try {
+      await runStatus({ baseUrl: DEFAULT_BASE_URL });
+    } catch {
+      /* runStatus already printed */
+    }
+    process.exitCode = 1;
+    throw err;
+  }
+}
+
+async function stopCommand(): Promise<void> {
+  await runStop({
+    pidFilePath: defaultPidFilePath(),
+    kill: (pid, signal) => process.kill(pid, signal),
+    isProcessAlive,
+  });
+}
+
+async function resetCommand(opts: { yes?: boolean }): Promise<void> {
+  await runReset({
+    dbFilePath: defaultDbFilePath(),
+    yes: Boolean(opts.yes),
+    promptConfirm: confirm,
+  });
+}
+
+export function buildCli(): Command {
+  const program = new Command();
+  program
+    .name('onboarding')
+    .description(pc.bold('Onboarding Agent CLI (PRD-MVP-SLIM v0.10 §6.2 A)'))
+    .version('0.1.0');
+
+  program
+    .command('start')
+    .description('데몬을 기동하고 첫 실행 위저드를 실행합니다.')
+    .action(startCommand);
+
+  program
+    .command('status')
+    .description('체크리스트, 동의, Vision 가드레일 상태를 출력합니다.')
+    .action(statusCommand);
+
+  program
+    .command('stop')
+    .description('실행 중인 데몬을 종료합니다.')
+    .action(stopCommand);
+
+  program
+    .command('reset')
+    .description('SQLite 데이터를 삭제하고 위저드를 재실행 가능 상태로 만듭니다.')
+    .option('-y, --yes', '확인 프롬프트 없이 즉시 초기화합니다.', false)
+    .action(resetCommand);
+
+  return program;
+}
+
+async function main(): Promise<void> {
+  const program = buildCli();
+  await program.parseAsync(process.argv);
+}
+
+main().catch((err) => {
+  console.error(pc.red(`오류: ${(err as Error).message}`));
+  process.exit(1);
+});

--- a/packages/daemon/src/cli/paths.ts
+++ b/packages/daemon/src/cli/paths.ts
@@ -1,0 +1,16 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export const DEFAULT_BASE_URL = 'http://localhost:7777';
+
+export function onboardingHome(): string {
+  return join(homedir(), '.onboarding');
+}
+
+export function defaultPidFilePath(): string {
+  return join(onboardingHome(), 'daemon.pid');
+}
+
+export function defaultDbFilePath(): string {
+  return join(onboardingHome(), 'agent.db');
+}

--- a/packages/daemon/src/cli/reset.ts
+++ b/packages/daemon/src/cli/reset.ts
@@ -1,0 +1,48 @@
+import { existsSync, rmSync } from 'node:fs';
+
+import pc from 'picocolors';
+
+import { defaultDbFilePath } from './paths.js';
+
+export type ResetConfirmFn = (q: { message: string }) => Promise<boolean>;
+
+export interface ResetDeps {
+  dbFilePath?: string;
+  yes: boolean;
+  promptConfirm: ResetConfirmFn;
+  log?: (line: string) => void;
+}
+
+export interface ResetResult {
+  deleted: boolean;
+}
+
+export async function runReset(deps: ResetDeps): Promise<ResetResult> {
+  const log = deps.log ?? ((l: string) => console.log(l));
+  const dbFilePath = deps.dbFilePath ?? defaultDbFilePath();
+
+  if (!existsSync(dbFilePath)) {
+    log(pc.yellow('이미 초기화된 상태입니다 (SQLite 파일 없음).'));
+    return { deleted: false };
+  }
+
+  if (!deps.yes) {
+    const confirmed = await deps.promptConfirm({
+      message:
+        '진행 상황과 동의 기록이 모두 삭제됩니다. 정말 초기화하시겠습니까?',
+    });
+    if (!confirmed) {
+      log(pc.dim('취소되었습니다.'));
+      return { deleted: false };
+    }
+  }
+
+  rmSync(dbFilePath, { force: true });
+  // SQLite WAL/SHM siblings produced by `journal_mode = WAL`.
+  rmSync(`${dbFilePath}-wal`, { force: true });
+  rmSync(`${dbFilePath}-shm`, { force: true });
+
+  log(pc.green('✓ SQLite 데이터베이스를 삭제했습니다.'));
+  log('  다음 `onboarding start` 실행 시 위저드가 다시 표시됩니다.');
+  return { deleted: true };
+}

--- a/packages/daemon/src/cli/start.ts
+++ b/packages/daemon/src/cli/start.ts
@@ -1,0 +1,110 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+import pc from 'picocolors';
+
+import {
+  DEFAULT_BASE_URL,
+  defaultDbFilePath,
+  defaultPidFilePath,
+} from './paths.js';
+import type { WizardResult } from './wizard.js';
+
+export interface SpawnedProcess {
+  pid?: number;
+  unref(): void;
+}
+
+export type SpawnFn = (
+  command: string,
+  args: string[],
+  options: { detached: boolean; stdio: 'ignore'; env: NodeJS.ProcessEnv },
+) => SpawnedProcess;
+
+export interface StartDeps {
+  pidFilePath?: string;
+  dbFilePath?: string;
+  daemonEntry?: string;
+  baseUrl?: string;
+  spawn: SpawnFn;
+  runWizard: (deps: { dbFilePath: string }) => Promise<WizardResult>;
+  isProcessAlive: (pid: number) => boolean;
+  waitForReady: (baseUrl: string) => Promise<boolean>;
+  log?: (line: string) => void;
+  env?: NodeJS.ProcessEnv;
+  now: () => number;
+}
+
+function readExistingPid(pidFilePath: string): number | null {
+  try {
+    if (!existsSync(pidFilePath)) return null;
+    const raw = readFileSync(pidFilePath, 'utf-8').trim();
+    const n = Number.parseInt(raw, 10);
+    return Number.isFinite(n) ? n : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function runStart(deps: StartDeps): Promise<void> {
+  const log = deps.log ?? ((l: string) => console.log(l));
+  const pidFilePath = deps.pidFilePath ?? defaultPidFilePath();
+  const dbFilePath = deps.dbFilePath ?? defaultDbFilePath();
+  const baseUrl = deps.baseUrl ?? DEFAULT_BASE_URL;
+  const env = deps.env ?? process.env;
+
+  const existingPid = readExistingPid(pidFilePath);
+  if (existingPid && deps.isProcessAlive(existingPid)) {
+    log(
+      pc.yellow(
+        `데몬이 이미 실행 중입니다 (PID ${existingPid}). 'onboarding status'로 상태를 확인하세요.`,
+      ),
+    );
+    return;
+  }
+
+  const daemonEntry = deps.daemonEntry ?? resolveDaemonEntry();
+  log(pc.bold('데몬을 기동합니다...'));
+
+  const child = deps.spawn('node', [daemonEntry], {
+    detached: true,
+    stdio: 'ignore',
+    env: {
+      ...env,
+      ONBOARDING_DB_PATH: dbFilePath,
+    },
+  });
+  child.unref();
+
+  if (typeof child.pid === 'number') {
+    mkdirSync(dirname(pidFilePath), { recursive: true });
+    writeFileSync(pidFilePath, String(child.pid), 'utf-8');
+  }
+
+  const ready = await deps.waitForReady(baseUrl);
+  if (!ready) {
+    log(
+      pc.red(
+        `데몬 기동을 확인하지 못했습니다. 'onboarding status'로 다시 확인해주세요.`,
+      ),
+    );
+    return;
+  }
+  log(pc.green(`✓ 데몬이 ${baseUrl}에서 응답합니다.`));
+
+  const wizardResult = await deps.runWizard({ dbFilePath });
+  if (wizardResult.skipped) {
+    log(pc.dim('첫 실행 위저드는 이미 완료되어 있습니다.'));
+  }
+
+  log('');
+  log('Floating Hint Window는 SPEC-014/015 머지 후 자동 기동됩니다.');
+  log(`상태 확인: ${pc.cyan('onboarding status')}`);
+  log(`종료: ${pc.cyan('onboarding stop')}`);
+}
+
+function resolveDaemonEntry(): string {
+  // The CLI is installed alongside the daemon entry as a sibling under dist/.
+  // src/cli/start.ts → dist/cli/start.js → dist/index.js
+  return new URL('../index.js', import.meta.url).pathname;
+}

--- a/packages/daemon/src/cli/status.ts
+++ b/packages/daemon/src/cli/status.ts
@@ -1,0 +1,154 @@
+import type { ConsentRecord, ConsentType, ItemState } from '@onboarding/shared';
+import pc from 'picocolors';
+
+import { DEFAULT_BASE_URL } from './paths.js';
+
+export interface ChecklistItemSummary extends ItemState {
+  title: string;
+}
+
+export interface ChecklistResponse {
+  items: ChecklistItemSummary[];
+}
+
+export type ConsentsResponse = Record<ConsentType, ConsentRecord>;
+
+export interface RateLimitResponse {
+  current_hour_calls: number;
+  state: 'ok' | 'paused';
+  reset_at: number;
+}
+
+export interface DaemonStatusSnapshot {
+  checklist: ChecklistResponse;
+  consents: ConsentsResponse;
+  rateLimit: RateLimitResponse;
+}
+
+export class DaemonUnreachableError extends Error {
+  readonly code = 'daemon_unreachable';
+  constructor(public readonly baseUrl: string, cause?: unknown) {
+    super(`daemon_unreachable: ${baseUrl}`);
+    this.name = 'DaemonUnreachableError';
+    if (cause !== undefined) {
+      (this as { cause?: unknown }).cause = cause;
+    }
+  }
+}
+
+export interface FetchStatusDeps {
+  baseUrl?: string;
+  fetch?: typeof globalThis.fetch;
+}
+
+async function getJson<T>(
+  fetchImpl: typeof globalThis.fetch,
+  url: string,
+): Promise<T> {
+  const res = await fetchImpl(url);
+  if (!res.ok) {
+    throw new Error(`request_failed: ${url} status=${res.status}`);
+  }
+  return (await res.json()) as T;
+}
+
+export async function fetchDaemonStatus(
+  deps: FetchStatusDeps = {},
+): Promise<DaemonStatusSnapshot> {
+  const baseUrl = deps.baseUrl ?? DEFAULT_BASE_URL;
+  const fetchImpl = deps.fetch ?? globalThis.fetch;
+  try {
+    const [checklist, consents, rateLimit] = await Promise.all([
+      getJson<ChecklistResponse>(fetchImpl, `${baseUrl}/api/checklist`),
+      getJson<ConsentsResponse>(fetchImpl, `${baseUrl}/api/consents`),
+      getJson<RateLimitResponse>(fetchImpl, `${baseUrl}/api/vision/rate-limit`),
+    ]);
+    return { checklist, consents, rateLimit };
+  } catch (err) {
+    if (err instanceof Error && err.message.startsWith('request_failed')) {
+      throw err;
+    }
+    throw new DaemonUnreachableError(baseUrl, err);
+  }
+}
+
+const STATUS_LABELS: Record<ItemState['status'], string> = {
+  pending: '대기',
+  in_progress: '진행 중',
+  completed: '완료',
+  skipped: '건너뜀',
+  blocked: '차단됨',
+};
+
+function statusBadge(status: ItemState['status']): string {
+  switch (status) {
+    case 'completed':
+      return pc.green('✓');
+    case 'in_progress':
+      return pc.yellow('▶');
+    case 'blocked':
+      return pc.red('✗');
+    case 'skipped':
+      return pc.dim('-');
+    case 'pending':
+    default:
+      return pc.dim('·');
+  }
+}
+
+export function renderStatus(
+  snapshot: DaemonStatusSnapshot,
+  log: (line: string) => void,
+): void {
+  log(pc.bold('체크리스트'));
+  for (const item of snapshot.checklist.items) {
+    const badge = statusBadge(item.status);
+    const label = STATUS_LABELS[item.status];
+    log(`  ${badge} ${item.title} ${pc.dim(`(${label})`)}`);
+  }
+
+  log('');
+  log(pc.bold('동의 상태'));
+  log(
+    `  Screen Recording: ${formatGranted(snapshot.consents.screen_recording)}`,
+  );
+  log(
+    `  Anthropic 전송: ${formatGranted(snapshot.consents.anthropic_transmission)}`,
+  );
+
+  log('');
+  log(pc.bold('Vision 가드레일'));
+  const rl = snapshot.rateLimit;
+  const stateLabel = rl.state === 'ok' ? pc.green('정상') : pc.red('일시정지');
+  log(`  현재 시간 호출: ${rl.current_hour_calls}회 (${stateLabel})`);
+}
+
+function formatGranted(record: ConsentRecord): string {
+  return record.granted ? pc.green('부여됨') : pc.red('미부여');
+}
+
+export interface RunStatusDeps extends FetchStatusDeps {
+  log?: (line: string) => void;
+}
+
+export async function runStatus(
+  deps: RunStatusDeps = {},
+): Promise<DaemonStatusSnapshot> {
+  const log = deps.log ?? ((line: string) => console.log(line));
+  try {
+    const snapshot = await fetchDaemonStatus(deps);
+    renderStatus(snapshot, log);
+    return snapshot;
+  } catch (err) {
+    if (err instanceof DaemonUnreachableError) {
+      log(
+        pc.red(
+          '데몬이 실행 중이 아닙니다. `onboarding start`로 데몬을 먼저 기동하세요.',
+        ),
+      );
+    } else {
+      log(pc.red(`상태 조회 실패: ${(err as Error).message}`));
+    }
+    throw err;
+  }
+}

--- a/packages/daemon/src/cli/stop.ts
+++ b/packages/daemon/src/cli/stop.ts
@@ -1,0 +1,49 @@
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+
+import pc from 'picocolors';
+
+import { defaultPidFilePath } from './paths.js';
+
+export type KillFn = (pid: number, signal: NodeJS.Signals) => void;
+
+export interface StopDeps {
+  pidFilePath?: string;
+  kill: KillFn;
+  isProcessAlive: (pid: number) => boolean;
+  log?: (line: string) => void;
+}
+
+export interface StopResult {
+  stopped: boolean;
+}
+
+const NOT_RUNNING_MESSAGE = '데몬이 실행 중이지 않습니다.';
+
+export async function runStop(deps: StopDeps): Promise<StopResult> {
+  const log = deps.log ?? ((l: string) => console.log(l));
+  const pidFilePath = deps.pidFilePath ?? defaultPidFilePath();
+
+  if (!existsSync(pidFilePath)) {
+    log(pc.yellow(NOT_RUNNING_MESSAGE));
+    return { stopped: false };
+  }
+
+  const raw = readFileSync(pidFilePath, 'utf-8').trim();
+  const pid = Number.parseInt(raw, 10);
+  if (!Number.isFinite(pid) || pid <= 0) {
+    rmSync(pidFilePath, { force: true });
+    log(pc.yellow(NOT_RUNNING_MESSAGE));
+    return { stopped: false };
+  }
+
+  if (!deps.isProcessAlive(pid)) {
+    rmSync(pidFilePath, { force: true });
+    log(pc.yellow(NOT_RUNNING_MESSAGE));
+    return { stopped: false };
+  }
+
+  deps.kill(pid, 'SIGTERM');
+  rmSync(pidFilePath, { force: true });
+  log(pc.green(`✓ 데몬을 정지했습니다 (PID ${pid}).`));
+  return { stopped: true };
+}

--- a/packages/daemon/src/cli/wizard.ts
+++ b/packages/daemon/src/cli/wizard.ts
@@ -1,0 +1,153 @@
+import type { ConsentType } from '@onboarding/shared';
+import pc from 'picocolors';
+
+import type { DatabaseInstance } from '../db/index.js';
+import { launchSystemPanel as defaultLaunchSystemPanel } from '../p5-system-panel/index.js';
+import { DEFAULT_BASE_URL } from './paths.js';
+
+export type PromptInput = (q: { message: string }) => Promise<string>;
+export type PromptConfirm = (q: { message: string }) => Promise<boolean>;
+export type PromptPress = (q: { message: string }) => Promise<void>;
+
+export interface WizardDeps {
+  db: DatabaseInstance;
+  baseUrl?: string;
+  fetch?: typeof globalThis.fetch;
+  log?: (line: string) => void;
+  promptInput: PromptInput;
+  promptConfirm: PromptConfirm;
+  promptPress: PromptPress;
+  launchSystemPanel?: (url: string) => Promise<void>;
+  platform?: NodeJS.Platform;
+  now?: () => number;
+}
+
+export interface WizardResult {
+  skipped: boolean;
+}
+
+const SCREEN_RECORDING_PANEL_URL =
+  'x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture';
+
+export function profileExists(db: DatabaseInstance): boolean {
+  const row = db
+    .prepare('SELECT employee_id FROM profile LIMIT 1')
+    .get() as { employee_id?: string } | undefined;
+  return Boolean(row?.employee_id);
+}
+
+interface ProfileInputs {
+  name: string;
+  email: string;
+  employeeId: string;
+  role: string;
+  phone: string;
+}
+
+async function promptProfile(
+  promptInput: PromptInput,
+): Promise<ProfileInputs> {
+  const name = (await promptInput({ message: '이름을 입력하세요' })).trim();
+  const email = (await promptInput({ message: '이메일을 입력하세요' })).trim();
+  const employeeId = (
+    await promptInput({ message: '사번 (Employee ID)을 입력하세요' })
+  ).trim();
+  const role = (await promptInput({ message: '직무를 입력하세요' })).trim();
+  const phone = (await promptInput({ message: '전화번호를 입력하세요' })).trim();
+  return { name, email, employeeId, role, phone };
+}
+
+function insertProfile(
+  db: DatabaseInstance,
+  inputs: ProfileInputs,
+  now: number,
+): void {
+  db.prepare(
+    'INSERT INTO profile (employee_id, email, name, created_at) VALUES (?, ?, ?, ?)',
+  ).run(inputs.employeeId, inputs.email, inputs.name, now);
+}
+
+async function postConsent(
+  fetchImpl: typeof globalThis.fetch,
+  baseUrl: string,
+  type: ConsentType,
+  granted: boolean,
+): Promise<void> {
+  const res = await fetchImpl(`${baseUrl}/api/consents`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ consent_type: type, granted }),
+  });
+  if (!res.ok) {
+    throw new Error(
+      `consent_post_failed: ${type} status=${res.status}`,
+    );
+  }
+}
+
+export async function runWizard(deps: WizardDeps): Promise<WizardResult> {
+  const log = deps.log ?? ((line: string) => console.log(line));
+  const baseUrl = deps.baseUrl ?? DEFAULT_BASE_URL;
+  const fetchImpl = deps.fetch ?? globalThis.fetch;
+  const platform = deps.platform ?? process.platform;
+  const launch = deps.launchSystemPanel ?? ((url) =>
+    defaultLaunchSystemPanel(url, { platform }));
+  const now = deps.now ?? Date.now;
+
+  if (profileExists(deps.db)) {
+    return { skipped: true };
+  }
+
+  log(pc.bold('환영합니다! 입사 첫날 환경 설정을 시작합니다.'));
+  log('');
+
+  log(pc.bold('1) 사용자 정보를 입력하세요.'));
+  const inputs = await promptProfile(deps.promptInput);
+  insertProfile(deps.db, inputs, now());
+  log(pc.green('  ✓ 프로필이 저장되었습니다.'));
+  log('');
+
+  log(pc.bold('2) Screen Recording 권한 부여'));
+  if (platform === 'darwin') {
+    log('  시스템 설정 → 개인정보 보호 및 보안 → 화면 기록 패널을 엽니다.');
+    log('  목록에서 onboarding을 찾아 권한을 부여한 뒤 ENTER를 눌러주세요.');
+    try {
+      await launch(SCREEN_RECORDING_PANEL_URL);
+    } catch (err) {
+      log(
+        pc.yellow(
+          `  시스템 설정을 자동으로 열지 못했습니다: ${(err as Error).message}`,
+        ),
+      );
+    }
+    await deps.promptPress({ message: '권한 부여 후 ENTER 키를 눌러주세요.' });
+    log(pc.green('  ✓ Screen Recording 권한 안내를 완료했습니다.'));
+  } else {
+    log(pc.yellow('  현재 macOS가 아닙니다. 이 단계를 건너뜁니다.'));
+  }
+  log('');
+
+  log(pc.bold('3) Anthropic 전송 동의'));
+  log('  화면 캡처 이미지를 Anthropic Claude API로 전송하여 안내를 생성합니다.');
+  log('  이미지는 응답 직후 즉시 파기되며 디스크에 저장되지 않습니다.');
+  const anthropicGranted = await deps.promptConfirm({
+    message: 'Anthropic 전송에 동의합니까?',
+  });
+  await postConsent(
+    fetchImpl,
+    baseUrl,
+    'anthropic_transmission',
+    anthropicGranted,
+  );
+  if (anthropicGranted) {
+    log(pc.green('  ✓ Anthropic 전송 동의가 기록되었습니다.'));
+  } else {
+    log(
+      pc.yellow(
+        '  동의가 거부되었습니다. AI Vision 기능 없이 결정론적 자동화만 사용합니다.',
+      ),
+    );
+  }
+
+  return { skipped: false };
+}

--- a/packages/daemon/tests/cli-control.test.ts
+++ b/packages/daemon/tests/cli-control.test.ts
@@ -1,0 +1,293 @@
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  runReset,
+  type ResetDeps,
+} from '../src/cli/reset.js';
+import {
+  runStart,
+  type StartDeps,
+} from '../src/cli/start.js';
+import {
+  runStop,
+  type StopDeps,
+} from '../src/cli/stop.js';
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'onboarding-cli-control-'));
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('runStart', () => {
+  it('spawns the daemon detached, writes a pidfile, and runs the wizard when first run', async () => {
+    const pidPath = join(tmp, 'daemon.pid');
+    const spawn = vi.fn(() => ({
+      pid: 4242,
+      unref: vi.fn(),
+    }));
+    const wizard = vi.fn(async () => ({ skipped: false }));
+    const logs: string[] = [];
+
+    const deps: StartDeps = {
+      pidFilePath: pidPath,
+      dbFilePath: join(tmp, 'agent.db'),
+      spawn: spawn as unknown as StartDeps['spawn'],
+      runWizard: wizard,
+      isProcessAlive: () => false,
+      log: (l) => logs.push(l),
+      waitForReady: vi.fn(async () => true),
+      env: {},
+      now: () => 1700000000000,
+    };
+
+    await runStart(deps);
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(existsSync(pidPath)).toBe(true);
+    expect(readFileSync(pidPath, 'utf-8').trim()).toBe('4242');
+    expect(wizard).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not start a second daemon when one is already running', async () => {
+    const pidPath = join(tmp, 'daemon.pid');
+    writeFileSync(pidPath, '5151', 'utf-8');
+    const spawn = vi.fn();
+    const wizard = vi.fn(async () => ({ skipped: true }));
+    const logs: string[] = [];
+    const deps: StartDeps = {
+      pidFilePath: pidPath,
+      dbFilePath: join(tmp, 'agent.db'),
+      spawn: spawn as unknown as StartDeps['spawn'],
+      runWizard: wizard,
+      isProcessAlive: () => true,
+      log: (l) => logs.push(l),
+      waitForReady: vi.fn(async () => true),
+      env: {},
+      now: () => 1,
+    };
+    await runStart(deps);
+    expect(spawn).not.toHaveBeenCalled();
+    expect(logs.some((l) => l.includes('이미') || l.includes('실행'))).toBe(true);
+  });
+
+  it('skips wizard when waitForReady fails to connect', async () => {
+    const pidPath = join(tmp, 'daemon.pid');
+    const spawn = vi.fn(() => ({
+      pid: 4242,
+      unref: vi.fn(),
+    }));
+    const wizard = vi.fn(async () => ({ skipped: true }));
+    const logs: string[] = [];
+    const deps: StartDeps = {
+      pidFilePath: pidPath,
+      dbFilePath: join(tmp, 'agent.db'),
+      spawn: spawn as unknown as StartDeps['spawn'],
+      runWizard: wizard,
+      isProcessAlive: () => false,
+      log: (l) => logs.push(l),
+      waitForReady: vi.fn(async () => false),
+      env: {},
+      now: () => 1,
+    };
+    await runStart(deps);
+    expect(wizard).not.toHaveBeenCalled();
+    expect(logs.some((l) => /시작|기동|실패/.test(l))).toBe(true);
+  });
+
+  it('replaces a stale pidfile when the recorded process is no longer alive', async () => {
+    const pidPath = join(tmp, 'daemon.pid');
+    writeFileSync(pidPath, '99999', 'utf-8');
+    const spawn = vi.fn(() => ({ pid: 1234, unref: vi.fn() }));
+    const wizard = vi.fn(async () => ({ skipped: false }));
+    const deps: StartDeps = {
+      pidFilePath: pidPath,
+      dbFilePath: join(tmp, 'agent.db'),
+      spawn: spawn as unknown as StartDeps['spawn'],
+      runWizard: wizard,
+      isProcessAlive: () => false,
+      log: () => undefined,
+      waitForReady: vi.fn(async () => true),
+      env: {},
+      now: () => 1,
+    };
+    await runStart(deps);
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(readFileSync(pidPath, 'utf-8').trim()).toBe('1234');
+  });
+
+  it('reports "이미 완료" when the wizard reports skipped after start', async () => {
+    const pidPath = join(tmp, 'daemon.pid');
+    const spawn = vi.fn(() => ({ pid: 1234, unref: vi.fn() }));
+    const wizard = vi.fn(async () => ({ skipped: true }));
+    const logs: string[] = [];
+    const deps: StartDeps = {
+      pidFilePath: pidPath,
+      dbFilePath: join(tmp, 'agent.db'),
+      spawn: spawn as unknown as StartDeps['spawn'],
+      runWizard: wizard,
+      isProcessAlive: () => false,
+      log: (l) => logs.push(l),
+      waitForReady: vi.fn(async () => true),
+      env: {},
+      now: () => 1,
+    };
+    await runStart(deps);
+    expect(wizard).toHaveBeenCalledTimes(1);
+    expect(logs.some((l) => l.includes('위저드'))).toBe(true);
+  });
+});
+
+describe('runStop', () => {
+  it('reads the pidfile, sends SIGTERM, and removes the pidfile', async () => {
+    const pidPath = join(tmp, 'daemon.pid');
+    writeFileSync(pidPath, '7777', 'utf-8');
+    const kill = vi.fn();
+    const logs: string[] = [];
+    const deps: StopDeps = {
+      pidFilePath: pidPath,
+      kill: kill as unknown as StopDeps['kill'],
+      isProcessAlive: () => true,
+      log: (l) => logs.push(l),
+    };
+    const result = await runStop(deps);
+    expect(result.stopped).toBe(true);
+    expect(kill).toHaveBeenCalledWith(7777, 'SIGTERM');
+    expect(existsSync(pidPath)).toBe(false);
+  });
+
+  it('reports "데몬이 실행 중이지 않음" when no pidfile exists', async () => {
+    const pidPath = join(tmp, 'daemon.pid');
+    const kill = vi.fn();
+    const logs: string[] = [];
+    const deps: StopDeps = {
+      pidFilePath: pidPath,
+      kill: kill as unknown as StopDeps['kill'],
+      isProcessAlive: () => false,
+      log: (l) => logs.push(l),
+    };
+    const result = await runStop(deps);
+    expect(result.stopped).toBe(false);
+    expect(kill).not.toHaveBeenCalled();
+    expect(logs.some((l) => l.includes('실행 중이지 않'))).toBe(true);
+  });
+
+  it('reports "데몬이 실행 중이지 않음" when pidfile exists but the process is dead', async () => {
+    const pidPath = join(tmp, 'daemon.pid');
+    writeFileSync(pidPath, '99999', 'utf-8');
+    const kill = vi.fn();
+    const logs: string[] = [];
+    const deps: StopDeps = {
+      pidFilePath: pidPath,
+      kill: kill as unknown as StopDeps['kill'],
+      isProcessAlive: () => false,
+      log: (l) => logs.push(l),
+    };
+    const result = await runStop(deps);
+    expect(result.stopped).toBe(false);
+    expect(kill).not.toHaveBeenCalled();
+    expect(existsSync(pidPath)).toBe(false);
+    expect(logs.some((l) => l.includes('실행 중이지 않'))).toBe(true);
+  });
+
+  it('removes the pidfile and reports not-running when contents are not a valid number', async () => {
+    const pidPath = join(tmp, 'daemon.pid');
+    writeFileSync(pidPath, 'not-a-number', 'utf-8');
+    const kill = vi.fn();
+    const logs: string[] = [];
+    const deps: StopDeps = {
+      pidFilePath: pidPath,
+      kill: kill as unknown as StopDeps['kill'],
+      isProcessAlive: () => true,
+      log: (l) => logs.push(l),
+    };
+    const result = await runStop(deps);
+    expect(result.stopped).toBe(false);
+    expect(kill).not.toHaveBeenCalled();
+    expect(existsSync(pidPath)).toBe(false);
+  });
+});
+
+describe('runReset', () => {
+  it('requires confirm prompt when --yes is not set', async () => {
+    const dbPath = join(tmp, 'agent.db');
+    writeFileSync(dbPath, 'fake', 'utf-8');
+    const promptConfirm = vi.fn(async () => false);
+    const logs: string[] = [];
+    const deps: ResetDeps = {
+      dbFilePath: dbPath,
+      yes: false,
+      promptConfirm:
+        promptConfirm as unknown as ResetDeps['promptConfirm'],
+      log: (l) => logs.push(l),
+    };
+    const result = await runReset(deps);
+    expect(result.deleted).toBe(false);
+    expect(promptConfirm).toHaveBeenCalledTimes(1);
+    expect(existsSync(dbPath)).toBe(true);
+  });
+
+  it('deletes the SQLite file when confirmed', async () => {
+    const dbPath = join(tmp, 'agent.db');
+    writeFileSync(dbPath, 'fake', 'utf-8');
+    const promptConfirm = vi.fn(async () => true);
+    const logs: string[] = [];
+    const deps: ResetDeps = {
+      dbFilePath: dbPath,
+      yes: false,
+      promptConfirm:
+        promptConfirm as unknown as ResetDeps['promptConfirm'],
+      log: (l) => logs.push(l),
+    };
+    const result = await runReset(deps);
+    expect(result.deleted).toBe(true);
+    expect(existsSync(dbPath)).toBe(false);
+  });
+
+  it('skips the prompt when --yes flag is set', async () => {
+    const dbPath = join(tmp, 'agent.db');
+    writeFileSync(dbPath, 'fake', 'utf-8');
+    const promptConfirm = vi.fn(async () => false);
+    const logs: string[] = [];
+    const deps: ResetDeps = {
+      dbFilePath: dbPath,
+      yes: true,
+      promptConfirm:
+        promptConfirm as unknown as ResetDeps['promptConfirm'],
+      log: (l) => logs.push(l),
+    };
+    const result = await runReset(deps);
+    expect(result.deleted).toBe(true);
+    expect(promptConfirm).not.toHaveBeenCalled();
+    expect(existsSync(dbPath)).toBe(false);
+  });
+
+  it('reports a friendly message when there is no database to delete', async () => {
+    const dbPath = join(tmp, 'agent.db');
+    const promptConfirm = vi.fn(async () => true);
+    const logs: string[] = [];
+    const deps: ResetDeps = {
+      dbFilePath: dbPath,
+      yes: true,
+      promptConfirm:
+        promptConfirm as unknown as ResetDeps['promptConfirm'],
+      log: (l) => logs.push(l),
+    };
+    const result = await runReset(deps);
+    expect(result.deleted).toBe(false);
+    expect(logs.some((l) => /이미|없|초기/.test(l))).toBe(true);
+  });
+});

--- a/packages/daemon/tests/cli-paths.test.ts
+++ b/packages/daemon/tests/cli-paths.test.ts
@@ -1,0 +1,33 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_BASE_URL,
+  defaultDbFilePath,
+  defaultPidFilePath,
+  onboardingHome,
+} from '../src/cli/paths.js';
+
+describe('cli paths', () => {
+  it('points DEFAULT_BASE_URL at localhost:7777 (PRD §9)', () => {
+    expect(DEFAULT_BASE_URL).toBe('http://localhost:7777');
+  });
+
+  it('onboardingHome is ~/.onboarding', () => {
+    expect(onboardingHome()).toBe(join(homedir(), '.onboarding'));
+  });
+
+  it('defaultPidFilePath is ~/.onboarding/daemon.pid', () => {
+    expect(defaultPidFilePath()).toBe(
+      join(homedir(), '.onboarding', 'daemon.pid'),
+    );
+  });
+
+  it('defaultDbFilePath matches the daemon defaultDbPath layout', () => {
+    expect(defaultDbFilePath()).toBe(
+      join(homedir(), '.onboarding', 'agent.db'),
+    );
+  });
+});

--- a/packages/daemon/tests/cli-status.test.ts
+++ b/packages/daemon/tests/cli-status.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  fetchDaemonStatus,
+  renderStatus,
+  runStatus,
+  type DaemonStatusSnapshot,
+} from '../src/cli/status.js';
+
+function makeFetchStub(responses: Record<string, unknown>): typeof fetch {
+  return vi.fn(async (input: Parameters<typeof fetch>[0]) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    for (const [match, body] of Object.entries(responses)) {
+      if (url.endsWith(match)) {
+        return new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+    }
+    return new Response(JSON.stringify({ error: 'not_found' }), { status: 404 });
+  }) as unknown as typeof fetch;
+}
+
+const SAMPLE_RESPONSES = {
+  '/api/checklist': {
+    items: [
+      {
+        item_id: 'install-homebrew',
+        title: 'Homebrew 설치',
+        status: 'completed',
+        current_step: null,
+        started_at: 1,
+        completed_at: 2,
+        attempt_count: 1,
+      },
+      {
+        item_id: 'configure-git',
+        title: 'Git 글로벌 설정',
+        status: 'pending',
+        current_step: null,
+        started_at: null,
+        completed_at: null,
+        attempt_count: 0,
+      },
+    ],
+  },
+  '/api/consents': {
+    screen_recording: {
+      consent_type: 'screen_recording',
+      granted: true,
+      granted_at: 1,
+      revoked_at: null,
+    },
+    anthropic_transmission: {
+      consent_type: 'anthropic_transmission',
+      granted: false,
+      granted_at: null,
+      revoked_at: null,
+    },
+  },
+  '/api/vision/rate-limit': {
+    current_hour_calls: 12,
+    state: 'ok',
+    reset_at: 1700000000000,
+  },
+};
+
+describe('fetchDaemonStatus', () => {
+  it('calls the three daemon endpoints with the given baseUrl', async () => {
+    const stub = makeFetchStub(SAMPLE_RESPONSES);
+    const snapshot = await fetchDaemonStatus({
+      baseUrl: 'http://localhost:7777',
+      fetch: stub,
+    });
+    expect(stub).toHaveBeenCalledTimes(3);
+    const calls = (stub as unknown as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c) => String(c[0]),
+    );
+    expect(calls).toContain('http://localhost:7777/api/checklist');
+    expect(calls).toContain('http://localhost:7777/api/consents');
+    expect(calls).toContain('http://localhost:7777/api/vision/rate-limit');
+    expect(snapshot.checklist.items).toHaveLength(2);
+    expect(snapshot.consents.anthropic_transmission.granted).toBe(false);
+    expect(snapshot.rateLimit.state).toBe('ok');
+  });
+
+  it('falls back to the default base URL (localhost:7777) when none is provided', async () => {
+    const stub = makeFetchStub(SAMPLE_RESPONSES);
+    await fetchDaemonStatus({ fetch: stub });
+    const calls = (stub as unknown as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c) => String(c[0]),
+    );
+    expect(calls.every((u) => u.startsWith('http://localhost:7777/'))).toBe(true);
+  });
+
+  it('throws DaemonUnreachableError when fetch rejects (daemon not running)', async () => {
+    const stub = vi.fn(async () => {
+      throw new Error('ECONNREFUSED');
+    }) as unknown as typeof fetch;
+    await expect(
+      fetchDaemonStatus({ fetch: stub, baseUrl: 'http://localhost:7777' }),
+    ).rejects.toMatchObject({ code: 'daemon_unreachable' });
+  });
+
+  it('throws when an endpoint returns non-2xx', async () => {
+    const stub = vi.fn(async () =>
+      new Response('boom', { status: 500 }),
+    ) as unknown as typeof fetch;
+    await expect(
+      fetchDaemonStatus({ fetch: stub, baseUrl: 'http://localhost:7777' }),
+    ).rejects.toThrow();
+  });
+});
+
+describe('renderStatus', () => {
+  const snapshot: DaemonStatusSnapshot = {
+    checklist: SAMPLE_RESPONSES['/api/checklist'] as DaemonStatusSnapshot['checklist'],
+    consents: SAMPLE_RESPONSES['/api/consents'] as DaemonStatusSnapshot['consents'],
+    rateLimit: SAMPLE_RESPONSES['/api/vision/rate-limit'] as DaemonStatusSnapshot['rateLimit'],
+  };
+
+  it('renders Korean output with item titles, consent state and rate limit', () => {
+    const lines: string[] = [];
+    renderStatus(snapshot, (line) => lines.push(line));
+    const all = lines.join('\n');
+    expect(all).toContain('체크리스트');
+    expect(all).toContain('Homebrew 설치');
+    expect(all).toContain('Git 글로벌 설정');
+    expect(all).toContain('동의');
+    expect(all).toContain('Anthropic');
+    expect(all).toContain('Vision');
+    expect(all).toContain('12');
+  });
+
+  it('marks completed items distinctly from pending ones', () => {
+    const lines: string[] = [];
+    renderStatus(snapshot, (line) => lines.push(line));
+    const homebrewLine = lines.find((l) => l.includes('Homebrew 설치'));
+    const gitLine = lines.find((l) => l.includes('Git 글로벌 설정'));
+    expect(homebrewLine).toBeDefined();
+    expect(gitLine).toBeDefined();
+    expect(homebrewLine).not.toEqual(gitLine);
+  });
+
+  it('shows Anthropic 동의 미부여 when not granted', () => {
+    const lines: string[] = [];
+    renderStatus(snapshot, (line) => lines.push(line));
+    const consentLine = lines.find((l) => l.includes('Anthropic'));
+    expect(consentLine).toMatch(/미부여|미동의/);
+  });
+});
+
+describe('runStatus', () => {
+  it('orchestrates fetch + render and returns the snapshot', async () => {
+    const stub = makeFetchStub(SAMPLE_RESPONSES);
+    const lines: string[] = [];
+    const result = await runStatus({
+      baseUrl: 'http://localhost:7777',
+      fetch: stub,
+      log: (l) => lines.push(l),
+    });
+    expect(result.checklist.items).toHaveLength(2);
+    expect(lines.join('\n')).toContain('Homebrew 설치');
+  });
+
+  it('logs a friendly daemon-unreachable message and rethrows', async () => {
+    const stub = vi.fn(async () => {
+      throw new Error('ECONNREFUSED');
+    }) as unknown as typeof fetch;
+    const lines: string[] = [];
+    await expect(
+      runStatus({
+        baseUrl: 'http://localhost:7777',
+        fetch: stub,
+        log: (l) => lines.push(l),
+      }),
+    ).rejects.toMatchObject({ code: 'daemon_unreachable' });
+    expect(lines.join('\n')).toMatch(/데몬|실행/);
+  });
+});

--- a/packages/daemon/tests/cli-wizard.test.ts
+++ b/packages/daemon/tests/cli-wizard.test.ts
@@ -1,0 +1,214 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { runWizard, type WizardDeps } from '../src/cli/wizard.js';
+import { openDatabase, type DatabaseInstance } from '../src/db/index.js';
+import { migrate } from '../src/db/migrate.js';
+
+interface ProfileRow {
+  employee_id: string;
+  email: string;
+  name: string;
+  created_at: number;
+}
+
+function createTempDb(): { db: DatabaseInstance; cleanup: () => void } {
+  const dir = mkdtempSync(join(tmpdir(), 'onboarding-cli-wizard-'));
+  const db = openDatabase(join(dir, 'agent.db'));
+  migrate(db);
+  return {
+    db,
+    cleanup: () => {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+function makeFetchStub(): ReturnType<typeof vi.fn> {
+  return vi.fn(async (input: Parameters<typeof fetch>[0]) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    if (url.endsWith('/api/consents')) {
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    return new Response('{}', { status: 200 });
+  });
+}
+
+function makeBaseDeps(
+  overrides: Partial<WizardDeps> & { db: DatabaseInstance },
+): WizardDeps & { fetchStub: ReturnType<typeof vi.fn>; logs: string[] } {
+  const logs: string[] = [];
+  const fetchStub =
+    (overrides.fetch as ReturnType<typeof vi.fn> | undefined) ?? makeFetchStub();
+  return {
+    fetchStub,
+    logs,
+    baseUrl: 'http://localhost:7777',
+    fetch: fetchStub as unknown as typeof fetch,
+    log: (line: string) => logs.push(line),
+    promptInput: vi.fn(async ({ message }: { message: string }) => {
+      if (message.includes('이름')) return '김하나';
+      if (message.includes('이메일')) return 'hana@wrtn.io';
+      if (message.includes('직무')) return 'Frontend';
+      if (message.includes('전화')) return '010-1234-5678';
+      if (message.includes('사번') || message.includes('Employee')) return 'E0001';
+      return '';
+    }) as unknown as WizardDeps['promptInput'],
+    promptConfirm: vi.fn(async () => true) as unknown as WizardDeps['promptConfirm'],
+    promptPress: vi.fn(async () => undefined) as unknown as WizardDeps['promptPress'],
+    launchSystemPanel: vi.fn(async () => undefined) as unknown as WizardDeps['launchSystemPanel'],
+    platform: 'darwin',
+    now: () => 1700000000000,
+    ...overrides,
+  };
+}
+
+describe('runWizard — first run', () => {
+  it('inserts the user profile, posts anthropic consent, and shows screen-recording guide', async () => {
+    const { db, cleanup } = createTempDb();
+    try {
+      const deps = makeBaseDeps({ db });
+      const result = await runWizard(deps);
+      expect(result.skipped).toBe(false);
+
+      const profile = db
+        .prepare('SELECT employee_id, email, name, created_at FROM profile')
+        .get() as ProfileRow | undefined;
+      expect(profile).toBeDefined();
+      expect(profile?.email).toBe('hana@wrtn.io');
+      expect(profile?.name).toBe('김하나');
+
+      const consentCalls = deps.fetchStub.mock.calls.filter((c) =>
+        String(c[0]).endsWith('/api/consents'),
+      );
+      expect(consentCalls.length).toBeGreaterThanOrEqual(1);
+      const last = consentCalls.at(-1)!;
+      const init = last[1] as RequestInit;
+      expect(init.method).toBe('POST');
+      const body = JSON.parse(String(init.body));
+      expect(body).toEqual({
+        consent_type: 'anthropic_transmission',
+        granted: true,
+      });
+
+      expect(deps.launchSystemPanel).toHaveBeenCalledTimes(1);
+      const url = (deps.launchSystemPanel as ReturnType<typeof vi.fn>).mock
+        .calls[0]![0];
+      expect(String(url)).toContain('Privacy_ScreenCapture');
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('does not POST consent when user denies anthropic transmission', async () => {
+    const { db, cleanup } = createTempDb();
+    try {
+      const promptConfirm = vi.fn(async ({ message }: { message: string }) => {
+        if (message.includes('Anthropic')) return false;
+        return true;
+      });
+      const deps = makeBaseDeps({
+        db,
+        promptConfirm: promptConfirm as unknown as WizardDeps['promptConfirm'],
+      });
+      const result = await runWizard(deps);
+      expect(result.skipped).toBe(false);
+      const consentCalls = deps.fetchStub.mock.calls.filter((c) =>
+        String(c[0]).endsWith('/api/consents'),
+      );
+      const granted = consentCalls.map((c) => {
+        const init = c[1] as RequestInit;
+        return JSON.parse(String(init.body));
+      });
+      expect(granted.some((g) => g.granted === true)).toBe(false);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe('runWizard — repeat run skip', () => {
+  it('returns skipped=true when profile already exists (AC-CORE-02)', async () => {
+    const { db, cleanup } = createTempDb();
+    try {
+      db.prepare(
+        'INSERT INTO profile (employee_id, email, name, created_at) VALUES (?, ?, ?, ?)',
+      ).run('E0001', 'hana@wrtn.io', '김하나', 1);
+      const deps = makeBaseDeps({ db });
+      const result = await runWizard(deps);
+      expect(result.skipped).toBe(true);
+      expect(deps.promptInput).not.toHaveBeenCalled();
+      expect(deps.fetchStub).not.toHaveBeenCalled();
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe('runWizard — non-darwin', () => {
+  it('skips launching the system panel and prints a notice on linux', async () => {
+    const { db, cleanup } = createTempDb();
+    try {
+      const launchSystemPanel = vi.fn(async () => undefined);
+      const deps = makeBaseDeps({
+        db,
+        platform: 'linux',
+        launchSystemPanel:
+          launchSystemPanel as unknown as WizardDeps['launchSystemPanel'],
+      });
+      const result = await runWizard(deps);
+      expect(result.skipped).toBe(false);
+      expect(launchSystemPanel).not.toHaveBeenCalled();
+      expect(deps.logs.some((l) => /macOS/.test(l))).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe('runWizard — error handling', () => {
+  it('logs but does not abort when the system-panel launch fails', async () => {
+    const { db, cleanup } = createTempDb();
+    try {
+      const launchSystemPanel = vi.fn(async () => {
+        throw new Error('open exited 1');
+      });
+      const deps = makeBaseDeps({
+        db,
+        launchSystemPanel:
+          launchSystemPanel as unknown as WizardDeps['launchSystemPanel'],
+      });
+      const result = await runWizard(deps);
+      expect(result.skipped).toBe(false);
+      expect(launchSystemPanel).toHaveBeenCalledTimes(1);
+      expect(deps.logs.some((l) => l.includes('자동으로 열지 못했습니다'))).toBe(
+        true,
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('throws when the consents endpoint returns non-2xx', async () => {
+    const { db, cleanup } = createTempDb();
+    try {
+      const fetchStub = vi.fn(async () =>
+        new Response('boom', { status: 500 }),
+      );
+      const deps = makeBaseDeps({
+        db,
+        fetch: fetchStub as unknown as typeof fetch,
+      });
+      await expect(runWizard(deps)).rejects.toThrow(/consent_post_failed/);
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/packages/daemon/vitest.config.ts
+++ b/packages/daemon/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'json-summary'],
       include: ['src/**/*.ts'],
-      exclude: ['src/index.ts'],
+      exclude: ['src/index.ts', 'src/cli/index.ts'],
       thresholds: {
         lines: 80,
         functions: 80,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,18 +13,30 @@ importers:
       '@anthropic-ai/sdk':
         specifier: ^0.30.0
         version: 0.30.1
+      '@inquirer/prompts':
+        specifier: ^5.0.0
+        version: 5.5.0
       '@onboarding/shared':
         specifier: workspace:*
         version: link:../shared
       better-sqlite3:
         specifier: ^11.0.0
         version: 11.10.0
+      commander:
+        specifier: ^12.0.0
+        version: 12.1.0
       execa:
         specifier: ^9.0.0
         version: 9.6.1
       express:
         specifier: ^4.19.2
         version: 4.22.1
+      ora:
+        specifier: ^8.0.0
+        version: 8.2.0
+      picocolors:
+        specifier: ^1.0.0
+        version: 1.1.1
       pino:
         specifier: ^9.0.0
         version: 9.14.0
@@ -373,6 +385,14 @@ packages:
     resolution: {integrity: sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
 
+  '@inquirer/checkbox@2.5.0':
+    resolution: {integrity: sha512-sMgdETOfi2dUHT8r7TT1BTKOwNvdDGFDXYWtQ2J69SvlYNntk9I/gJe7r5yvMwwsuKnYbuRs3pNhx4tgNck5aA==}
+    engines: {node: '>=18'}
+
+  '@inquirer/confirm@3.2.0':
+    resolution: {integrity: sha512-oOIwPs0Dvq5220Z8lGL/6LHRTEr9TgLHmiI99Rj1PJ1p1czTys+olrgBqZk4E2qC0YTzeHprxSQmoHioVdJ7Lw==}
+    engines: {node: '>=18'}
+
   '@inquirer/confirm@6.0.12':
     resolution: {integrity: sha512-h9FgGun3QwVYNj5TWIZZ+slii73bMoBFjPfVIGtnFuL4t8gBiNDV9PcSfIzkuxvgquJKt9nr1QzszpBzTbH8Og==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
@@ -391,9 +411,61 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/core@9.2.1':
+    resolution: {integrity: sha512-F2VBt7W/mwqEU4bL0RnHNZmC/OxzNx9cOYxHqnXX3MP6ruYvZUZAW9imgN9+h/uBT/oP8Gh888J2OZSbjSeWcg==}
+    engines: {node: '>=18'}
+
+  '@inquirer/editor@2.2.0':
+    resolution: {integrity: sha512-9KHOpJ+dIL5SZli8lJ6xdaYLPPzB8xB9GZItg39MBybzhxA16vxmszmQFrRwbOA918WA2rvu8xhDEg/p6LXKbw==}
+    engines: {node: '>=18'}
+
+  '@inquirer/expand@2.3.0':
+    resolution: {integrity: sha512-qnJsUcOGCSG1e5DTOErmv2BPQqrtT6uzqn1vI/aYGiPKq+FgslGZmtdnXbhuI7IlT7OByDoEEqdnhUnVR2hhLw==}
+    engines: {node: '>=18'}
+
+  '@inquirer/figures@1.0.15':
+    resolution: {integrity: sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==}
+    engines: {node: '>=18'}
+
   '@inquirer/figures@2.0.5':
     resolution: {integrity: sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+
+  '@inquirer/input@2.3.0':
+    resolution: {integrity: sha512-XfnpCStx2xgh1LIRqPXrTNEEByqQWoxsWYzNRSEUxJ5c6EQlhMogJ3vHKu8aXuTacebtaZzMAHwEL0kAflKOBw==}
+    engines: {node: '>=18'}
+
+  '@inquirer/number@1.1.0':
+    resolution: {integrity: sha512-ilUnia/GZUtfSZy3YEErXLJ2Sljo/mf9fiKc08n18DdwdmDbOzRcTv65H1jjDvlsAuvdFXf4Sa/aL7iw/NanVA==}
+    engines: {node: '>=18'}
+
+  '@inquirer/password@2.2.0':
+    resolution: {integrity: sha512-5otqIpgsPYIshqhgtEwSspBQE40etouR8VIxzpJkv9i0dVHIpyhiivbkH9/dGiMLdyamT54YRdGJLfl8TFnLHg==}
+    engines: {node: '>=18'}
+
+  '@inquirer/prompts@5.5.0':
+    resolution: {integrity: sha512-BHDeL0catgHdcHbSFFUddNzvx/imzJMft+tWDPwTm3hfu8/tApk1HrooNngB2Mb4qY+KaRWF+iZqoVUPeslEog==}
+    engines: {node: '>=18'}
+
+  '@inquirer/rawlist@2.3.0':
+    resolution: {integrity: sha512-zzfNuINhFF7OLAtGHfhwOW2TlYJyli7lOUoJUXw/uyklcwalV6WRXBXtFIicN8rTRK1XTiPWB4UY+YuW8dsnLQ==}
+    engines: {node: '>=18'}
+
+  '@inquirer/search@1.1.0':
+    resolution: {integrity: sha512-h+/5LSj51dx7hp5xOn4QFnUaKeARwUCLs6mIhtkJ0JYPBLmEYjdHSYh7I6GrLg9LwpJ3xeX0FZgAG1q0QdCpVQ==}
+    engines: {node: '>=18'}
+
+  '@inquirer/select@2.5.0':
+    resolution: {integrity: sha512-YmDobTItPP3WcEI86GvPo+T2sRHkxxOq/kXmsBjHS5BVXUgvgZ5AfJjkvQvZr03T81NnI3KrrRuMzeuYUQRFOA==}
+    engines: {node: '>=18'}
+
+  '@inquirer/type@1.5.5':
+    resolution: {integrity: sha512-MzICLu4yS7V8AA61sANROZ9vT1H3ooca5dSmI1FjZkzq7o/koMsRfQSzRtFo+F3Ao4Sf1C0bpLKejpKB/+j6MA==}
+    engines: {node: '>=18'}
+
+  '@inquirer/type@2.0.0':
+    resolution: {integrity: sha512-XvJRx+2KR3YXyYtPUUy+qd9i7p+GO9Ko6VIIpWlBrpWwXDv8WLFeHTxz35CfQFUiBMLXlGHhGzys7lqit9gWag==}
+    engines: {node: '>=18'}
 
   '@inquirer/type@4.0.5':
     resolution: {integrity: sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==}
@@ -630,6 +702,9 @@ packages:
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
 
+  '@types/mute-stream@0.0.4':
+    resolution: {integrity: sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==}
+
   '@types/node-fetch@2.6.13':
     resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
 
@@ -665,6 +740,9 @@ packages:
 
   '@types/supertest@6.0.3':
     resolution: {integrity: sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==}
+
+  '@types/wrap-ansi@3.0.0':
+    resolution: {integrity: sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==}
 
   '@vitest/coverage-v8@2.1.9':
     resolution: {integrity: sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==}
@@ -715,6 +793,10 @@ packages:
   agentkeepalive@4.6.0:
     resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
     engines: {node: '>= 8.0.0'}
+
+  ansi-escapes@4.3.2:
+    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
+    engines: {node: '>=8'}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -802,12 +884,27 @@ packages:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
 
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  chardet@0.7.0:
+    resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
+
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
 
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
+  cli-cursor@5.0.0:
+    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
+    engines: {node: '>=18'}
+
+  cli-spinners@2.9.2:
+    resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
+    engines: {node: '>=6'}
 
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
@@ -834,6 +931,10 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
+    engines: {node: '>=18'}
 
   component-emitter@1.3.1:
     resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
@@ -926,6 +1027,9 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -997,6 +1101,10 @@ packages:
     resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
     engines: {node: '>= 0.10.0'}
 
+  external-editor@3.1.0:
+    resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
+    engines: {node: '>=4'}
+
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
@@ -1061,6 +1169,10 @@ packages:
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-east-asian-width@1.5.0:
+    resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
+    engines: {node: '>=18'}
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -1147,6 +1259,10 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
+  is-interactive@2.0.0:
+    resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
+    engines: {node: '>=12'}
+
   is-node-process@1.2.0:
     resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
 
@@ -1157,6 +1273,10 @@ packages:
   is-stream@4.0.1:
     resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
     engines: {node: '>=18'}
+
+  is-unicode-supported@1.3.0:
+    resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
+    engines: {node: '>=12'}
 
   is-unicode-supported@2.1.0:
     resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
@@ -1183,6 +1303,10 @@ packages:
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  log-symbols@6.0.0:
+    resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
+    engines: {node: '>=18'}
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
@@ -1233,6 +1357,10 @@ packages:
     engines: {node: '>=4.0.0'}
     hasBin: true
 
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
+
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
@@ -1270,6 +1398,10 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  mute-stream@1.0.0:
+    resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   mute-stream@3.0.0:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
@@ -1323,6 +1455,18 @@ packages:
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  onetime@7.0.0:
+    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
+    engines: {node: '>=18'}
+
+  ora@8.2.0:
+    resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
+    engines: {node: '>=18'}
+
+  os-tmpdir@1.0.2:
+    resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
+    engines: {node: '>=0.10.0'}
 
   outvariant@1.4.3:
     resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
@@ -1435,6 +1579,10 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
+  restore-cursor@5.1.0:
+    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
+
   rettime@0.11.8:
     resolution: {integrity: sha512-0fERGXktJTyJ+h8fBEiPxHPEFOu0h15JY7JtwrOVqR5K+vb99ho6IyOo7ekLS3h4sJCzIDy4VWKIbZUfe9njmg==}
 
@@ -1537,6 +1685,10 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  stdin-discarder@0.2.2:
+    resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
+    engines: {node: '>=18'}
+
   strict-event-emitter@0.5.1:
     resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
 
@@ -1547,6 +1699,10 @@ packages:
   string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
+
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -1622,6 +1778,10 @@ packages:
     resolution: {integrity: sha512-JIXCerhudr/N6OWLwLF1HVsTTUo7ry6qHa5eWZEkiMuxsIiAACL55tGLfqfHfoH7QaMQUW8fngD7u7TxWexYQg==}
     hasBin: true
 
+  tmp@0.0.33:
+    resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
+    engines: {node: '>=0.6.0'}
+
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
@@ -1638,6 +1798,10 @@ packages:
 
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
+  type-fest@0.21.3:
+    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
+    engines: {node: '>=10'}
 
   type-fest@5.6.0:
     resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
@@ -1761,6 +1925,10 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -1788,6 +1956,10 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yoctocolors-cjs@2.1.3:
+    resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
+    engines: {node: '>=18'}
 
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
@@ -1981,6 +2153,19 @@ snapshots:
 
   '@inquirer/ansi@2.0.5': {}
 
+  '@inquirer/checkbox@2.5.0':
+    dependencies:
+      '@inquirer/core': 9.2.1
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 1.5.5
+      ansi-escapes: 4.3.2
+      yoctocolors-cjs: 2.1.3
+
+  '@inquirer/confirm@3.2.0':
+    dependencies:
+      '@inquirer/core': 9.2.1
+      '@inquirer/type': 1.5.5
+
   '@inquirer/confirm@6.0.12(@types/node@22.19.17)':
     dependencies:
       '@inquirer/core': 11.1.9(@types/node@22.19.17)
@@ -2000,7 +2185,94 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.17
 
+  '@inquirer/core@9.2.1':
+    dependencies:
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 2.0.0
+      '@types/mute-stream': 0.0.4
+      '@types/node': 22.19.17
+      '@types/wrap-ansi': 3.0.0
+      ansi-escapes: 4.3.2
+      cli-width: 4.1.0
+      mute-stream: 1.0.0
+      signal-exit: 4.1.0
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
+
+  '@inquirer/editor@2.2.0':
+    dependencies:
+      '@inquirer/core': 9.2.1
+      '@inquirer/type': 1.5.5
+      external-editor: 3.1.0
+
+  '@inquirer/expand@2.3.0':
+    dependencies:
+      '@inquirer/core': 9.2.1
+      '@inquirer/type': 1.5.5
+      yoctocolors-cjs: 2.1.3
+
+  '@inquirer/figures@1.0.15': {}
+
   '@inquirer/figures@2.0.5': {}
+
+  '@inquirer/input@2.3.0':
+    dependencies:
+      '@inquirer/core': 9.2.1
+      '@inquirer/type': 1.5.5
+
+  '@inquirer/number@1.1.0':
+    dependencies:
+      '@inquirer/core': 9.2.1
+      '@inquirer/type': 1.5.5
+
+  '@inquirer/password@2.2.0':
+    dependencies:
+      '@inquirer/core': 9.2.1
+      '@inquirer/type': 1.5.5
+      ansi-escapes: 4.3.2
+
+  '@inquirer/prompts@5.5.0':
+    dependencies:
+      '@inquirer/checkbox': 2.5.0
+      '@inquirer/confirm': 3.2.0
+      '@inquirer/editor': 2.2.0
+      '@inquirer/expand': 2.3.0
+      '@inquirer/input': 2.3.0
+      '@inquirer/number': 1.1.0
+      '@inquirer/password': 2.2.0
+      '@inquirer/rawlist': 2.3.0
+      '@inquirer/search': 1.1.0
+      '@inquirer/select': 2.5.0
+
+  '@inquirer/rawlist@2.3.0':
+    dependencies:
+      '@inquirer/core': 9.2.1
+      '@inquirer/type': 1.5.5
+      yoctocolors-cjs: 2.1.3
+
+  '@inquirer/search@1.1.0':
+    dependencies:
+      '@inquirer/core': 9.2.1
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 1.5.5
+      yoctocolors-cjs: 2.1.3
+
+  '@inquirer/select@2.5.0':
+    dependencies:
+      '@inquirer/core': 9.2.1
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 1.5.5
+      ansi-escapes: 4.3.2
+      yoctocolors-cjs: 2.1.3
+
+  '@inquirer/type@1.5.5':
+    dependencies:
+      mute-stream: 1.0.0
+
+  '@inquirer/type@2.0.0':
+    dependencies:
+      mute-stream: 1.0.0
 
   '@inquirer/type@4.0.5(@types/node@22.19.17)':
     optionalDependencies:
@@ -2178,6 +2450,10 @@ snapshots:
 
   '@types/mime@1.3.5': {}
 
+  '@types/mute-stream@0.0.4':
+    dependencies:
+      '@types/node': 22.19.17
+
   '@types/node-fetch@2.6.13':
     dependencies:
       '@types/node': 22.19.17
@@ -2227,6 +2503,8 @@ snapshots:
     dependencies:
       '@types/methods': 1.1.4
       '@types/superagent': 8.1.9
+
+  '@types/wrap-ansi@3.0.0': {}
 
   '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@22.19.17)(msw@2.14.2(@types/node@22.19.17)(typescript@5.9.3)))':
     dependencies:
@@ -2299,6 +2577,10 @@ snapshots:
   agentkeepalive@4.6.0:
     dependencies:
       humanize-ms: 1.2.1
+
+  ansi-escapes@4.3.2:
+    dependencies:
+      type-fest: 0.21.3
 
   ansi-regex@5.0.1: {}
 
@@ -2393,9 +2675,19 @@ snapshots:
       loupe: 3.2.1
       pathval: 2.0.1
 
+  chalk@5.6.2: {}
+
+  chardet@0.7.0: {}
+
   check-error@2.1.3: {}
 
   chownr@1.1.4: {}
+
+  cli-cursor@5.0.0:
+    dependencies:
+      restore-cursor: 5.1.0
+
+  cli-spinners@2.9.2: {}
 
   cli-width@4.1.0: {}
 
@@ -2424,6 +2716,8 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+
+  commander@12.1.0: {}
 
   component-emitter@1.3.1: {}
 
@@ -2487,6 +2781,8 @@ snapshots:
   eastasianwidth@0.2.0: {}
 
   ee-first@1.1.1: {}
+
+  emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
 
@@ -2608,6 +2904,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  external-editor@3.1.0:
+    dependencies:
+      chardet: 0.7.0
+      iconv-lite: 0.4.24
+      tmp: 0.0.33
+
   fast-safe-stringify@2.1.1: {}
 
   fast-string-truncated-width@3.0.3: {}
@@ -2676,6 +2978,8 @@ snapshots:
   function-bind@1.1.2: {}
 
   get-caller-file@2.0.5: {}
+
+  get-east-asian-width@1.5.0: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -2764,11 +3068,15 @@ snapshots:
 
   is-fullwidth-code-point@3.0.0: {}
 
+  is-interactive@2.0.0: {}
+
   is-node-process@1.2.0: {}
 
   is-plain-obj@4.1.0: {}
 
   is-stream@4.0.1: {}
+
+  is-unicode-supported@1.3.0: {}
 
   is-unicode-supported@2.1.0: {}
 
@@ -2800,6 +3108,11 @@ snapshots:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
+
+  log-symbols@6.0.0:
+    dependencies:
+      chalk: 5.6.2
+      is-unicode-supported: 1.3.0
 
   loupe@3.2.1: {}
 
@@ -2836,6 +3149,8 @@ snapshots:
   mime@1.6.0: {}
 
   mime@2.6.0: {}
+
+  mimic-function@5.0.1: {}
 
   mimic-response@3.1.0: {}
 
@@ -2882,6 +3197,8 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
+  mute-stream@1.0.0: {}
+
   mute-stream@3.0.0: {}
 
   nanoid@3.3.12: {}
@@ -2916,6 +3233,24 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+
+  onetime@7.0.0:
+    dependencies:
+      mimic-function: 5.0.1
+
+  ora@8.2.0:
+    dependencies:
+      chalk: 5.6.2
+      cli-cursor: 5.0.0
+      cli-spinners: 2.9.2
+      is-interactive: 2.0.0
+      is-unicode-supported: 2.1.0
+      log-symbols: 6.0.0
+      stdin-discarder: 0.2.2
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+
+  os-tmpdir@1.0.2: {}
 
   outvariant@1.4.3: {}
 
@@ -3036,6 +3371,11 @@ snapshots:
   real-require@0.2.0: {}
 
   require-directory@2.1.1: {}
+
+  restore-cursor@5.1.0:
+    dependencies:
+      onetime: 7.0.0
+      signal-exit: 4.1.0
 
   rettime@0.11.8: {}
 
@@ -3199,6 +3539,8 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  stdin-discarder@0.2.2: {}
+
   strict-event-emitter@0.5.1: {}
 
   string-width@4.2.3:
@@ -3211,6 +3553,12 @@ snapshots:
     dependencies:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.5.0
       strip-ansi: 7.2.0
 
   string_decoder@1.3.0:
@@ -3298,6 +3646,10 @@ snapshots:
     dependencies:
       tldts-core: 7.0.29
 
+  tmp@0.0.33:
+    dependencies:
+      os-tmpdir: 1.0.2
+
   toidentifier@1.0.1: {}
 
   tough-cookie@6.0.1:
@@ -3312,6 +3664,8 @@ snapshots:
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
+
+  type-fest@0.21.3: {}
 
   type-fest@5.6.0:
     dependencies:
@@ -3420,6 +3774,12 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -3449,6 +3809,8 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yoctocolors-cjs@2.1.3: {}
 
   yoctocolors@2.1.2: {}
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Onboarding Agent installer (PRD-MVP-SLIM v0.10 §6.2 A, AC-CORE-01)
+# Usage:  curl -fsSL https://onboarding.wrtn.io/install.sh | sh
+set -euo pipefail
+
+readonly INSTALL_ROOT="${ONBOARDING_HOME:-$HOME/.onboarding}"
+readonly BIN_LINK="${ONBOARDING_BIN_LINK:-/usr/local/bin/onboarding}"
+readonly RELEASE_TARBALL_URL="${ONBOARDING_RELEASE_URL:-https://onboarding.wrtn.io/releases/latest/onboarding.tar.gz}"
+
+red()    { printf '\033[31m%s\033[0m\n' "$*"; }
+green()  { printf '\033[32m%s\033[0m\n' "$*"; }
+yellow() { printf '\033[33m%s\033[0m\n' "$*"; }
+bold()   { printf '\033[1m%s\033[0m\n' "$*"; }
+
+require_macos() {
+  case "$(uname -s)" in
+    Darwin) ;;
+    *)
+      red "지원하지 않는 OS입니다: $(uname -s)."
+      red "Onboarding Agent는 macOS에서만 동작합니다 (PRD-MVP-SLIM §6.2)."
+      exit 1
+      ;;
+  esac
+}
+
+require_node22() {
+  if ! command -v node >/dev/null 2>&1; then
+    red "Node.js가 설치되어 있지 않습니다."
+    yellow "다음 명령으로 설치한 뒤 다시 시도하세요:"
+    echo  "  brew install node@22"
+    exit 1
+  fi
+  local major
+  major="$(node -p 'process.versions.node.split(".")[0]')"
+  if [ "${major:-0}" -lt 22 ]; then
+    red "Node.js 22 LTS 이상이 필요합니다 (현재: $(node -v))."
+    yellow "다음 명령으로 업그레이드하세요:"
+    echo  "  brew install node@22"
+    exit 1
+  fi
+}
+
+download_and_extract() {
+  bold "1) 최신 릴리즈 다운로드: ${RELEASE_TARBALL_URL}"
+  mkdir -p "${INSTALL_ROOT}"
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "${tmp}"' EXIT
+  if ! curl -fsSL "${RELEASE_TARBALL_URL}" -o "${tmp}/onboarding.tar.gz"; then
+    red "릴리즈 tarball을 다운로드하지 못했습니다."
+    exit 1
+  fi
+  bold "2) ${INSTALL_ROOT}에 압축을 해제합니다."
+  tar -xzf "${tmp}/onboarding.tar.gz" -C "${INSTALL_ROOT}"
+}
+
+create_symlink() {
+  local target="${INSTALL_ROOT}/dist/cli/index.js"
+  if [ ! -f "${target}" ]; then
+    red "CLI 진입점을 찾지 못했습니다: ${target}"
+    exit 1
+  fi
+  chmod +x "${target}"
+  bold "3) /usr/local/bin/onboarding 심볼릭 링크를 만듭니다 (sudo 필요할 수 있음)."
+  if ln -sfn "${target}" "${BIN_LINK}" 2>/dev/null; then
+    green "  ✓ ${BIN_LINK} → ${target}"
+  else
+    yellow "  관리자 권한이 필요합니다. 다음 명령을 실행하세요:"
+    echo  "    sudo ln -sfn \"${target}\" \"${BIN_LINK}\""
+  fi
+}
+
+main() {
+  bold "Onboarding Agent 설치를 시작합니다."
+  require_macos
+  require_node22
+  download_and_extract
+  create_symlink
+  green "설치가 완료되었습니다!"
+  echo ""
+  bold "다음 명령으로 데몬을 기동하세요:"
+  echo  "  onboarding start"
+  echo ""
+  echo  "처음 실행하면 사용자 정보 입력과 권한/동의 위저드가 진행됩니다."
+}
+
+main "$@"


### PR DESCRIPTION
# Code Review — spec-013-daemon-cli-install

- **Reviewer**: Claude (Opus 4.7)
- **Date**: 2026-05-01
- **Branch**: feature/spec-013-daemon-cli-install
- **Commit under review**: 948228e `feat(spec-013-daemon-cli-install): add onboarding CLI + wizard + install.sh`
- **Spec**: `specs/spec-013-daemon-cli-install.md`
- **Authority**: `docs/PRD-MVP-SLIM.md` v0.10
- **Boundaries**: `BOUNDARIES.md` v1.0

> 비고: `git diff main...HEAD`는 spec-002~spec-013 누적 commit을 모두 포함하지만, 본 리뷰는 spec-013에 해당하는 단일 commit `948228e`(16개 파일, +1,881줄)만 평가 대상으로 한다.

## 종합 판정

| 항목 | 결과 |
|------|------|
| 1. AC 정합성 (PRD §10) | **PASS** |
| 2. PRD 정합성 (의도/스코프) | **PASS** |
| 3. 데이터 모델 정합성 (PRD §8) | **WARN** |
| 4. API 계약 정합성 (PRD §9) | **PASS** |
| 5. 보안 점검 | **PASS** |
| 6. 코드 품질 (함수 길이/커버리지) | **WARN** |
| 7. BOUNDARIES.md 준수 | **PASS** |
| 8. 의존성 체크 (PRD §12) | **PASS** |
| **종합** | **PASS with WARN** |

검증 명령 결과:

- `pnpm --filter @onboarding/daemon test` → **323/323 통과**, 라인 커버리지 **97.69%**, 함수 커버리지 **99.29%**
- `pnpm --filter @onboarding/daemon build` → 통과 (`tsc` + `copy-migrations` + `cli-shebang` 모두 성공)
- `pnpm --filter @onboarding/daemon lint` (tsc strict) → 통과 (에러 0)

---

## 1. AC 정합성 — **PASS**

spec §"Acceptance Criteria"의 11개 항목과 PRD §10의 핵심 ACs를 코드/테스트 매핑으로 추적.

| AC | 충족 위치 | 결과 |
|----|----------|------|
| AC-CORE-01 (`curl ... \| sh` → 데몬+권한 가이드) | `scripts/install.sh:73-85`(설치) + `src/cli/start.ts:49-104`(detached spawn + waitForReady + 위저드 호출) + `src/cli/wizard.ts:110-127`(Screen Recording 패널 자동 진입) | PASS |
| AC-CORE-02 (Anthropic 동의 클릭 → SQLite 기록 + 다음 실행 위저드 스킵) | `src/cli/wizard.ts:97-99`(`profileExists` 게이트), `src/cli/wizard.ts:130-141`(POST /api/consents anthropic_transmission), 테스트 `tests/cli-wizard.test.ts:138-153` | PASS |
| `onboarding stop` 재실행 시 "데몬이 실행 중이지 않음" 메시지 | `src/cli/stop.ts:26-43` (pidfile 부재/죽은 PID/잘못된 PID 모두 동일 메시지), 테스트 `tests/cli-control.test.ts:172-221` | PASS |
| `onboarding reset --yes` 없으면 confirm 강제 | `src/cli/reset.ts:29-38`, 테스트 `tests/cli-control.test.ts:225-241` | PASS |
| `install.sh`는 macOS 외 OS에서 명시적 에러 + 종료 코드 1 | `scripts/install.sh:15-24` (`require_macos` → red 메시지 + `exit 1`) | PASS |
| CLI 출력 한국어 | `src/cli/{start,status,stop,reset,wizard}.ts` 전반의 모든 사용자 메시지 한국어; 테스트 `tests/cli-status.test.ts:127-133` 한국어 단어 단언 | PASS |
| `pnpm test` 통과 | 323/323 통과 | PASS |
| `pnpm build` 통과 (cli도 dist에 emit) | `dist/cli/index.js`에 shebang `#!/usr/bin/env node` 부착 + `chmod 755` (`scripts/cli-shebang.mjs:14-18`) | PASS |
| `pnpm lint` 에러 0 | tsc strict 통과 | PASS |
| 테스트 커버리지 ≥ 80% | src/cli 평균 ~98%, 전체 97.69% | PASS |
| BOUNDARIES.md 준수 | §7 참조 | PASS |
| 신규 의존성은 PRD §12만 | §8 참조 | PASS |

---

## 2. PRD 정합성 — **PASS**

- 스코프 준수: spec이 비범위로 선언한 `Floating Hint 자동 기동 구현`, `Node SEA 빌드`, `자동 업데이트`는 모두 미구현 상태로 남아있고, `start.ts:101`의 안내 라인("Floating Hint Window는 SPEC-014/015 머지 후 자동 기동됩니다.")만 출력 — spec의 "미머지 시 스킵 + 안내" 정책과 부합.
- PRD §6.2 A의 CLI 컴포넌트 책임(설치/기동/권한 가이드/동의 가이드)을 모두 구현.
- PRD §7.1 F-CORE-01/02/05 명령 라인 표면(`onboarding {start|status|stop|reset}`)이 `src/cli/index.ts:121-140`에 정확히 매핑됨.
- spec 외 패키지 침범 없음: `packages/floating-hint/`, `packages/shared/src/` 미수정 (§7 참고).

---

## 3. 데이터 모델 정합성 (PRD §8) — **WARN**

- SQLite 스키마는 spec-002에서 만든 `001_init.sql`을 그대로 사용. spec-013은 어떤 마이그레이션도 추가하지 않음 → BOUNDARIES §4 충족.
- `wizard.ts:60-68`의 `insertProfile`은 PRD §8.1 `profile` 테이블의 4개 컬럼(`employee_id`, `email`, `name`, `created_at`)만 사용 → 스키마와 100% 일치.
- 데이터 보존 정책 (PRD §8.2) 침범 없음: 캡처/이미지 데이터는 본 spec에서 다루지 않음.

**WARN — spec 출력 명세와 PRD §8.1 사이의 불일치:**

- spec은 "이름/이메일/직무/전화 입력 → SQLite profile에 저장"을 명시하나, PRD §8.1 `profile` 스키마에는 `role`/`phone` 컬럼이 없음.
- 구현은 `wizard.ts:50-57`에서 `role`/`phone`을 입력받지만 `insertProfile`에서 사용하지 않고 **조용히 폐기**한다.
- 동작상 안전하나(BOUNDARIES §4의 "스키마 변경 금지"를 지키기 위해 어쩔 수 없는 선택), 사용자에게는 "왜 입력했는데 저장 안 되지?"의 혼동을 줄 수 있음.
- 권장: PRD §8.1 개정으로 컬럼을 추가하거나, 위저드에서 해당 입력을 제거하여 정합 확보 (이는 spec/PRD 차원의 결정이라 본 PR에서 수정 불가).

---

## 4. API 계약 정합성 (PRD §9) — **PASS**

- 본 spec은 신규 라우트를 만들지 않고 클라이언트로서만 호출.
- `wizard.ts:76-86` POST `/api/consents` 요청 본문 `{ consent_type, granted }` → PRD §9.1.6과 일치.
- `status.ts:62-65`의 GET `/api/checklist`, GET `/api/consents`, GET `/api/vision/rate-limit` → PRD §9.1.1, §9.1.6, §9.1.5와 일치.
- `paths.ts:4`의 `DEFAULT_BASE_URL = 'http://localhost:7777'` → PRD §9.1 base와 일치, `tests/cli-paths.test.ts:14-16`에서 회귀 테스트.
- HTTP 상태 처리: `wizard.ts:81-85`는 비-2xx에서 명시 throw, `status.ts:49-52`는 `request_failed: ... status=...` throw. 200/4xx/5xx 의미 변경 없음.
- Breaking change 없음.

---

## 5. 보안 점검 — **PASS**

| 점검 항목 | 결과 | 근거 |
|----------|------|------|
| 시크릿 하드코딩 | OK | `grep -nE "sk-ant\|api[_-]?key\|password\|secret"` 결과 0건. Anthropic 키는 환경변수로만 처리 (본 spec 외 영역). |
| SQL 인젝션 | OK | `wizard.ts:65-68`, `wizard.ts:33-35` 모두 `db.prepare(...).run(...)` placeholder 바인딩만 사용. 동적 문자열 연결 없음. |
| 캡처 이미지 처리 (PRD §8.2 보존 정책) | OK | 본 spec은 캡처 경로에 손대지 않음. 위저드는 동의 수집과 패널 진입만 담당. |
| install.sh 안전성 | OK | `set -euo pipefail`, `mktemp -d` 사용, `trap 'rm -rf "${tmp}"' EXIT`로 임시 디렉토리 정리, OS/Node 사전 체크. |
| 로그/메시지 PII | OK | 콘솔 출력 메시지에는 입력값(이름/이메일) 미노출. SQLite로 직접 저장만. |
| 패널 URL 검증 | OK | `wizard.ts:30`의 URL은 `x-apple.systempreferences:`로 시작 → SPEC-008의 `isAllowedPanelUrl` 화이트리스트 통과. |

소소한 관찰(차단 이유 아님):

- `wizard.ts:50-57`은 입력 trim만 하고 비어있는 문자열 검증이 없어, 사용자가 ENTER만 눌러도 빈 `employee_id`로 INSERT가 성공한다. 이후 위저드는 무조건 스킵된다(profileExists가 truthy로 판정되지 않으므로 사실 다시 실행됨 — `Boolean('')` is false이므로 안전). 동작상 문제는 없으나 향후 검증 추가 권장.

---

## 6. 코드 품질 — **WARN**

**테스트 커버리지** (PASS):

- `src/cli/*` 라인 커버리지: paths 100%, reset 100%, start 96.82%, status 95.45%, stop 100%, wizard 99.06%
- 함수 커버리지 100% (cli 모듈 전체)
- 모든 분기는 mocked spawn / fetch / inquirer로 검증 (`tests/cli-control.test.ts`, `tests/cli-wizard.test.ts`, `tests/cli-status.test.ts`, `tests/cli-paths.test.ts`)

**WARN — 함수 50줄 가이드 초과 2건:**

| 함수 | 위치 | 줄수 | 비고 |
|------|------|------|------|
| `runWizard` | `src/cli/wizard.ts:88-153` | **66줄** | 단계 1(프로필 입력)/2(Screen Recording 안내)/3(Anthropic 동의) 3개 섹션을 한 함수에 인라인. `step1Profile`, `step2ScreenRecording`, `step3AnthropicConsent` 헬퍼로 분리하면 ≤50줄 가능. |
| `runStart` | `src/cli/start.ts:49-104` | **56줄** | pidfile 검사 → spawn → ready-poll → 위저드 호출 → 안내 출력의 5단계를 인라인. |

가이드라인 초과이며 분리 가능하므로 WARN. 동작은 정확하고 가독성도 양호하다.

**기타 관찰**:

- `start.ts:108-110`의 `resolveDaemonEntry()`는 `import.meta.url`을 사용해 dist 경로를 추론(`dist/cli/start.js → dist/index.js`). dev 모드(ts-node 등)에서는 깨질 수 있으나, 본 spec은 빌드된 단일 진입점만 가정 — 정상.
- `index.ts:88-94`의 `statusCommand` 에러 경로는 `fetchDaemonStatus` 실패 시 `runStatus`를 한 번 더 호출해 사용자에게 메시지를 보여준다. 두 번째 호출도 실패할 것이므로 사실상 fail-twice 패턴 — 메시지 중복은 없으나 의도가 다소 우회적. 작은 리팩터로 단순화 가능 (블로킹 아님).

---

## 7. BOUNDARIES.md 준수 — **PASS**

| 경계 | 결과 |
|------|------|
| §1 Read-Only 파일 미수정 | OK (PRD/BOUNDARIES/spec-template/타 spec 미터치) |
| §2 spec 외 패키지 미수정 | OK — 변경된 16개 파일 모두 `packages/daemon/**` 또는 spec이 명시한 `scripts/install.sh` |
| §3 신규 의존성 화이트리스트 | OK (§8) |
| §4 API 계약 보호 | OK (§4) |
| §5 시크릿 하드코딩 금지 | OK (§5) |

`packages/daemon/vitest.config.ts`의 `exclude`에 `src/cli/index.ts` 추가는 자기 패키지 내 변경이며 합리적(엔트리포인트 제외) — 위반 아님.

루트 `package.json`은 변경되지 않았다 (cli-shebang 스크립트는 packages/daemon/scripts/ 내부).

---

## 8. 의존성 체크 (PRD §12) — **PASS**

본 commit에서 추가된 4개 의존성 모두 PRD §12 카탈로그 + BOUNDARIES.md §3에 등재됨:

| 패키지 | 추가 버전 | PRD §12 허용 범위 | 결과 |
|--------|----------|-----------------|------|
| `commander` | `^12.0.0` | `^12.0` (cli) | OK |
| `@inquirer/prompts` | `^5.0.0` | `^5.0` (cli) | OK |
| `picocolors` | `^1.0.0` | `^1.0` (cli) | OK |
| `ora` | `^8.0.0` | `^8.0` (cli) | OK |

표 외 패키지 추가 0건. transitive deps만 lockfile 변동.

---

## 결론

차단 결함(FAIL)은 없다. 다음 두 가지 WARN이 남아있으나, 모두 spec 외부 결정이거나 가독성 개선 수준의 사항이다:

1. **데이터 모델 vs spec 출력 명세 불일치 (§3)** — `직무`/`전화`를 입력받지만 PRD §8.1 스키마에 컬럼이 없어 폐기됨. PRD 차원의 결정이 필요하므로 본 PR에서 수정 불가. spec 또는 PRD 갱신을 권장한다.
2. **함수 길이 가이드 초과 (§6)** — `runWizard` 66줄, `runStart` 56줄. 헬퍼 추출로 50줄 이하 분리 가능. 후속 정리 권장.

테스트 323/323 통과, 라인 커버리지 97.69%, 빌드/린트 모두 통과, BOUNDARIES와 의존성 화이트리스트 모두 준수.

<promise>SPEC_013_DAEMON_CLI_INSTALL_REVIEW_PASS_WITH_WARN</promise>
