### PR TITLE
[Ralph] spec-014-fh-skeleton

### DIFF
--- a/packages/floating-hint/.gitignore
+++ b/packages/floating-hint/.gitignore
@@ -1,0 +1,3 @@
+coverage/
+dist/
+node_modules/

--- a/packages/floating-hint/package.json
+++ b/packages/floating-hint/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@onboarding/floating-hint",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Onboarding Agent Floating Hint Window — Electron always-on-top translucent window (PRD-MVP-SLIM v0.10 §6.2 C)",
+  "type": "module",
+  "main": "./dist/main/index.js",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json && node scripts/copy-renderer.mjs",
+    "dev": "electron .",
+    "test": "vitest run --coverage",
+    "lint": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "@onboarding/shared": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@vitest/coverage-v8": "^2.1.0",
+    "electron": "^32.0.0",
+    "typescript": "^5.5.4",
+    "vitest": "^2.1.0"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/packages/floating-hint/scripts/copy-renderer.mjs
+++ b/packages/floating-hint/scripts/copy-renderer.mjs
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+// Copies static renderer assets (index.html) into dist/ so that
+// dist/renderer/index.html sits next to the compiled dist/renderer/index.js.
+import { mkdir, copyFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = resolve(here, '..');
+
+const assets = [['src/renderer/index.html', 'dist/renderer/index.html']];
+
+for (const [from, to] of assets) {
+  const src = resolve(pkgRoot, from);
+  const dst = resolve(pkgRoot, to);
+  await mkdir(dirname(dst), { recursive: true });
+  await copyFile(src, dst);
+  console.log(`copied ${from} -> ${to}`);
+}

--- a/packages/floating-hint/src/main/daemon-client.ts
+++ b/packages/floating-hint/src/main/daemon-client.ts
@@ -1,0 +1,91 @@
+export const DEFAULT_DAEMON_BASE_URL = 'http://localhost:7777';
+
+export interface DaemonClientOptions {
+  baseUrl?: string;
+  fetchImpl?: typeof fetch;
+}
+
+export interface VisionStepInput {
+  item_id: string;
+  step_id: string;
+}
+
+export interface ConsentInput {
+  consent_type: string;
+  granted: boolean;
+}
+
+export interface ClipboardInput {
+  command: string;
+}
+
+export interface VerifyRunInput {
+  item_id: string;
+  verification: unknown;
+}
+
+export interface DaemonClient {
+  getChecklist(): Promise<unknown>;
+  startItem(itemId: string): Promise<unknown>;
+  requestGuide(input: VisionStepInput): Promise<unknown>;
+  requestVerify(input: VisionStepInput): Promise<unknown>;
+  getRateLimit(): Promise<unknown>;
+  getConsents(): Promise<unknown>;
+  postConsent(input: ConsentInput): Promise<unknown>;
+  postClipboard(input: ClipboardInput): Promise<unknown>;
+  runVerify(input: VerifyRunInput): Promise<unknown>;
+}
+
+export class DaemonHttpError extends Error {
+  public readonly status: number;
+  public readonly body: unknown;
+
+  constructor(status: number, body: unknown) {
+    super(`Daemon HTTP error ${status}`);
+    this.name = 'DaemonHttpError';
+    this.status = status;
+    this.body = body;
+  }
+}
+
+export function createDaemonClient(options: DaemonClientOptions = {}): DaemonClient {
+  const baseUrl = options.baseUrl ?? DEFAULT_DAEMON_BASE_URL;
+  const fetchImpl: typeof fetch =
+    options.fetchImpl ?? ((...args) => globalThis.fetch(...args));
+
+  async function request<T>(
+    method: 'GET' | 'POST',
+    path: string,
+    body?: unknown,
+  ): Promise<T> {
+    const init: RequestInit = { method };
+    if (body !== undefined) {
+      init.headers = { 'Content-Type': 'application/json' };
+      init.body = JSON.stringify(body);
+    }
+    const res = await fetchImpl(`${baseUrl}${path}`, init);
+    if (!res.ok) {
+      let errBody: unknown = undefined;
+      try {
+        errBody = await res.json();
+      } catch {
+        errBody = undefined;
+      }
+      throw new DaemonHttpError(res.status, errBody);
+    }
+    return (await res.json()) as T;
+  }
+
+  return {
+    getChecklist: () => request('GET', '/api/checklist'),
+    startItem: (itemId) =>
+      request('POST', `/api/items/${encodeURIComponent(itemId)}/start`),
+    requestGuide: (input) => request('POST', '/api/vision/guide', input),
+    requestVerify: (input) => request('POST', '/api/vision/verify', input),
+    getRateLimit: () => request('GET', '/api/vision/rate-limit'),
+    getConsents: () => request('GET', '/api/consents'),
+    postConsent: (input) => request('POST', '/api/consents', input),
+    postClipboard: (input) => request('POST', '/api/clipboard', input),
+    runVerify: (input) => request('POST', '/api/verify/run', input),
+  };
+}

--- a/packages/floating-hint/src/main/index.ts
+++ b/packages/floating-hint/src/main/index.ts
@@ -1,0 +1,50 @@
+import { app, BrowserWindow, screen } from 'electron';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  assertSupportedPlatform,
+  buildBrowserWindowOptions,
+} from './window-options.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const PRELOAD_PATH = path.join(__dirname, '..', 'preload', 'index.js');
+const RENDERER_HTML_PATH = path.join(__dirname, '..', 'renderer', 'index.html');
+
+function createMainWindow(): BrowserWindow {
+  const primary = screen.getPrimaryDisplay();
+  const opts = buildBrowserWindowOptions(primary.workArea, PRELOAD_PATH);
+  const win = new BrowserWindow(opts);
+  win.setAlwaysOnTop(true, 'floating');
+  win.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
+  void win.loadFile(RENDERER_HTML_PATH).then(() => {
+    win.show();
+  });
+  return win;
+}
+
+let mainWindow: BrowserWindow | null = null;
+
+function bootstrap(): void {
+  assertSupportedPlatform(
+    process.platform,
+    process.exit.bind(process) as (code: number) => never,
+  );
+
+  void app.whenReady().then(() => {
+    mainWindow = createMainWindow();
+    app.on('activate', () => {
+      if (!mainWindow || mainWindow.isDestroyed()) {
+        mainWindow = createMainWindow();
+      }
+    });
+  });
+
+  app.on('window-all-closed', () => {
+    if (process.platform !== 'darwin') {
+      app.quit();
+    }
+  });
+}
+
+bootstrap();

--- a/packages/floating-hint/src/main/window-options.ts
+++ b/packages/floating-hint/src/main/window-options.ts
@@ -1,0 +1,63 @@
+import type { BrowserWindowConstructorOptions, Rectangle } from 'electron';
+
+export const HINT_WINDOW_WIDTH = 360;
+export const HINT_WINDOW_HEIGHT = 200;
+export const HINT_WINDOW_MARGIN = 16;
+
+export type WorkArea = Pick<Rectangle, 'x' | 'y' | 'width' | 'height'>;
+
+export function calculatePosition(
+  workArea: WorkArea,
+  windowWidth: number = HINT_WINDOW_WIDTH,
+  windowHeight: number = HINT_WINDOW_HEIGHT,
+  margin: number = HINT_WINDOW_MARGIN,
+): { x: number; y: number } {
+  return {
+    x: workArea.x + workArea.width - windowWidth - margin,
+    y: workArea.y + workArea.height - windowHeight - margin,
+  };
+}
+
+export function buildBrowserWindowOptions(
+  workArea: WorkArea,
+  preloadPath: string,
+): BrowserWindowConstructorOptions {
+  const { x, y } = calculatePosition(workArea);
+  return {
+    width: HINT_WINDOW_WIDTH,
+    height: HINT_WINDOW_HEIGHT,
+    x,
+    y,
+    alwaysOnTop: true,
+    frame: false,
+    transparent: true,
+    backgroundColor: '#00000000',
+    focusable: false,
+    resizable: false,
+    minimizable: false,
+    maximizable: false,
+    skipTaskbar: true,
+    show: false,
+    hasShadow: false,
+    webPreferences: {
+      preload: preloadPath,
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+    },
+  };
+}
+
+export function assertSupportedPlatform(
+  platform: NodeJS.Platform,
+  exit: (code: number) => never,
+  log: (message: string) => void = (msg) => console.error(msg),
+): void {
+  if (platform !== 'darwin') {
+    log(
+      `[floating-hint] Only macOS (darwin) is supported in MVP. ` +
+        `Detected platform: ${platform}. Aborting.`,
+    );
+    exit(1);
+  }
+}

--- a/packages/floating-hint/src/preload/index.ts
+++ b/packages/floating-hint/src/preload/index.ts
@@ -1,0 +1,27 @@
+import { contextBridge } from 'electron';
+import {
+  createDaemonClient,
+  type ClipboardInput,
+  type ConsentInput,
+  type DaemonClient,
+  type VerifyRunInput,
+  type VisionStepInput,
+} from '../main/daemon-client.js';
+
+const client: DaemonClient = createDaemonClient();
+
+const exposed = {
+  getChecklist: () => client.getChecklist(),
+  startItem: (itemId: string) => client.startItem(itemId),
+  requestGuide: (input: VisionStepInput) => client.requestGuide(input),
+  requestVerify: (input: VisionStepInput) => client.requestVerify(input),
+  getRateLimit: () => client.getRateLimit(),
+  getConsents: () => client.getConsents(),
+  postConsent: (input: ConsentInput) => client.postConsent(input),
+  postClipboard: (input: ClipboardInput) => client.postClipboard(input),
+  runVerify: (input: VerifyRunInput) => client.runVerify(input),
+} as const;
+
+export type DaemonClientBridge = typeof exposed;
+
+contextBridge.exposeInMainWorld('daemonClient', exposed);

--- a/packages/floating-hint/src/renderer/index.html
+++ b/packages/floating-hint/src/renderer/index.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'"
+    />
+    <title>Onboarding Hint</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        width: 100%;
+        height: 100%;
+        background: transparent;
+        color: #f5f5f5;
+        font-family:
+          -apple-system, BlinkMacSystemFont, 'Apple SD Gothic Neo', 'Pretendard',
+          system-ui, sans-serif;
+        overflow: hidden;
+      }
+
+      #app {
+        width: 100%;
+        height: 100%;
+        box-sizing: border-box;
+        padding: 16px;
+        background: rgba(20, 20, 30, 0.85);
+        border-radius: 12px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+        font-size: 14px;
+        line-height: 1.5;
+        backdrop-filter: blur(8px);
+        -webkit-backdrop-filter: blur(8px);
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./index.js"></script>
+  </body>
+</html>

--- a/packages/floating-hint/src/renderer/index.tsx
+++ b/packages/floating-hint/src/renderer/index.tsx
@@ -1,0 +1,8 @@
+// Renderer entry — vanilla DOM placeholder. SPEC-015 will replace this with the
+// real UI (two buttons + AI response). PRD §12 catalog does not include React;
+// no JSX is used here so the .tsx extension reduces to plain TypeScript.
+
+const root = document.getElementById('app');
+if (root) {
+  root.textContent = 'Hint Window 준비됨';
+}

--- a/packages/floating-hint/tests/daemon-client.test.ts
+++ b/packages/floating-hint/tests/daemon-client.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  DEFAULT_DAEMON_BASE_URL,
+  DaemonHttpError,
+  createDaemonClient,
+} from '../src/main/daemon-client.js';
+
+interface RecordedCall {
+  url: string;
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string;
+}
+
+function makeFetch(
+  response: { status?: number; body?: unknown } = {},
+): { fetchImpl: typeof fetch; calls: RecordedCall[] } {
+  const calls: RecordedCall[] = [];
+  const status = response.status ?? 200;
+  const fetchImpl = (async (url: string | URL, init?: RequestInit) => {
+    const headers: Record<string, string> = {};
+    if (init?.headers) {
+      const h = init.headers as Record<string, string>;
+      for (const k of Object.keys(h)) headers[k] = h[k]!;
+    }
+    calls.push({
+      url: url.toString(),
+      method: init?.method,
+      headers,
+      body: typeof init?.body === 'string' ? init.body : undefined,
+    });
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => response.body ?? {},
+    } as Response;
+  }) as unknown as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+describe('DEFAULT_DAEMON_BASE_URL', () => {
+  it('is http://localhost:7777 (PRD §9.1)', () => {
+    expect(DEFAULT_DAEMON_BASE_URL).toBe('http://localhost:7777');
+  });
+});
+
+describe('createDaemonClient', () => {
+  it('GETs /api/checklist on getChecklist()', async () => {
+    const { fetchImpl, calls } = makeFetch({ body: { items: [] } });
+    const client = createDaemonClient({ fetchImpl });
+    const result = await client.getChecklist();
+    expect(result).toEqual({ items: [] });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe('http://localhost:7777/api/checklist');
+    expect(calls[0]!.method).toBe('GET');
+    expect(calls[0]!.body).toBeUndefined();
+  });
+
+  it('POSTs /api/items/:itemId/start with URL-encoded itemId', async () => {
+    const { fetchImpl, calls } = makeFetch({ body: { ok: true } });
+    const client = createDaemonClient({ fetchImpl });
+    await client.startItem('install/homebrew');
+    expect(calls[0]!.url).toBe(
+      'http://localhost:7777/api/items/install%2Fhomebrew/start',
+    );
+    expect(calls[0]!.method).toBe('POST');
+  });
+
+  it('POSTs /api/vision/guide with JSON body', async () => {
+    const { fetchImpl, calls } = makeFetch({ body: { call_id: 'vc_1' } });
+    const client = createDaemonClient({ fetchImpl });
+    await client.requestGuide({ item_id: 'a', step_id: 'b' });
+    expect(calls[0]!.url).toBe('http://localhost:7777/api/vision/guide');
+    expect(calls[0]!.method).toBe('POST');
+    expect(calls[0]!.headers?.['Content-Type']).toBe('application/json');
+    expect(JSON.parse(calls[0]!.body!)).toEqual({ item_id: 'a', step_id: 'b' });
+  });
+
+  it('POSTs /api/vision/verify with JSON body', async () => {
+    const { fetchImpl, calls } = makeFetch({ body: { call_id: 'vc_2' } });
+    const client = createDaemonClient({ fetchImpl });
+    await client.requestVerify({ item_id: 'a', step_id: 'b' });
+    expect(calls[0]!.url).toBe('http://localhost:7777/api/vision/verify');
+    expect(calls[0]!.method).toBe('POST');
+  });
+
+  it('GETs /api/vision/rate-limit', async () => {
+    const { fetchImpl, calls } = makeFetch({
+      body: { state: 'normal', current_hour_calls: 0 },
+    });
+    const client = createDaemonClient({ fetchImpl });
+    const out = await client.getRateLimit();
+    expect(out).toEqual({ state: 'normal', current_hour_calls: 0 });
+    expect(calls[0]!.url).toBe('http://localhost:7777/api/vision/rate-limit');
+    expect(calls[0]!.method).toBe('GET');
+  });
+
+  it('GETs and POSTs /api/consents', async () => {
+    const { fetchImpl, calls } = makeFetch({ body: {} });
+    const client = createDaemonClient({ fetchImpl });
+    await client.getConsents();
+    await client.postConsent({ consent_type: 'anthropic_transmission', granted: true });
+    expect(calls[0]!.method).toBe('GET');
+    expect(calls[0]!.url).toBe('http://localhost:7777/api/consents');
+    expect(calls[1]!.method).toBe('POST');
+    expect(calls[1]!.url).toBe('http://localhost:7777/api/consents');
+    expect(JSON.parse(calls[1]!.body!)).toEqual({
+      consent_type: 'anthropic_transmission',
+      granted: true,
+    });
+  });
+
+  it('POSTs /api/clipboard with command body', async () => {
+    const { fetchImpl, calls } = makeFetch({ body: { ok: true } });
+    const client = createDaemonClient({ fetchImpl });
+    await client.postClipboard({ command: 'brew --version' });
+    expect(calls[0]!.url).toBe('http://localhost:7777/api/clipboard');
+    expect(JSON.parse(calls[0]!.body!)).toEqual({ command: 'brew --version' });
+  });
+
+  it('POSTs /api/verify/run with verification payload', async () => {
+    const { fetchImpl, calls } = makeFetch({
+      body: { status: 'pass', details: '' },
+    });
+    const client = createDaemonClient({ fetchImpl });
+    await client.runVerify({ item_id: 'a', verification: { type: 'noop' } });
+    expect(calls[0]!.url).toBe('http://localhost:7777/api/verify/run');
+    expect(JSON.parse(calls[0]!.body!)).toEqual({
+      item_id: 'a',
+      verification: { type: 'noop' },
+    });
+  });
+
+  it('honours a custom baseUrl', async () => {
+    const { fetchImpl, calls } = makeFetch({ body: {} });
+    const client = createDaemonClient({
+      baseUrl: 'http://127.0.0.1:9999',
+      fetchImpl,
+    });
+    await client.getChecklist();
+    expect(calls[0]!.url).toBe('http://127.0.0.1:9999/api/checklist');
+  });
+
+  it('throws DaemonHttpError on a non-2xx response, exposing status and body', async () => {
+    const { fetchImpl } = makeFetch({
+      status: 503,
+      body: { error: 'vision_api_timeout' },
+    });
+    const client = createDaemonClient({ fetchImpl });
+    await expect(
+      client.requestGuide({ item_id: 'x', step_id: 'y' }),
+    ).rejects.toBeInstanceOf(DaemonHttpError);
+    try {
+      await client.requestGuide({ item_id: 'x', step_id: 'y' });
+    } catch (err) {
+      const e = err as DaemonHttpError;
+      expect(e.status).toBe(503);
+      expect(e.body).toEqual({ error: 'vision_api_timeout' });
+      expect(e.message).toMatch(/503/);
+    }
+  });
+
+  it('still rejects with DaemonHttpError when the error body is not valid JSON', async () => {
+    const fetchImpl = (async () => ({
+      ok: false,
+      status: 500,
+      json: async () => {
+        throw new Error('not json');
+      },
+    })) as unknown as typeof fetch;
+    const client = createDaemonClient({ fetchImpl });
+    await expect(client.getChecklist()).rejects.toBeInstanceOf(DaemonHttpError);
+  });
+
+  it('falls back to global fetch when no fetchImpl is provided', async () => {
+    const original = globalThis.fetch;
+    const stub = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ items: [] }),
+    })) as unknown as typeof fetch;
+    globalThis.fetch = stub;
+    try {
+      const client = createDaemonClient();
+      await client.getChecklist();
+      expect(stub).toHaveBeenCalledTimes(1);
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+});

--- a/packages/floating-hint/tests/main.smoke.test.ts
+++ b/packages/floating-hint/tests/main.smoke.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+
+const browserWindowMock = vi.fn().mockImplementation(() => ({
+  setAlwaysOnTop: vi.fn(),
+  setVisibleOnAllWorkspaces: vi.fn(),
+  setIgnoreMouseEvents: vi.fn(),
+  loadFile: vi.fn().mockResolvedValue(undefined),
+  show: vi.fn(),
+  isDestroyed: () => false,
+  webContents: { on: vi.fn() },
+  on: vi.fn(),
+}));
+
+const appMock = {
+  whenReady: vi.fn(() => Promise.resolve()),
+  on: vi.fn(),
+  quit: vi.fn(),
+};
+
+vi.mock('electron', () => ({
+  app: appMock,
+  BrowserWindow: browserWindowMock,
+  screen: {
+    getPrimaryDisplay: () => ({
+      workArea: { x: 0, y: 25, width: 1440, height: 875 },
+    }),
+  },
+  contextBridge: { exposeInMainWorld: vi.fn() },
+}));
+
+const originalPlatform = process.platform;
+
+beforeAll(() => {
+  Object.defineProperty(process, 'platform', {
+    value: 'darwin',
+    configurable: true,
+  });
+});
+
+afterAll(() => {
+  Object.defineProperty(process, 'platform', {
+    value: originalPlatform,
+    configurable: true,
+  });
+});
+
+describe('main process smoke', () => {
+  it('boots the Electron app and creates the floating-hint BrowserWindow', async () => {
+    browserWindowMock.mockClear();
+    appMock.whenReady.mockClear();
+    appMock.on.mockClear();
+
+    await import('../src/main/index.js');
+    // Allow whenReady().then(...) microtasks to run.
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(appMock.whenReady).toHaveBeenCalled();
+    expect(browserWindowMock).toHaveBeenCalledTimes(1);
+
+    const opts = browserWindowMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(opts).toBeTruthy();
+    expect(opts.alwaysOnTop).toBe(true);
+    expect(opts.frame).toBe(false);
+    expect(opts.transparent).toBe(true);
+    expect(opts.backgroundColor).toBe('#00000000');
+    expect(opts.focusable).toBe(false);
+    expect(opts.width).toBe(360);
+    expect(opts.height).toBe(200);
+
+    const winInstance = browserWindowMock.mock.results[0]?.value as {
+      setAlwaysOnTop: ReturnType<typeof vi.fn>;
+      loadFile: ReturnType<typeof vi.fn>;
+    };
+    expect(winInstance.setAlwaysOnTop).toHaveBeenCalledWith(true, 'floating');
+    expect(winInstance.loadFile).toHaveBeenCalled();
+  });
+});

--- a/packages/floating-hint/tests/window-options.test.ts
+++ b/packages/floating-hint/tests/window-options.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  HINT_WINDOW_HEIGHT,
+  HINT_WINDOW_MARGIN,
+  HINT_WINDOW_WIDTH,
+  assertSupportedPlatform,
+  buildBrowserWindowOptions,
+  calculatePosition,
+} from '../src/main/window-options.js';
+
+describe('calculatePosition', () => {
+  it('places the window at the bottom-right with a 16px margin', () => {
+    const workArea = { x: 0, y: 0, width: 1920, height: 1080 };
+    const pos = calculatePosition(workArea);
+    expect(pos.x).toBe(1920 - HINT_WINDOW_WIDTH - HINT_WINDOW_MARGIN);
+    expect(pos.y).toBe(1080 - HINT_WINDOW_HEIGHT - HINT_WINDOW_MARGIN);
+  });
+
+  it('respects a non-zero work-area origin (e.g. macOS menu bar offset)', () => {
+    const workArea = { x: 0, y: 25, width: 1440, height: 875 };
+    const pos = calculatePosition(workArea);
+    expect(pos.x).toBe(0 + 1440 - HINT_WINDOW_WIDTH - HINT_WINDOW_MARGIN);
+    expect(pos.y).toBe(25 + 875 - HINT_WINDOW_HEIGHT - HINT_WINDOW_MARGIN);
+  });
+
+  it('accepts custom width / height / margin overrides', () => {
+    const workArea = { x: 0, y: 0, width: 1000, height: 800 };
+    const pos = calculatePosition(workArea, 200, 100, 8);
+    expect(pos.x).toBe(1000 - 200 - 8);
+    expect(pos.y).toBe(800 - 100 - 8);
+  });
+});
+
+describe('buildBrowserWindowOptions', () => {
+  const workArea = { x: 0, y: 0, width: 1920, height: 1080 };
+  const opts = buildBrowserWindowOptions(workArea, '/path/to/preload.js');
+
+  it('sets the F-P5PP-01 window flags (always-on-top, transparent, focusable=false)', () => {
+    expect(opts.alwaysOnTop).toBe(true);
+    expect(opts.frame).toBe(false);
+    expect(opts.transparent).toBe(true);
+    expect(opts.backgroundColor).toBe('#00000000');
+    expect(opts.focusable).toBe(false);
+  });
+
+  it('uses the PRD §5 sizing (360 × 200) and primary-display bottom-right placement', () => {
+    expect(opts.width).toBe(360);
+    expect(opts.height).toBe(200);
+    expect(opts.x).toBe(1920 - 360 - 16);
+    expect(opts.y).toBe(1080 - 200 - 16);
+  });
+
+  it('locks down the renderer with contextIsolation=true and nodeIntegration=false', () => {
+    expect(opts.webPreferences?.contextIsolation).toBe(true);
+    expect(opts.webPreferences?.nodeIntegration).toBe(false);
+    expect(opts.webPreferences?.sandbox).toBe(true);
+    expect(opts.webPreferences?.preload).toBe('/path/to/preload.js');
+  });
+
+  it('disables window decorations that would interfere with overlay use', () => {
+    expect(opts.resizable).toBe(false);
+    expect(opts.minimizable).toBe(false);
+    expect(opts.maximizable).toBe(false);
+    expect(opts.skipTaskbar).toBe(true);
+    expect(opts.show).toBe(false);
+  });
+});
+
+describe('assertSupportedPlatform', () => {
+  it('does nothing on darwin', () => {
+    const exit = vi.fn() as unknown as (code: number) => never;
+    const log = vi.fn();
+    assertSupportedPlatform('darwin', exit, log);
+    expect(exit).not.toHaveBeenCalled();
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it('logs a guidance message and exits with code 1 on non-darwin platforms', () => {
+    const exit = vi.fn() as unknown as (code: number) => never;
+    const log = vi.fn();
+    assertSupportedPlatform('linux', exit, log);
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(log).toHaveBeenCalledTimes(1);
+    const message = log.mock.calls[0]?.[0] as string;
+    expect(message).toMatch(/macOS/);
+    expect(message).toMatch(/linux/);
+  });
+
+  it('also rejects win32', () => {
+    const exit = vi.fn() as unknown as (code: number) => never;
+    const log = vi.fn();
+    assertSupportedPlatform('win32', exit, log);
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/floating-hint/tsconfig.build.json
+++ b/packages/floating-hint/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "lib": ["ES2022", "DOM"],
+    "types": ["node"],
+    "jsx": "react-jsx",
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["tests", "node_modules", "dist"]
+}

--- a/packages/floating-hint/tsconfig.json
+++ b/packages/floating-hint/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "lib": ["ES2022", "DOM"],
+    "types": ["node"],
+    "jsx": "react-jsx"
+  },
+  "include": ["src/**/*", "tests/**/*", "vitest.config.ts"]
+}

--- a/packages/floating-hint/vitest.config.ts
+++ b/packages/floating-hint/vitest.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary'],
+      include: ['src/**/*.ts'],
+      exclude: [
+        'src/main/index.ts',
+        'src/preload/index.ts',
+        'src/renderer/index.ts',
+      ],
+      thresholds: {
+        lines: 80,
+        functions: 80,
+        branches: 80,
+        statements: 80,
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,28 @@ importers:
         specifier: ^2.1.0
         version: 2.1.9(@types/node@22.19.17)(msw@2.14.2(@types/node@22.19.17)(typescript@5.9.3))
 
+  packages/floating-hint:
+    dependencies:
+      '@onboarding/shared':
+        specifier: workspace:*
+        version: link:../shared
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
+      '@vitest/coverage-v8':
+        specifier: ^2.1.0
+        version: 2.1.9(vitest@2.1.9(@types/node@22.19.17)(msw@2.14.2(@types/node@22.19.17)(typescript@5.9.3)))
+      electron:
+        specifier: ^32.0.0
+        version: 32.3.3
+      typescript:
+        specifier: ^5.5.4
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(@types/node@22.19.17)(msw@2.14.2(@types/node@22.19.17)(typescript@5.9.3))
+
   packages/shared:
     dependencies:
       zod:
@@ -122,6 +144,10 @@ packages:
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@electron/get@2.0.3':
+    resolution: {integrity: sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==}
+    engines: {node: '>=12'}
 
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
@@ -668,15 +694,26 @@ packages:
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
+  '@sindresorhus/is@4.6.0':
+    resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
+    engines: {node: '>=10'}
+
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
+
+  '@szmarczak/http-timer@4.0.6':
+    resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
+    engines: {node: '>=10'}
 
   '@types/better-sqlite3@7.6.13':
     resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
 
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
+  '@types/cacheable-request@6.0.3':
+    resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
 
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
@@ -693,8 +730,14 @@ packages:
   '@types/express@4.17.25':
     resolution: {integrity: sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==}
 
+  '@types/http-cache-semantics@4.2.0':
+    resolution: {integrity: sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==}
+
   '@types/http-errors@2.0.5':
     resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
+
+  '@types/keyv@3.1.4':
+    resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
 
   '@types/methods@1.1.4':
     resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
@@ -711,6 +754,9 @@ packages:
   '@types/node@18.19.130':
     resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
+  '@types/node@20.19.39':
+    resolution: {integrity: sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==}
+
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
@@ -719,6 +765,9 @@ packages:
 
   '@types/range-parser@1.2.7':
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
+  '@types/responselike@1.0.3':
+    resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
 
   '@types/send@0.17.6':
     resolution: {integrity: sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==}
@@ -743,6 +792,9 @@ packages:
 
   '@types/wrap-ansi@3.0.0':
     resolution: {integrity: sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==}
+
+  '@types/yauzl@2.10.3':
+    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
   '@vitest/coverage-v8@2.1.9':
     resolution: {integrity: sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==}
@@ -854,12 +906,19 @@ packages:
     resolution: {integrity: sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
+  boolean@3.2.0:
+    resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
   brace-expansion@2.1.0:
     resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
+
+  buffer-crc32@0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
@@ -870,6 +929,14 @@ packages:
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  cacheable-lookup@5.0.4:
+    resolution: {integrity: sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==}
+    engines: {node: '>=10.6.0'}
+
+  cacheable-request@7.0.4:
+    resolution: {integrity: sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==}
     engines: {node: '>=8'}
 
   call-bind-apply-helpers@1.0.2:
@@ -913,6 +980,9 @@ packages:
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
+
+  clone-response@1.0.3:
+    resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -998,6 +1068,18 @@ packages:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
 
+  defer-to-connect@2.0.1:
+    resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
+    engines: {node: '>=10'}
+
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+
+  define-properties@1.2.1:
+    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
+    engines: {node: '>= 0.4'}
+
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
@@ -1014,6 +1096,9 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  detect-node@2.1.0:
+    resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
+
   dezalgo@1.0.4:
     resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
 
@@ -1026,6 +1111,11 @@ packages:
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  electron@32.3.3:
+    resolution: {integrity: sha512-7FT8tDg+MueAw8dBn5LJqDvlM4cZkKJhXfgB3w7P5gvSoUQVAY6LIQcXJxgL+vw2rIRY/b9ak7ZBFbCMF2Bk4w==}
+    engines: {node: '>= 12.20.55'}
+    hasBin: true
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -1042,6 +1132,10 @@ packages:
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -1062,6 +1156,9 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
+  es6-error@4.1.1:
+    resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
+
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
@@ -1073,6 +1170,10 @@ packages:
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -1105,6 +1206,11 @@ packages:
     resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
     engines: {node: '>=4'}
 
+  extract-zip@2.0.1:
+    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
+    engines: {node: '>= 10.17.0'}
+    hasBin: true
+
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
@@ -1116,6 +1222,9 @@ packages:
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
+
+  fd-slicer@1.1.0:
+    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
@@ -1158,6 +1267,10 @@ packages:
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
+  fs-extra@8.1.0:
+    resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
+    engines: {node: '>=6 <7 || >=8'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1182,6 +1295,10 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-stream@5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
+
   get-stream@9.0.1:
     resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
     engines: {node: '>=18'}
@@ -1194,9 +1311,24 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
+  global-agent@3.0.0:
+    resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
+    engines: {node: '>=10.0'}
+
+  globalthis@1.0.4:
+    resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
+    engines: {node: '>= 0.4'}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
+
+  got@11.8.6:
+    resolution: {integrity: sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==}
+    engines: {node: '>=10.19.0'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
   graphql@16.13.2:
     resolution: {integrity: sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==}
@@ -1205,6 +1337,9 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
 
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
@@ -1224,9 +1359,16 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
+  http-cache-semantics@4.2.0:
+    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  http2-wrapper@1.0.3:
+    resolution: {integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==}
+    engines: {node: '>=10.19.0'}
 
   human-signals@8.0.1:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
@@ -1304,12 +1446,28 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-stringify-safe@5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+
+  jsonfile@4.0.0:
+    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
   log-symbols@6.0.0:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
     engines: {node: '>=18'}
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lowercase-keys@2.0.0:
+    resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
+    engines: {node: '>=8'}
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
@@ -1322,6 +1480,10 @@ packages:
 
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+
+  matcher@3.0.0:
+    resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
     engines: {node: '>=10'}
 
   math-intrinsics@1.1.0:
@@ -1360,6 +1522,10 @@ packages:
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
+
+  mimic-response@1.0.1:
+    resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
+    engines: {node: '>=4'}
 
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
@@ -1437,12 +1603,20 @@ packages:
       encoding:
         optional: true
 
+  normalize-url@6.1.0:
+    resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
+    engines: {node: '>=10'}
+
   npm-run-path@6.0.0:
     resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
     engines: {node: '>=18'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  object-keys@1.1.1:
+    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
 
   on-exit-leak-free@2.1.2:
@@ -1470,6 +1644,10 @@ packages:
 
   outvariant@1.4.3:
     resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
+
+  p-cancelable@2.1.1:
+    resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
+    engines: {node: '>=8'}
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
@@ -1507,6 +1685,9 @@ packages:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
+  pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1537,6 +1718,10 @@ packages:
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -1554,6 +1739,10 @@ packages:
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  quick-lru@5.1.1:
+    resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
+    engines: {node: '>=10'}
 
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
@@ -1579,12 +1768,22 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
+  resolve-alpn@1.2.1:
+    resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
+
+  responselike@2.0.1:
+    resolution: {integrity: sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==}
+
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
 
   rettime@0.11.8:
     resolution: {integrity: sha512-0fERGXktJTyJ+h8fBEiPxHPEFOu0h15JY7JtwrOVqR5K+vb99ho6IyOo7ekLS3h4sJCzIDy4VWKIbZUfe9njmg==}
+
+  roarr@2.15.4:
+    resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
+    engines: {node: '>=8.0'}
 
   rollup@4.60.2:
     resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
@@ -1601,6 +1800,13 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  semver-compare@1.0.0:
+    resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
@@ -1609,6 +1815,10 @@ packages:
   send@0.19.2:
     resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
     engines: {node: '>= 0.8.0'}
+
+  serialize-error@7.0.1:
+    resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
+    engines: {node: '>=10'}
 
   serve-static@1.16.3:
     resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
@@ -1675,6 +1885,9 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
+  sprintf-js@1.1.3:
+    resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -1722,6 +1935,10 @@ packages:
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
+
+  sumchecker@3.0.1:
+    resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
+    engines: {node: '>= 8.0'}
 
   superagent@10.3.0:
     resolution: {integrity: sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==}
@@ -1799,6 +2016,10 @@ packages:
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
+  type-fest@0.13.1:
+    resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
+    engines: {node: '>=10'}
+
   type-fest@0.21.3:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
@@ -1825,6 +2046,10 @@ packages:
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
+
+  universalify@0.1.2:
+    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
+    engines: {node: '>= 4.0.0'}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -1957,6 +2182,9 @@ packages:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
 
+  yauzl@2.10.0:
+    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
+
   yoctocolors-cjs@2.1.3:
     resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
     engines: {node: '>=18'}
@@ -2001,6 +2229,20 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@bcoe/v8-coverage@0.2.3': {}
+
+  '@electron/get@2.0.3':
+    dependencies:
+      debug: 4.4.3
+      env-paths: 2.2.1
+      fs-extra: 8.1.0
+      got: 11.8.6
+      progress: 2.0.3
+      semver: 6.3.1
+      sumchecker: 3.0.1
+    optionalDependencies:
+      global-agent: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@emnapi/runtime@1.10.0':
     dependencies:
@@ -2411,7 +2653,13 @@ snapshots:
 
   '@sec-ant/readable-stream@0.4.1': {}
 
+  '@sindresorhus/is@4.6.0': {}
+
   '@sindresorhus/merge-streams@4.0.0': {}
+
+  '@szmarczak/http-timer@4.0.6':
+    dependencies:
+      defer-to-connect: 2.0.1
 
   '@types/better-sqlite3@7.6.13':
     dependencies:
@@ -2421,6 +2669,13 @@ snapshots:
     dependencies:
       '@types/connect': 3.4.38
       '@types/node': 22.19.17
+
+  '@types/cacheable-request@6.0.3':
+    dependencies:
+      '@types/http-cache-semantics': 4.2.0
+      '@types/keyv': 3.1.4
+      '@types/node': 22.19.17
+      '@types/responselike': 1.0.3
 
   '@types/connect@3.4.38':
     dependencies:
@@ -2444,7 +2699,13 @@ snapshots:
       '@types/qs': 6.15.0
       '@types/serve-static': 1.15.10
 
+  '@types/http-cache-semantics@4.2.0': {}
+
   '@types/http-errors@2.0.5': {}
+
+  '@types/keyv@3.1.4':
+    dependencies:
+      '@types/node': 22.19.17
 
   '@types/methods@1.1.4': {}
 
@@ -2463,6 +2724,10 @@ snapshots:
     dependencies:
       undici-types: 5.26.5
 
+  '@types/node@20.19.39':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@22.19.17':
     dependencies:
       undici-types: 6.21.0
@@ -2470,6 +2735,10 @@ snapshots:
   '@types/qs@6.15.0': {}
 
   '@types/range-parser@1.2.7': {}
+
+  '@types/responselike@1.0.3':
+    dependencies:
+      '@types/node': 22.19.17
 
   '@types/send@0.17.6':
     dependencies:
@@ -2505,6 +2774,11 @@ snapshots:
       '@types/superagent': 8.1.9
 
   '@types/wrap-ansi@3.0.0': {}
+
+  '@types/yauzl@2.10.3':
+    dependencies:
+      '@types/node': 22.19.17
+    optional: true
 
   '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@22.19.17)(msw@2.14.2(@types/node@22.19.17)(typescript@5.9.3)))':
     dependencies:
@@ -2640,6 +2914,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  boolean@3.2.0:
+    optional: true
+
   brace-expansion@2.1.0:
     dependencies:
       balanced-match: 1.0.2
@@ -2647,6 +2924,8 @@ snapshots:
   brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
+
+  buffer-crc32@0.2.13: {}
 
   buffer@5.7.1:
     dependencies:
@@ -2656,6 +2935,18 @@ snapshots:
   bytes@3.1.2: {}
 
   cac@6.7.14: {}
+
+  cacheable-lookup@5.0.4: {}
+
+  cacheable-request@7.0.4:
+    dependencies:
+      clone-response: 1.0.3
+      get-stream: 5.2.0
+      http-cache-semantics: 4.2.0
+      keyv: 4.5.4
+      lowercase-keys: 2.0.0
+      normalize-url: 6.1.0
+      responselike: 2.0.1
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -2696,6 +2987,10 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
+
+  clone-response@1.0.3:
+    dependencies:
+      mimic-response: 1.0.1
 
   color-convert@2.0.1:
     dependencies:
@@ -2759,6 +3054,22 @@ snapshots:
 
   deep-extend@0.6.0: {}
 
+  defer-to-connect@2.0.1: {}
+
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+    optional: true
+
+  define-properties@1.2.1:
+    dependencies:
+      define-data-property: 1.1.4
+      has-property-descriptors: 1.0.2
+      object-keys: 1.1.1
+    optional: true
+
   delayed-stream@1.0.0: {}
 
   depd@2.0.0: {}
@@ -2766,6 +3077,9 @@ snapshots:
   destroy@1.2.0: {}
 
   detect-libc@2.1.2: {}
+
+  detect-node@2.1.0:
+    optional: true
 
   dezalgo@1.0.4:
     dependencies:
@@ -2782,6 +3096,14 @@ snapshots:
 
   ee-first@1.1.1: {}
 
+  electron@32.3.3:
+    dependencies:
+      '@electron/get': 2.0.3
+      '@types/node': 20.19.39
+      extract-zip: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
@@ -2793,6 +3115,8 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
+
+  env-paths@2.2.1: {}
 
   es-define-property@1.0.1: {}
 
@@ -2810,6 +3134,9 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.3
+
+  es6-error@4.1.1:
+    optional: true
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -2840,6 +3167,9 @@ snapshots:
   escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
+
+  escape-string-regexp@4.0.0:
+    optional: true
 
   estree-walker@3.0.3:
     dependencies:
@@ -2910,6 +3240,16 @@ snapshots:
       iconv-lite: 0.4.24
       tmp: 0.0.33
 
+  extract-zip@2.0.1:
+    dependencies:
+      debug: 4.4.3
+      get-stream: 5.2.0
+      yauzl: 2.10.0
+    optionalDependencies:
+      '@types/yauzl': 2.10.3
+    transitivePeerDependencies:
+      - supports-color
+
   fast-safe-stringify@2.1.1: {}
 
   fast-string-truncated-width@3.0.3: {}
@@ -2921,6 +3261,10 @@ snapshots:
   fast-wrap-ansi@0.2.0:
     dependencies:
       fast-string-width: 3.0.2
+
+  fd-slicer@1.1.0:
+    dependencies:
+      pend: 1.2.0
 
   figures@6.1.0:
     dependencies:
@@ -2972,6 +3316,12 @@ snapshots:
 
   fs-constants@1.0.0: {}
 
+  fs-extra@8.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 4.0.0
+      universalify: 0.1.2
+
   fsevents@2.3.3:
     optional: true
 
@@ -2999,6 +3349,10 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  get-stream@5.2.0:
+    dependencies:
+      pump: 3.0.4
+
   get-stream@9.0.1:
     dependencies:
       '@sec-ant/readable-stream': 0.4.1
@@ -3015,11 +3369,48 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
+  global-agent@3.0.0:
+    dependencies:
+      boolean: 3.2.0
+      es6-error: 4.1.1
+      matcher: 3.0.0
+      roarr: 2.15.4
+      semver: 7.7.4
+      serialize-error: 7.0.1
+    optional: true
+
+  globalthis@1.0.4:
+    dependencies:
+      define-properties: 1.2.1
+      gopd: 1.2.0
+    optional: true
+
   gopd@1.2.0: {}
+
+  got@11.8.6:
+    dependencies:
+      '@sindresorhus/is': 4.6.0
+      '@szmarczak/http-timer': 4.0.6
+      '@types/cacheable-request': 6.0.3
+      '@types/responselike': 1.0.3
+      cacheable-lookup: 5.0.4
+      cacheable-request: 7.0.4
+      decompress-response: 6.0.0
+      http2-wrapper: 1.0.3
+      lowercase-keys: 2.0.0
+      p-cancelable: 2.1.1
+      responselike: 2.0.1
+
+  graceful-fs@4.2.11: {}
 
   graphql@16.13.2: {}
 
   has-flag@4.0.0: {}
+
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
+    optional: true
 
   has-symbols@1.1.0: {}
 
@@ -3038,6 +3429,8 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
+  http-cache-semantics@4.2.0: {}
+
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -3045,6 +3438,11 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
+
+  http2-wrapper@1.0.3:
+    dependencies:
+      quick-lru: 5.1.1
+      resolve-alpn: 1.2.1
 
   human-signals@8.0.1: {}
 
@@ -3109,12 +3507,27 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
+  json-buffer@3.0.1: {}
+
+  json-stringify-safe@5.0.1:
+    optional: true
+
+  jsonfile@4.0.0:
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
   log-symbols@6.0.0:
     dependencies:
       chalk: 5.6.2
       is-unicode-supported: 1.3.0
 
   loupe@3.2.1: {}
+
+  lowercase-keys@2.0.0: {}
 
   lru-cache@10.4.3: {}
 
@@ -3131,6 +3544,11 @@ snapshots:
   make-dir@4.0.0:
     dependencies:
       semver: 7.7.4
+
+  matcher@3.0.0:
+    dependencies:
+      escape-string-regexp: 4.0.0
+    optional: true
 
   math-intrinsics@1.1.0: {}
 
@@ -3151,6 +3569,8 @@ snapshots:
   mime@2.6.0: {}
 
   mimic-function@5.0.1: {}
+
+  mimic-response@1.0.1: {}
 
   mimic-response@3.1.0: {}
 
@@ -3217,12 +3637,17 @@ snapshots:
     dependencies:
       whatwg-url: 5.0.0
 
+  normalize-url@6.1.0: {}
+
   npm-run-path@6.0.0:
     dependencies:
       path-key: 4.0.0
       unicorn-magic: 0.3.0
 
   object-inspect@1.13.4: {}
+
+  object-keys@1.1.1:
+    optional: true
 
   on-exit-leak-free@2.1.2: {}
 
@@ -3254,6 +3679,8 @@ snapshots:
 
   outvariant@1.4.3: {}
 
+  p-cancelable@2.1.1: {}
+
   package-json-from-dist@1.0.1: {}
 
   parse-ms@4.0.0: {}
@@ -3276,6 +3703,8 @@ snapshots:
   pathe@1.1.2: {}
 
   pathval@2.0.1: {}
+
+  pend@1.2.0: {}
 
   picocolors@1.1.1: {}
 
@@ -3326,6 +3755,8 @@ snapshots:
 
   process-warning@5.0.0: {}
 
+  progress@2.0.3: {}
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -3345,6 +3776,8 @@ snapshots:
       side-channel: 1.1.0
 
   quick-format-unescaped@4.0.4: {}
+
+  quick-lru@5.1.1: {}
 
   range-parser@1.2.1: {}
 
@@ -3372,12 +3805,28 @@ snapshots:
 
   require-directory@2.1.1: {}
 
+  resolve-alpn@1.2.1: {}
+
+  responselike@2.0.1:
+    dependencies:
+      lowercase-keys: 2.0.0
+
   restore-cursor@5.1.0:
     dependencies:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
   rettime@0.11.8: {}
+
+  roarr@2.15.4:
+    dependencies:
+      boolean: 3.2.0
+      detect-node: 2.1.0
+      globalthis: 1.0.4
+      json-stringify-safe: 5.0.1
+      semver-compare: 1.0.0
+      sprintf-js: 1.1.3
+    optional: true
 
   rollup@4.60.2:
     dependencies:
@@ -3416,6 +3865,11 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  semver-compare@1.0.0:
+    optional: true
+
+  semver@6.3.1: {}
+
   semver@7.7.4: {}
 
   send@0.19.2:
@@ -3435,6 +3889,11 @@ snapshots:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
+
+  serialize-error@7.0.1:
+    dependencies:
+      type-fest: 0.13.1
+    optional: true
 
   serve-static@1.16.3:
     dependencies:
@@ -3533,6 +3992,9 @@ snapshots:
 
   split2@4.2.0: {}
 
+  sprintf-js@1.1.3:
+    optional: true
+
   stackback@0.0.2: {}
 
   statuses@2.0.2: {}
@@ -3576,6 +4038,12 @@ snapshots:
   strip-final-newline@4.0.0: {}
 
   strip-json-comments@2.0.1: {}
+
+  sumchecker@3.0.1:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   superagent@10.3.0:
     dependencies:
@@ -3665,6 +4133,9 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  type-fest@0.13.1:
+    optional: true
+
   type-fest@0.21.3: {}
 
   type-fest@5.6.0:
@@ -3683,6 +4154,8 @@ snapshots:
   undici-types@6.21.0: {}
 
   unicorn-magic@0.3.0: {}
+
+  universalify@0.1.2: {}
 
   unpipe@1.0.0: {}
 
@@ -3809,6 +4282,11 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yauzl@2.10.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      fd-slicer: 1.1.0
 
   yoctocolors-cjs@2.1.3: {}
 


### PR DESCRIPTION
# Code Review — spec-014-fh-skeleton

- **Spec**: `specs/spec-014-fh-skeleton.md`
- **Branch**: `feature/spec-014-fh-skeleton` (commit `81cec2e`)
- **Reviewer**: Claude Opus 4.7 (read-only review)
- **Review date**: 2026-05-01
- **Diff scope**: `git diff 81cec2e^..81cec2e` (16 files, +1,231 lines, all under `packages/floating-hint/` plus `pnpm-lock.yaml`)

## 종합 판정

| # | 항목 | 판정 |
|---|---|---|
| 1 | AC 정합성 (PRD §10) | **PASS** |
| 2 | PRD 정합성 (의도/스코프) | **PASS** |
| 3 | 데이터 모델 정합성 (PRD §8) | **PASS** (해당 없음) |
| 4 | API 계약 정합성 (PRD §9) | **PASS** |
| 5 | 보안 점검 | **PASS** |
| 6 | 코드 품질 (함수 길이, 커버리지) | **PASS** |
| 7 | BOUNDARIES.md 준수 | **PASS** |
| 8 | 의존성 체크 (PRD §12) | **PASS WITH WARN** |

**최종**: **PASS WITH WARN** — 모든 AC 충족, 빌드/테스트/린트 통과. 단 spec 문언과 `package.json` 사이에 사소한 불일치 2건 (renderer 스택 React→vanilla DOM 변경, devDeps에 `@types/node`/`@vitest/coverage-v8` 추가)이 있으나 모두 PRD §12 / BOUNDARIES.md §3 카탈로그 외 신규 의존성 도입을 회피하기 위한 합리적 선택으로 판단됨.

---

## 1. AC 정합성 (PRD §10) — **PASS**

spec의 Acceptance Criteria를 코드/테스트와 1:1 매핑한다.

| AC | 충족 위치 | 결과 |
|---|---|---|
| **F-P5PP-01** (always-on-top, 반투명, focusable=false) | `src/main/window-options.ts:31-35` (alwaysOnTop, frame=false, transparent, backgroundColor='#00000000', focusable=false) + 단언 `tests/window-options.test.ts:38-44` | PASS |
| **AC-VIS-09 부분 충족** (외부 앱 입력 비탈취) | `focusable: false` (`src/main/window-options.ts:35`) + 윈도우는 `setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true })`만 적용. 단언 `tests/window-options.test.ts:43`. 클릭-스루 (`setIgnoreMouseEvents`)는 SPEC-016 빨간 박스 오버레이에서 별도 윈도우로 다룰 항목이라 본 spec 범위 밖. 수동 검증 항목은 spec에 명시되어 있음. | PASS (부분 — spec 명시대로) |
| **우측 하단 16px 마진, primary display 기준** | `calculatePosition()` (`src/main/window-options.ts:9-19`) + `screen.getPrimaryDisplay()` (`src/main/index.ts:15-16`). 단언 `tests/window-options.test.ts:11-31` (메뉴바 오프셋 케이스 포함) | PASS |
| **preload contextBridge로만 노출, nodeIntegration=false, contextIsolation=true** | `src/preload/index.ts:27` (`exposeInMainWorld`) + webPreferences `src/main/window-options.ts:42-47` (`contextIsolation: true`, `nodeIntegration: false`, `sandbox: true`). 단언 `tests/window-options.test.ts:53-58` | PASS (오히려 sandbox=true까지 추가 강화) |
| **비-macOS 부팅 시 안내 + 종료 코드 1** | `assertSupportedPlatform()` (`src/main/window-options.ts:51-63`), 호출 `src/main/index.ts:29-32`. 단언 `tests/window-options.test.ts:69-95` (linux/win32) | PASS |
| **`pnpm --filter @onboarding/floating-hint test` 통과** | 검증 실행: 24/24 통과 | PASS |
| **`pnpm --filter @onboarding/floating-hint build` 통과** | 검증 실행: `tsc -p tsconfig.build.json && copy-renderer.mjs` 성공, `dist/main`, `dist/preload`, `dist/renderer/index.{html,js}` 모두 생성됨 | PASS |
| **`pnpm --filter @onboarding/floating-hint lint` 에러 0** | 검증 실행: 통과 (`lint = tsc -p tsconfig.json`, 에러 없음) | PASS |
| **테스트 커버리지 ≥ 80%** | v8 coverage: lines 100% / branches 100% / functions 94.11% / statements 100% (대상: `daemon-client.ts`, `window-options.ts`). 부트 진입점 (`main/index.ts`, `preload/index.ts`, `renderer/index.ts`)은 `vitest.config.ts:11-14`에서 의도적으로 제외 — Electron 부팅 단언을 smoke test로 대체한다는 spec 명시와 일치 | PASS |
| **BOUNDARIES.md 준수** | 항목 #7 참조 | PASS |
| **신규 의존성 PRD §12만 추가** | 항목 #8 참조 | PASS WITH WARN |

추가로 `tests/main.smoke.test.ts`가 `BrowserWindow` 옵션, `setAlwaysOnTop(true, 'floating')` 호출, `loadFile` 호출까지 검증하므로 Electron 부팅 단언도 갖춰져 있음.

---

## 2. PRD 정합성 — **PASS**

- PRD §6.2 C "Floating Hint Window — Electron 기반 always-on-top 반투명 윈도우, 운영 중 메인 UI, 데몬 API와 IPC 통신" → 빈 스켈레톤 + daemon HTTP wrapper로 충족.
- PRD §3.1 P5++ Floating Hint Window 라인업의 첫 단추로서, 두 버튼/AI 응답/빨간 박스/재시도 등 후속 UI 기능은 명시된 비범위 (SPEC-015, SPEC-016)로 분리되어 있어 spec scope creep 없음.
- PRD §5 김하나 시나리오 윈도우 외형: 360×200, 우측 하단 배치 — 코드상 일치 (`HINT_WINDOW_WIDTH = 360`, `HINT_WINDOW_HEIGHT = 200`, 16px 마진).
- 본 spec 외 패키지 (`packages/daemon`, `packages/cli`, `packages/shared`) 침범 없음 (`git diff 81cec2e^..81cec2e --stat` 확인). spec-014 커밋 영향 범위는 `packages/floating-hint/**` + `pnpm-lock.yaml`(자동 갱신)뿐.

---

## 3. 데이터 모델 정합성 (PRD §8) — **PASS** (해당 없음)

본 spec은 SQLite 접근 코드를 추가하지 않는다. floating-hint는 daemon HTTP API를 호출하는 클라이언트일 뿐이며, DB 직접 접근은 daemon 측 책임이다 (PRD §6.2 B). 코드에 `better-sqlite3` 또는 SQL 문자열 없음을 grep으로 확인 (검색 결과 0건).

---

## 4. API 계약 정합성 (PRD §9) — **PASS**

`src/main/daemon-client.ts`의 모든 엔드포인트 경로/메서드를 PRD §9.1과 1:1 비교:

| Daemon client 메서드 | 호출 경로 | 메서드 | PRD §9 라우트 | 일치 |
|---|---|---|---|---|
| `getChecklist` | `/api/checklist` | GET | §9.1.1 | ✓ |
| `startItem` | `/api/items/:itemId/start` | POST | §9.1.2 | ✓ |
| `requestGuide` | `/api/vision/guide` | POST | §9.1.3 | ✓ |
| `requestVerify` | `/api/vision/verify` | POST | §9.1.4 | ✓ |
| `getRateLimit` | `/api/vision/rate-limit` | GET | §9.1.5 | ✓ |
| `getConsents` / `postConsent` | `/api/consents` | GET/POST | §9.1.6 | ✓ |
| `postClipboard` | `/api/clipboard` | POST | §9.1.7 | ✓ |
| `runVerify` | `/api/verify/run` | POST | §9.1.8 | ✓ |

baseUrl `http://localhost:7777` 일치 (`DEFAULT_DAEMON_BASE_URL`). 요청 본문은 PRD가 명시한 `{ item_id, step_id }`, `{ consent_type, granted }`, `{ command }`, `{ item_id, verification }` 형태로 그대로 전달. 응답은 `Promise<unknown>` 반환 (스켈레톤 단계라 zod 검증 미포함이지만 BOUNDARIES.md §4 계약 변경에는 해당하지 않음 — 호출자만 추가). Breaking change 없음.

`startItem`이 `encodeURIComponent(itemId)`로 path를 안전하게 인코딩하는 점도 양호 (`tests/daemon-client.test.ts:59-67`).

---

## 5. 보안 점검 — **PASS**

| 점검 | 결과 |
|---|---|
| 시크릿 하드코딩 | 없음. Anthropic 키, 토큰, 개인정보 어떤 형태로도 코드/테스트/픽스처에 미존재 (소스 grep 결과 0건). |
| SQL 인젝션 | 해당 없음 (DB 접근 없음). |
| 캡처 이미지 데이터 파기 (PRD §8.2 / AC-VIS-07) | 본 spec 범위 밖이지만, floating-hint는 캡처 이미지를 직접 다루지 않고 daemon API만 호출. `daemon-client.ts`에 binary/base64 처리 코드 없음. 위반 위험 없음. |
| 렌더러 격리 | `contextIsolation: true`, `nodeIntegration: false`, `sandbox: true`, CSP `default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'` (`src/renderer/index.html:5-8`). preload는 IPC 표면을 9개 메서드로만 제한 노출하여 최소 권한 원칙을 따름. |
| URL 입력 인코딩 | `startItem`이 `encodeURIComponent` 사용으로 path 주입 차단. |

`style-src 'unsafe-inline'`은 인라인 `<style>` 블록(`index.html:11-40`) 때문에 필요. CSP 자체를 제거하기보다 인라인 허용을 명시적으로 보존한 합리적 선택. 향후 CSS 파일 분리 시 제거 가능 — 현 단계 보안 결함 아님.

---

## 6. 코드 품질 — **PASS**

### 함수 길이 (50줄 미만)

| 파일 | 함수 | 줄 수 |
|---|---|---|
| `src/main/index.ts` | `createMainWindow` | 11 |
| `src/main/index.ts` | `bootstrap` | 21 |
| `src/main/window-options.ts` | `calculatePosition` | 11 |
| `src/main/window-options.ts` | `buildBrowserWindowOptions` | 29 |
| `src/main/window-options.ts` | `assertSupportedPlatform` | 13 |
| `src/main/daemon-client.ts` | `createDaemonClient` (closure 포함) | 41 |
| `src/main/daemon-client.ts` | `request` (내부) | 23 |

모든 함수 50줄 미만. 가장 긴 함수가 41줄.

### 테스트 커버리지

```
File               | % Stmts | % Branch | % Funcs | % Lines
daemon-client.ts   |   100   |   100    |   100   |   100
window-options.ts  |   100   |   100    |    75   |   100
All files          |   100   |   100    | 94.11   |   100
```

함수 커버리지 94.11%로 80% 임계 통과. `window-options.ts` 75%는 `assertSupportedPlatform`의 기본 인자 (`log`) 분기가 미커버일 가능성. line/branch가 100%이므로 실질 커버리지는 충분.

### 기타

- 명확한 export 타입 (`DaemonClient`, `DaemonClientOptions`, `VisionStepInput` 등) — 호환 가능한 인터페이스로 SPEC-015가 바로 의존 가능.
- 의존성 주입 (`fetchImpl` 옵션, `assertSupportedPlatform`의 `exit`/`log` 인자) — 테스트 가능성 우수.
- 주석은 비범위 표시 (`renderer/index.tsx:1-3`)와 `copy-renderer.mjs` 헤더 정도로 절제됨.

---

## 7. BOUNDARIES.md 준수 — **PASS**

| 항목 | 결과 |
|---|---|
| §1 수정 금지 (PRD, BOUNDARIES, spec-template, 다른 spec) | 미수정 |
| §2 spec 외 패키지 미수정 | 변경 파일 모두 `packages/floating-hint/**` (+ `pnpm-lock.yaml` 자동 갱신). `git diff 81cec2e^..81cec2e --stat`로 확인. 다른 패키지 / 루트 워크스페이스 설정 미변경. |
| §3 의존성 카탈로그 | 항목 #8 참조 |
| §4 API 계약 보호 | 라우트 / 요청 본문 변경 없음 (항목 #4 참조). |
| §5 시크릿 하드코딩 금지 | 위반 없음 (항목 #5 참조). |

---

## 8. 의존성 체크 (PRD §12) — **PASS WITH WARN**

`packages/floating-hint/package.json` 의존성:

| 라이브러리 | 종류 | PRD §12 / BOUNDARIES §3 | 비고 |
|---|---|---|---|
| `@onboarding/shared` (workspace) | dep | OK (내부 워크스페이스) | — |
| `electron` ^32.0.0 | devDep | OK (PRD §12 명시) | spec 명시와 일치 |
| `vitest` ^2.1.0 | devDep | OK (PRD §12 명시) | spec 명시와 일치 |
| `typescript` ^5.5.4 | devDep | OK (PRD §12 명시: ^5.5) | — |
| `@types/node` ^22.0.0 | devDep | **표 미등재** (WARN) | 타입 전용. 다른 패키지(daemon, cli)도 동일 사용. PRD §12를 엄격 해석하면 신규지만, 표준 라이브러리 타입이라 BOUNDARIES.md §3 "transitive dependency 허용" 정신에는 부합. spec이 "신규 의존성은 PRD §12 (`electron`, `vitest`)만"이라 명시하므로 사소한 일탈로 기록. |
| `@vitest/coverage-v8` ^2.1.0 | devDep | **표 미등재** (WARN) | vitest의 공식 coverage 플러그인 (별도 npm 패키지). spec에 커버리지 80%+ 요구가 있어 사실상 필요. PRD §12는 `vitest`만 명시하지만 vitest 모노레포의 sub-package라 PRD 의도상 문제 없음. spec 문언 엄격 해석 시 일탈. |

또한 spec 문언에 "최소 React 마운트"가 적혀 있으나 실제 구현은 vanilla DOM (`renderer/index.tsx:5-8` 한 줄 placeholder)로 변경되었음. 코드 주석에 "PRD §12 catalog does not include React; no JSX is used here so the .tsx extension reduces to plain TypeScript"로 그 사유가 명시됨. **이는 spec 문언과 BOUNDARIES.md §3 (PRD §12 외 라이브러리 추가 금지) 사이의 충돌을 BOUNDARIES.md 준수 쪽으로 해소한 올바른 판단**으로 보이며, FAIL이 아닌 WARN으로 분류한다.

---

## 권고 (블로커 없음)

1. **Spec 문언 정정** (선택): `specs/spec-014-fh-skeleton.md`의 "최소 React 마운트" 문구를 vanilla DOM placeholder로 갱신하면 spec/구현 정합성이 기록상에서도 일치한다. 이번 commit은 사람의 spec 개정으로만 처리해야 하므로 이 review에서는 변경하지 않음.
2. **PRD §12 명시화** (선택): `@types/node`, `@vitest/coverage-v8`을 PRD §12 표에 transitive/types-only 카테고리로 명시하면 향후 spec 작성 시 동일 WARN을 회피할 수 있다.
3. **AC-VIS-09 수동 검증 흔적**: spec이 수동 검증을 인정하므로 본 review 대상은 아니나, 빨간 박스 오버레이를 만드는 SPEC-016에서 별도 click-through 윈도우(`setIgnoreMouseEvents(true, { forward: true })`)가 필요할 것을 미리 확인.

---

## 검증 명령 실행 결과 (참고용)

| 명령 | 결과 |
|---|---|
| `pnpm --filter @onboarding/floating-hint test` | 24/24 통과, 커버리지 lines 100% / functions 94.11% |
| `pnpm --filter @onboarding/floating-hint lint` | 0 에러 |
| `pnpm --filter @onboarding/floating-hint build` | 성공 (dist/main, dist/preload, dist/renderer 모두 생성, index.html 복사 완료) |

---

## 완료 신호

WARN만 존재하므로:

<promise>SPEC_014_FH_SKELETON_REVIEW_PASS_WITH_WARN</promise>
