### PR TITLE
[Ralph] spec-015-fh-ui-buttons

### DIFF
--- a/packages/floating-hint/src/preload/bridge.ts
+++ b/packages/floating-hint/src/preload/bridge.ts
@@ -1,0 +1,18 @@
+import type {
+  ClipboardInput,
+  ConsentInput,
+  VerifyRunInput,
+  VisionStepInput,
+} from '../main/daemon-client.js';
+
+export interface DaemonClientBridge {
+  getChecklist: () => Promise<unknown>;
+  startItem: (itemId: string) => Promise<unknown>;
+  requestGuide: (input: VisionStepInput) => Promise<unknown>;
+  requestVerify: (input: VisionStepInput) => Promise<unknown>;
+  getRateLimit: () => Promise<unknown>;
+  getConsents: () => Promise<unknown>;
+  postConsent: (input: ConsentInput) => Promise<unknown>;
+  postClipboard: (input: ClipboardInput) => Promise<unknown>;
+  runVerify: (input: VerifyRunInput) => Promise<unknown>;
+}

--- a/packages/floating-hint/src/preload/index.ts
+++ b/packages/floating-hint/src/preload/index.ts
@@ -7,10 +7,13 @@ import {
   type VerifyRunInput,
   type VisionStepInput,
 } from '../main/daemon-client.js';
+import type { DaemonClientBridge } from './bridge.js';
+
+export type { DaemonClientBridge } from './bridge.js';
 
 const client: DaemonClient = createDaemonClient();
 
-const exposed = {
+const exposed: DaemonClientBridge = {
   getChecklist: () => client.getChecklist(),
   startItem: (itemId: string) => client.startItem(itemId),
   requestGuide: (input: VisionStepInput) => client.requestGuide(input),
@@ -20,8 +23,6 @@ const exposed = {
   postConsent: (input: ConsentInput) => client.postConsent(input),
   postClipboard: (input: ClipboardInput) => client.postClipboard(input),
   runVerify: (input: VerifyRunInput) => client.runVerify(input),
-} as const;
-
-export type DaemonClientBridge = typeof exposed;
+};
 
 contextBridge.exposeInMainWorld('daemonClient', exposed);

--- a/packages/floating-hint/src/renderer/api.ts
+++ b/packages/floating-hint/src/renderer/api.ts
@@ -1,0 +1,41 @@
+import type { DaemonClientBridge } from '../preload/bridge.js';
+import type {
+  ChecklistResponse,
+  RendererApi,
+  VisionGuideResponse,
+  VisionVerifyResponse,
+} from './state/store.js';
+import type { RateLimitInfo } from './state/machine.js';
+
+export interface CreateRendererApiOptions {
+  bridge?: DaemonClientBridge;
+}
+
+function resolveBridge(
+  override: DaemonClientBridge | undefined,
+): DaemonClientBridge {
+  if (override) return override;
+  const global = globalThis as { daemonClient?: DaemonClientBridge };
+  if (!global.daemonClient) {
+    throw new Error(
+      'daemonClient bridge is not exposed on the window. Make sure preload/index.ts ran.',
+    );
+  }
+  return global.daemonClient;
+}
+
+export function createRendererApi(
+  options: CreateRendererApiOptions = {},
+): RendererApi {
+  const bridge = resolveBridge(options.bridge);
+  return {
+    getChecklist: () =>
+      bridge.getChecklist() as Promise<ChecklistResponse>,
+    requestGuide: (input) =>
+      bridge.requestGuide(input) as Promise<VisionGuideResponse>,
+    requestVerify: (input) =>
+      bridge.requestVerify(input) as Promise<VisionVerifyResponse>,
+    getRateLimit: () => bridge.getRateLimit() as Promise<RateLimitInfo>,
+    getConsents: () => bridge.getConsents(),
+  };
+}

--- a/packages/floating-hint/src/renderer/components/ActionButtons.ts
+++ b/packages/floating-hint/src/renderer/components/ActionButtons.ts
@@ -1,0 +1,74 @@
+import type { UiMode } from '../state/machine.js';
+import { el, text, type ElementVNode } from '../vnode.js';
+
+export interface ActionButtonsProps {
+  mode: UiMode;
+  onGuide: () => void;
+  onVerify: () => void;
+}
+
+function isDisabled(mode: UiMode): boolean {
+  return mode.kind === 'loading' || mode.kind === 'consent-blocked';
+}
+
+function spinner(testid: string): ElementVNode {
+  return el(
+    'span',
+    {
+      className: 'spinner',
+      dataset: { testid },
+      ariaLabel: '로딩 중',
+      role: 'status',
+    },
+    [text('⏳')],
+  );
+}
+
+function button(
+  testid: string,
+  label: string,
+  onClick: () => void,
+  disabled: boolean,
+  showSpinner: boolean,
+): ElementVNode {
+  const children = showSpinner
+    ? [spinner(`spinner-${testid.replace('btn-', '')}`), text(' '), text(label)]
+    : [text(label)];
+  return el(
+    'button',
+    {
+      type: 'button',
+      className: 'action-btn',
+      disabled,
+      dataset: { testid },
+      on: { click: () => onClick() },
+    },
+    children,
+  );
+}
+
+export function ActionButtons(props: ActionButtonsProps): ElementVNode {
+  const disabled = isDisabled(props.mode);
+  const loadingPending =
+    props.mode.kind === 'loading' ? props.mode.pending : null;
+  return el(
+    'div',
+    { className: 'action-buttons', dataset: { testid: 'action-buttons' } },
+    [
+      button(
+        'btn-guide',
+        '📋 안내 요청',
+        props.onGuide,
+        disabled,
+        loadingPending === 'guide',
+      ),
+      button(
+        'btn-verify',
+        '✓ 진행 확인',
+        props.onVerify,
+        disabled,
+        loadingPending === 'verify',
+      ),
+    ],
+  );
+}

--- a/packages/floating-hint/src/renderer/components/ConsentBlocker.ts
+++ b/packages/floating-hint/src/renderer/components/ConsentBlocker.ts
@@ -1,0 +1,46 @@
+import type { UiMode } from '../state/machine.js';
+import { el, text, type ElementVNode } from '../vnode.js';
+
+export interface ConsentBlockerProps {
+  mode: UiMode;
+  onOpenSettings: () => void;
+}
+
+const COPY: Record<'screen_recording' | 'consent_required', string> = {
+  screen_recording:
+    '화면 기록 권한이 필요합니다. 시스템 설정 > 개인 정보 보호 > 화면 기록에서 onboarding을 허용해주세요.',
+  consent_required:
+    'Anthropic 전송 동의가 필요합니다. `onboarding` CLI 위저드를 다시 실행해 동의를 갱신해주세요.',
+};
+
+export function ConsentBlocker(
+  props: ConsentBlockerProps,
+): ElementVNode | null {
+  if (props.mode.kind !== 'consent-blocked') return null;
+  const message = COPY[props.mode.reason];
+  return el(
+    'div',
+    {
+      className: 'consent-blocker',
+      role: 'alert',
+      dataset: { testid: 'consent-blocker' },
+    },
+    [
+      el(
+        'p',
+        { className: 'consent-blocker__message' },
+        [text(message)],
+      ),
+      el(
+        'button',
+        {
+          type: 'button',
+          className: 'btn-open-settings',
+          dataset: { testid: 'btn-open-settings' },
+          on: { click: () => props.onOpenSettings() },
+        },
+        [text('설정 열기')],
+      ),
+    ],
+  );
+}

--- a/packages/floating-hint/src/renderer/components/HintWindow.ts
+++ b/packages/floating-hint/src/renderer/components/HintWindow.ts
@@ -1,0 +1,44 @@
+import type { AppState } from '../state/machine.js';
+import { el, type ElementVNode } from '../vnode.js';
+import { ActionButtons } from './ActionButtons.js';
+import { ConsentBlocker } from './ConsentBlocker.js';
+import { ProgressBadge } from './ProgressBadge.js';
+import { RatePausedBanner } from './RatePausedBanner.js';
+import { ResponsePanel } from './ResponsePanel.js';
+import { RetryBanner } from './RetryBanner.js';
+
+export interface HintWindowProps {
+  state: AppState;
+  now: number;
+  onGuide: () => void;
+  onVerify: () => void;
+  onRetry: () => void;
+  onOpenSettings: () => void;
+}
+
+export function HintWindow(props: HintWindowProps): ElementVNode {
+  const { state, now, onGuide, onVerify, onRetry, onOpenSettings } = props;
+  const banner =
+    RetryBanner({ mode: state.mode, onRetry }) ??
+    RatePausedBanner({ mode: state.mode, now }) ??
+    ConsentBlocker({ mode: state.mode, onOpenSettings });
+
+  const children: ElementVNode[] = [
+    ProgressBadge({
+      stepIndex: state.context.stepIndex,
+      totalSteps: state.context.totalSteps,
+    }),
+    ResponsePanel({ mode: state.mode }),
+    ActionButtons({ mode: state.mode, onGuide, onVerify }),
+  ];
+  if (banner) children.push(banner);
+
+  return el(
+    'div',
+    {
+      className: 'hint-window',
+      dataset: { testid: 'hint-window' },
+    },
+    children,
+  );
+}

--- a/packages/floating-hint/src/renderer/components/ProgressBadge.ts
+++ b/packages/floating-hint/src/renderer/components/ProgressBadge.ts
@@ -1,0 +1,26 @@
+import { el, text, type ElementVNode } from '../vnode.js';
+
+export interface ProgressBadgeProps {
+  stepIndex: number;
+  totalSteps: number;
+}
+
+export function ProgressBadge(props: ProgressBadgeProps): ElementVNode {
+  if (props.totalSteps <= 0) {
+    return el(
+      'div',
+      { className: 'progress-badge', hidden: true, dataset: { testid: 'progress-badge' } },
+      [],
+    );
+  }
+  const current = Math.min(props.totalSteps, Math.max(1, props.stepIndex + 1));
+  return el(
+    'div',
+    {
+      className: 'progress-badge',
+      dataset: { testid: 'progress-badge' },
+      ariaLive: 'polite',
+    },
+    [text(`단계 ${current}/${props.totalSteps}`)],
+  );
+}

--- a/packages/floating-hint/src/renderer/components/RatePausedBanner.ts
+++ b/packages/floating-hint/src/renderer/components/RatePausedBanner.ts
@@ -1,0 +1,44 @@
+import type { UiMode } from '../state/machine.js';
+import { el, text, type ElementVNode } from '../vnode.js';
+
+export interface RatePausedBannerProps {
+  mode: UiMode;
+  now: number;
+}
+
+function formatCountdown(remainingMs: number): string {
+  const total = Math.max(0, Math.floor(remainingMs / 1000));
+  const minutes = Math.floor(total / 60);
+  const seconds = total % 60;
+  return `${minutes.toString().padStart(2, '0')}:${seconds
+    .toString()
+    .padStart(2, '0')}`;
+}
+
+export function RatePausedBanner(
+  props: RatePausedBannerProps,
+): ElementVNode | null {
+  if (props.mode.kind !== 'rate-paused') return null;
+  const remaining = props.mode.resetAt - props.now;
+  const display = formatCountdown(remaining);
+  return el(
+    'div',
+    {
+      className: 'rate-paused-banner',
+      role: 'alert',
+      dataset: { testid: 'rate-paused-banner' },
+    },
+    [
+      el(
+        'p',
+        { className: 'rate-paused-banner__message' },
+        [text('AI Vision 호출이 일시 정지되었습니다. 다음 시간대까지 정지됩니다.')],
+      ),
+      el(
+        'span',
+        { className: 'rate-countdown', dataset: { testid: 'rate-countdown' } },
+        [text(display)],
+      ),
+    ],
+  );
+}

--- a/packages/floating-hint/src/renderer/components/ResponsePanel.ts
+++ b/packages/floating-hint/src/renderer/components/ResponsePanel.ts
@@ -1,0 +1,127 @@
+import type { UiMode } from '../state/machine.js';
+import { el, text, type ElementVNode } from '../vnode.js';
+
+export interface ResponsePanelProps {
+  mode: UiMode;
+}
+
+const SCROLL_THRESHOLD = 200;
+
+function panel(
+  children: ElementVNode[],
+  scrollable: boolean,
+): ElementVNode {
+  return el(
+    'div',
+    {
+      className: 'response-panel',
+      role: 'region',
+      ariaLive: 'polite',
+      dataset: {
+        testid: 'response-panel',
+        scrollable: scrollable ? 'true' : 'false',
+      },
+    },
+    children,
+  );
+}
+
+function guideContent(message: string, confidence: string): ElementVNode[] {
+  return [
+    el(
+      'p',
+      { className: 'response-message', dataset: { testid: 'response-message' } },
+      [text(message)],
+    ),
+    el(
+      'span',
+      {
+        className: `response-confidence response-confidence--${confidence}`,
+        dataset: { testid: 'response-confidence' },
+      },
+      [text(`confidence: ${confidence}`)],
+    ),
+  ];
+}
+
+function verifyContent(
+  status: string,
+  reasoning: string,
+  hint?: string,
+): ElementVNode[] {
+  const children: ElementVNode[] = [
+    el(
+      'span',
+      {
+        className: `response-status response-status--${status}`,
+        dataset: { testid: 'response-status' },
+      },
+      [text(`status: ${status}`)],
+    ),
+    el(
+      'p',
+      { className: 'response-message', dataset: { testid: 'response-message' } },
+      [text(reasoning)],
+    ),
+  ];
+  if (hint) {
+    children.push(
+      el(
+        'p',
+        { className: 'response-hint', dataset: { testid: 'response-hint' } },
+        [text(hint)],
+      ),
+    );
+  }
+  return children;
+}
+
+export function ResponsePanel(props: ResponsePanelProps): ElementVNode {
+  const mode = props.mode;
+  if (mode.kind === 'showing-guide') {
+    return panel(
+      guideContent(mode.result.message, mode.result.confidence),
+      mode.result.message.length > SCROLL_THRESHOLD,
+    );
+  }
+  if (mode.kind === 'showing-verify') {
+    return panel(
+      verifyContent(
+        mode.result.status,
+        mode.result.reasoning,
+        mode.result.next_action_hint,
+      ),
+      mode.result.reasoning.length > SCROLL_THRESHOLD,
+    );
+  }
+  if (mode.kind === 'loading') {
+    return panel(
+      [
+        el(
+          'span',
+          {
+            className: 'response-loading',
+            dataset: { testid: 'response-loading' },
+            role: 'status',
+          },
+          [text('AI에 요청 중…')],
+        ),
+      ],
+      false,
+    );
+  }
+  // idle / error / rate-paused / consent-blocked: empty placeholder.
+  return panel(
+    [
+      el(
+        'span',
+        {
+          className: 'response-empty',
+          dataset: { testid: 'response-empty' },
+        },
+        [text('아직 안내가 없습니다. 버튼을 눌러주세요.')],
+      ),
+    ],
+    false,
+  );
+}

--- a/packages/floating-hint/src/renderer/components/RetryBanner.ts
+++ b/packages/floating-hint/src/renderer/components/RetryBanner.ts
@@ -1,0 +1,38 @@
+import type { UiMode } from '../state/machine.js';
+import { el, text, type ElementVNode } from '../vnode.js';
+
+export interface RetryBannerProps {
+  mode: UiMode;
+  onRetry: () => void;
+}
+
+export function RetryBanner(props: RetryBannerProps): ElementVNode | null {
+  if (props.mode.kind !== 'error') return null;
+  const status = props.mode.status;
+  const message = props.mode.message;
+  return el(
+    'div',
+    {
+      className: 'retry-banner',
+      role: 'alert',
+      dataset: { testid: 'retry-banner' },
+    },
+    [
+      el(
+        'p',
+        { className: 'retry-banner__message' },
+        [text(`오류 ${status}: ${message}`)],
+      ),
+      el(
+        'button',
+        {
+          type: 'button',
+          className: 'btn-retry',
+          dataset: { testid: 'btn-retry' },
+          on: { click: () => props.onRetry() },
+        },
+        [text('🔄 재시도')],
+      ),
+    ],
+  );
+}

--- a/packages/floating-hint/src/renderer/dom-mount.ts
+++ b/packages/floating-hint/src/renderer/dom-mount.ts
@@ -1,0 +1,100 @@
+import { isText, type ElementVNode, type VNode, type VNodeAttrs } from './vnode.js';
+
+// Minimal DOM contract — large enough to render our VNodes without depending
+// on full lib.dom typings (so tests can pass a stub).
+interface DomElementLike {
+  appendChild(child: DomElementLike): DomElementLike;
+  replaceChildren(...nodes: DomElementLike[]): void;
+  setAttribute(name: string, value: string): void;
+  removeAttribute(name: string): void;
+  addEventListener(event: string, handler: (e: unknown) => void): void;
+  textContent: string;
+  disabled?: boolean;
+  hidden?: boolean;
+}
+
+export interface DomLike {
+  createElement(tag: string): DomElementLike;
+  createTextNode(text: string): DomElementLike;
+}
+
+const BOOLEAN_PROPS = new Set<keyof VNodeAttrs>(['disabled', 'hidden']);
+
+function applyAttrs(target: DomElementLike, attrs: VNodeAttrs | null | undefined): void {
+  if (!attrs) return;
+  if (attrs.className !== undefined) target.setAttribute('class', attrs.className);
+  if (attrs.id !== undefined) target.setAttribute('id', attrs.id);
+  if (attrs.role !== undefined) target.setAttribute('role', attrs.role);
+  if (attrs.ariaLabel !== undefined) target.setAttribute('aria-label', attrs.ariaLabel);
+  if (attrs.ariaLive !== undefined) target.setAttribute('aria-live', attrs.ariaLive);
+  if (attrs.tabIndex !== undefined) target.setAttribute('tabindex', String(attrs.tabIndex));
+  if (attrs.href !== undefined) target.setAttribute('href', attrs.href);
+  if (attrs.type !== undefined) target.setAttribute('type', attrs.type);
+  const targetMap = target as unknown as Record<string, unknown>;
+  for (const prop of BOOLEAN_PROPS) {
+    const value = attrs[prop];
+    if (value === true) {
+      target.setAttribute(String(prop), '');
+      targetMap[prop] = true;
+    } else if (value === false) {
+      target.removeAttribute(String(prop));
+      targetMap[prop] = false;
+    }
+  }
+  if (attrs.dataset) {
+    for (const [k, v] of Object.entries(attrs.dataset)) {
+      target.setAttribute(`data-${k}`, v);
+    }
+  }
+  if (attrs.style) {
+    const cssParts: string[] = [];
+    for (const [k, v] of Object.entries(attrs.style)) {
+      if (v !== undefined) cssParts.push(`${k}: ${String(v)}`);
+    }
+    if (cssParts.length > 0) target.setAttribute('style', cssParts.join('; '));
+  }
+  if (attrs.on) {
+    for (const [event, handler] of Object.entries(attrs.on)) {
+      if (handler) {
+        target.addEventListener(event, handler as (e: unknown) => void);
+      }
+    }
+  }
+}
+
+function createNode(node: VNode, dom: DomLike): DomElementLike {
+  if (isText(node)) {
+    return dom.createTextNode(node.text);
+  }
+  const element = dom.createElement(node.tag);
+  applyAttrs(element, node.attrs);
+  if (node.children) {
+    for (const child of node.children) {
+      element.appendChild(createNode(child, dom));
+    }
+  }
+  return element;
+}
+
+export function mountVNode(
+  node: ElementVNode,
+  parent: DomElementLike,
+  dom: DomLike,
+): DomElementLike {
+  const created = createNode(node, dom);
+  parent.appendChild(created);
+  return created;
+}
+
+export function applyVNode(
+  node: ElementVNode | null,
+  root: DomElementLike,
+  dom: DomLike,
+): void {
+  if (node === null) {
+    root.replaceChildren();
+    return;
+  }
+  const created = createNode(node, dom);
+  root.replaceChildren(created);
+}

--- a/packages/floating-hint/src/renderer/index.ts
+++ b/packages/floating-hint/src/renderer/index.ts
@@ -1,0 +1,57 @@
+// Renderer entry — wires the store, daemon-client bridge, and component tree to
+// the live DOM. This module is intentionally untestable end-to-end (it touches
+// `window`, `document`, and Electron's preload bridge); see vitest.config.ts
+// where it is excluded from coverage. All non-trivial logic lives in modules
+// that are unit-tested.
+
+import { HintWindow } from './components/HintWindow.js';
+import { applyVNode, type DomLike } from './dom-mount.js';
+import { createRendererApi } from './api.js';
+import { createStore } from './state/store.js';
+
+const RATE_TICK_MS = 1_000;
+
+function bootstrap(): void {
+  const root = document.getElementById('app');
+  if (!root) return;
+  const api = createRendererApi();
+  const store = createStore({ api });
+  const dom: DomLike = {
+    createElement: (tag) =>
+      document.createElement(tag) as unknown as ReturnType<DomLike['createElement']>,
+    createTextNode: (text) =>
+      document.createTextNode(text) as unknown as ReturnType<
+        DomLike['createTextNode']
+      >,
+  };
+  const rootDom = root as unknown as Parameters<typeof applyVNode>[1];
+
+  function render(): void {
+    const tree = HintWindow({
+      state: store.getState(),
+      now: Date.now(),
+      onGuide: () => {
+        void store.requestGuide();
+      },
+      onVerify: () => {
+        void store.requestVerify();
+      },
+      onRetry: () => {
+        void store.retry();
+      },
+      onOpenSettings: () => {
+        // Phase 2 hook — for now nudge the user via the response panel.
+      },
+    });
+    applyVNode(tree, rootDom, dom);
+  }
+
+  store.subscribe(render);
+  store.startChecklistPoll();
+  setInterval(() => {
+    if (store.getState().mode.kind === 'rate-paused') render();
+  }, RATE_TICK_MS);
+  render();
+}
+
+bootstrap();

--- a/packages/floating-hint/src/renderer/index.tsx
+++ b/packages/floating-hint/src/renderer/index.tsx
@@ -1,8 +1,0 @@
-// Renderer entry — vanilla DOM placeholder. SPEC-015 will replace this with the
-// real UI (two buttons + AI response). PRD §12 catalog does not include React;
-// no JSX is used here so the .tsx extension reduces to plain TypeScript.
-
-const root = document.getElementById('app');
-if (root) {
-  root.textContent = 'Hint Window 준비됨';
-}

--- a/packages/floating-hint/src/renderer/state/machine.ts
+++ b/packages/floating-hint/src/renderer/state/machine.ts
@@ -1,0 +1,196 @@
+import type {
+  VisionGuideResult,
+  VisionVerifyResult,
+} from '@onboarding/shared';
+
+export interface UiContext {
+  itemId: string | null;
+  stepId: string | null;
+  stepIndex: number;
+  totalSteps: number;
+}
+
+export type UiMode =
+  | { kind: 'idle' }
+  | { kind: 'loading'; pending: 'guide' | 'verify' }
+  | { kind: 'showing-guide'; result: VisionGuideResult }
+  | { kind: 'showing-verify'; result: VisionVerifyResult }
+  | {
+      kind: 'error';
+      lastIntent: 'guide' | 'verify';
+      status: number;
+      message: string;
+    }
+  | {
+      kind: 'rate-paused';
+      resetAt: number;
+      lastIntent: 'guide' | 'verify';
+    }
+  | {
+      kind: 'consent-blocked';
+      reason: 'consent_required' | 'screen_recording';
+      lastIntent: 'guide' | 'verify';
+    };
+
+export interface RateLimitInfo {
+  state: 'normal' | 'alert' | 'paused';
+  current_hour_calls?: number;
+  reset_at?: number;
+}
+
+export interface ConsentMap {
+  screen_recording: boolean;
+  anthropic_transmission: boolean;
+}
+
+export interface AppState {
+  mode: UiMode;
+  context: UiContext;
+  stepIds: string[];
+  rateLimit?: RateLimitInfo;
+  consents?: ConsentMap;
+}
+
+export interface ApiErrorBody {
+  error?: string;
+  state?: string;
+  reset_at?: number;
+}
+
+export type Event =
+  | { type: 'REQUEST_GUIDE' }
+  | { type: 'REQUEST_VERIFY' }
+  | { type: 'GUIDE_SUCCESS'; result: VisionGuideResult }
+  | { type: 'VERIFY_SUCCESS'; result: VisionVerifyResult }
+  | { type: 'ERROR'; status: number; body: ApiErrorBody | null }
+  | { type: 'RETRY' }
+  | { type: 'RESOLVE_CONSENT' }
+  | {
+      type: 'SET_CONTEXT';
+      context: UiContext;
+      stepIds: string[];
+    }
+  | { type: 'SET_RATE_LIMIT'; rateLimit: RateLimitInfo }
+  | { type: 'SET_CONSENTS'; consents: ConsentMap };
+
+export const initialState: AppState = Object.freeze({
+  mode: { kind: 'idle' as const },
+  context: {
+    itemId: null,
+    stepId: null,
+    stepIndex: 0,
+    totalSteps: 0,
+  },
+  stepIds: [],
+});
+
+function hasContext(state: AppState): boolean {
+  return state.context.itemId !== null && state.context.stepId !== null;
+}
+
+function lastIntentOf(mode: UiMode): 'guide' | 'verify' | null {
+  switch (mode.kind) {
+    case 'loading':
+      return mode.pending;
+    case 'error':
+    case 'rate-paused':
+    case 'consent-blocked':
+      return mode.lastIntent;
+    default:
+      return null;
+  }
+}
+
+function classifyError(
+  status: number,
+  body: ApiErrorBody | null,
+  intent: 'guide' | 'verify',
+): UiMode {
+  if (status === 401) {
+    return { kind: 'consent-blocked', reason: 'screen_recording', lastIntent: intent };
+  }
+  if (status === 403) {
+    return { kind: 'consent-blocked', reason: 'consent_required', lastIntent: intent };
+  }
+  if (status === 429 && body?.state === 'paused') {
+    return {
+      kind: 'rate-paused',
+      resetAt: body.reset_at ?? 0,
+      lastIntent: intent,
+    };
+  }
+  return {
+    kind: 'error',
+    lastIntent: intent,
+    status,
+    message: body?.error ?? 'unknown_error',
+  };
+}
+
+export function reduce(state: AppState, event: Event): AppState {
+  switch (event.type) {
+    case 'REQUEST_GUIDE': {
+      if (state.mode.kind === 'loading') return state;
+      if (!hasContext(state)) return state;
+      return { ...state, mode: { kind: 'loading', pending: 'guide' } };
+    }
+    case 'REQUEST_VERIFY': {
+      if (state.mode.kind === 'loading') return state;
+      if (!hasContext(state)) return state;
+      return { ...state, mode: { kind: 'loading', pending: 'verify' } };
+    }
+    case 'GUIDE_SUCCESS': {
+      if (state.mode.kind !== 'loading' || state.mode.pending !== 'guide') {
+        return state;
+      }
+      return {
+        ...state,
+        mode: { kind: 'showing-guide', result: event.result },
+      };
+    }
+    case 'VERIFY_SUCCESS': {
+      if (state.mode.kind !== 'loading' || state.mode.pending !== 'verify') {
+        return state;
+      }
+      let context = state.context;
+      if (event.result.status === 'pass') {
+        const nextIndex = state.context.stepIndex + 1;
+        if (nextIndex < state.stepIds.length) {
+          context = {
+            ...state.context,
+            stepIndex: nextIndex,
+            stepId: state.stepIds[nextIndex] ?? state.context.stepId,
+          };
+        }
+      }
+      return {
+        ...state,
+        context,
+        mode: { kind: 'showing-verify', result: event.result },
+      };
+    }
+    case 'ERROR': {
+      const intent = lastIntentOf(state.mode);
+      if (intent === null) return state;
+      return { ...state, mode: classifyError(event.status, event.body, intent) };
+    }
+    case 'RETRY': {
+      const intent = lastIntentOf(state.mode);
+      if (intent === null) return state;
+      return { ...state, mode: { kind: 'loading', pending: intent } };
+    }
+    case 'RESOLVE_CONSENT': {
+      if (state.mode.kind !== 'consent-blocked') return state;
+      return { ...state, mode: { kind: 'idle' } };
+    }
+    case 'SET_CONTEXT': {
+      return { ...state, context: event.context, stepIds: event.stepIds };
+    }
+    case 'SET_RATE_LIMIT': {
+      return { ...state, rateLimit: event.rateLimit };
+    }
+    case 'SET_CONSENTS': {
+      return { ...state, consents: event.consents };
+    }
+  }
+}

--- a/packages/floating-hint/src/renderer/state/store.ts
+++ b/packages/floating-hint/src/renderer/state/store.ts
@@ -1,0 +1,252 @@
+import type {
+  ChecklistItem,
+  ItemState,
+  VisionGuideResult,
+  VisionVerifyResult,
+} from '@onboarding/shared';
+import {
+  initialState,
+  reduce,
+  type AppState,
+  type ApiErrorBody,
+  type Event,
+  type RateLimitInfo,
+  type UiContext,
+} from './machine.js';
+
+export interface VisionGuideResponse {
+  call_id: string;
+  cached?: boolean;
+  latency_ms?: number;
+  result: VisionGuideResult;
+}
+
+export interface VisionVerifyResponse {
+  call_id: string;
+  result: VisionVerifyResult;
+}
+
+export interface ChecklistResponse {
+  items: Array<ItemState & { title: string }>;
+}
+
+export interface RendererApi {
+  getChecklist(): Promise<ChecklistResponse>;
+  requestGuide(input: { item_id: string; step_id: string }): Promise<VisionGuideResponse>;
+  requestVerify(input: { item_id: string; step_id: string }): Promise<VisionVerifyResponse>;
+  getRateLimit(): Promise<RateLimitInfo>;
+  getConsents(): Promise<unknown>;
+}
+
+export interface CreateStoreOptions {
+  api?: RendererApi;
+  checklist?: ChecklistItem[];
+  pollIntervalMs?: number;
+}
+
+export interface Store {
+  getState(): AppState;
+  subscribe(listener: (state: AppState) => void): () => void;
+  dispatch(event: Event): void;
+  startChecklistPoll(): void;
+  stopChecklistPoll(): void;
+  requestGuide(): Promise<void>;
+  requestVerify(): Promise<void>;
+  retry(): Promise<void>;
+}
+
+export const DEFAULT_POLL_INTERVAL_MS = 5_000;
+
+interface DaemonHttpErrorLike {
+  name: 'DaemonHttpError';
+  status: number;
+  body: ApiErrorBody | null;
+}
+
+function isDaemonHttpError(err: unknown): err is DaemonHttpErrorLike {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    (err as { name?: string }).name === 'DaemonHttpError' &&
+    typeof (err as { status?: unknown }).status === 'number'
+  );
+}
+
+function lastIntent(state: AppState): 'guide' | 'verify' | null {
+  switch (state.mode.kind) {
+    case 'loading':
+      return state.mode.pending;
+    case 'error':
+    case 'rate-paused':
+    case 'consent-blocked':
+      return state.mode.lastIntent;
+    case 'showing-guide':
+      return 'guide';
+    case 'showing-verify':
+      return 'verify';
+    default:
+      return null;
+  }
+}
+
+export function createStore(options: CreateStoreOptions = {}): Store {
+  let state: AppState = initialState;
+  const listeners = new Set<(s: AppState) => void>();
+  const checklist = options.checklist ?? [];
+  const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  const api = options.api;
+  let pollHandle: ReturnType<typeof setInterval> | null = null;
+
+  function setState(next: AppState): void {
+    if (next === state) return;
+    state = next;
+    for (const listener of listeners) listener(state);
+  }
+
+  function dispatch(event: Event): void {
+    setState(reduce(state, event));
+  }
+
+  function findItem(itemId: string): ChecklistItem | undefined {
+    return checklist.find((item) => item.id === itemId);
+  }
+
+  function deriveContext(
+    items: ChecklistResponse['items'],
+  ): { context: UiContext; stepIds: string[] } | null {
+    const active =
+      items.find((i) => i.status === 'in_progress') ??
+      items.find((i) => i.status === 'pending');
+    if (!active) return null;
+    const item = findItem(active.item_id);
+    const steps = item?.ai_coaching?.steps ?? [];
+    const stepIds = steps.map((s) => s.id);
+    const currentStepId =
+      active.current_step ??
+      stepIds[0] ??
+      null;
+    const stepIndex = currentStepId
+      ? Math.max(0, stepIds.indexOf(currentStepId))
+      : 0;
+    return {
+      context: {
+        itemId: active.item_id,
+        stepId: currentStepId,
+        stepIndex,
+        totalSteps: stepIds.length,
+      },
+      stepIds,
+    };
+  }
+
+  async function syncChecklist(): Promise<void> {
+    if (!api) return;
+    try {
+      const data = await api.getChecklist();
+      const derived = deriveContext(data.items);
+      if (derived) {
+        dispatch({
+          type: 'SET_CONTEXT',
+          context: derived.context,
+          stepIds: derived.stepIds,
+        });
+      }
+    } catch {
+      // Network/server error during poll: leave existing state.
+    }
+  }
+
+  function startChecklistPoll(): void {
+    if (pollHandle !== null) return;
+    void syncChecklist();
+    pollHandle = setInterval(() => {
+      void syncChecklist();
+    }, pollIntervalMs);
+  }
+
+  function stopChecklistPoll(): void {
+    if (pollHandle !== null) {
+      clearInterval(pollHandle);
+      pollHandle = null;
+    }
+  }
+
+  function errorEvent(err: unknown): Event {
+    if (isDaemonHttpError(err)) {
+      return { type: 'ERROR', status: err.status, body: err.body };
+    }
+    return { type: 'ERROR', status: 500, body: null };
+  }
+
+  async function performGuide(): Promise<void> {
+    if (!api) return;
+    const ctx = state.context;
+    if (!ctx.itemId || !ctx.stepId) return;
+    try {
+      const res = await api.requestGuide({
+        item_id: ctx.itemId,
+        step_id: ctx.stepId,
+      });
+      dispatch({ type: 'GUIDE_SUCCESS', result: res.result });
+    } catch (err) {
+      dispatch(errorEvent(err));
+    }
+  }
+
+  async function performVerify(): Promise<void> {
+    if (!api) return;
+    const ctx = state.context;
+    if (!ctx.itemId || !ctx.stepId) return;
+    try {
+      const res = await api.requestVerify({
+        item_id: ctx.itemId,
+        step_id: ctx.stepId,
+      });
+      dispatch({ type: 'VERIFY_SUCCESS', result: res.result });
+    } catch (err) {
+      dispatch(errorEvent(err));
+    }
+  }
+
+  async function requestGuide(): Promise<void> {
+    if (!state.context.itemId || !state.context.stepId) return;
+    dispatch({ type: 'REQUEST_GUIDE' });
+    if (state.mode.kind !== 'loading') return;
+    await performGuide();
+  }
+
+  async function requestVerify(): Promise<void> {
+    if (!state.context.itemId || !state.context.stepId) return;
+    dispatch({ type: 'REQUEST_VERIFY' });
+    if (state.mode.kind !== 'loading') return;
+    await performVerify();
+  }
+
+  async function retry(): Promise<void> {
+    const intent = lastIntent(state);
+    if (intent === null) return;
+    dispatch({ type: 'RETRY' });
+    if (state.mode.kind !== 'loading') return;
+    if (intent === 'guide') {
+      await performGuide();
+    } else {
+      await performVerify();
+    }
+  }
+
+  return {
+    getState: () => state,
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    dispatch,
+    startChecklistPoll,
+    stopChecklistPoll,
+    requestGuide,
+    requestVerify,
+    retry,
+  };
+}

--- a/packages/floating-hint/src/renderer/vnode.ts
+++ b/packages/floating-hint/src/renderer/vnode.ts
@@ -1,0 +1,107 @@
+export type EventName =
+  | 'click'
+  | 'input'
+  | 'change'
+  | 'keydown'
+  | 'keyup'
+  | 'submit';
+
+export interface VNodeAttrs {
+  className?: string;
+  id?: string;
+  role?: string;
+  ariaLabel?: string;
+  ariaLive?: 'off' | 'polite' | 'assertive';
+  disabled?: boolean;
+  hidden?: boolean;
+  tabIndex?: number;
+  href?: string;
+  type?: string;
+  dataset?: Record<string, string>;
+  style?: Partial<Record<string, string>>;
+  on?: Partial<Record<EventName, (event: unknown) => void>>;
+}
+
+export interface ElementVNode {
+  tag: string;
+  attrs?: VNodeAttrs | null;
+  children?: VNode[];
+}
+
+export interface TextVNode {
+  tag: '#text';
+  text: string;
+}
+
+export type VNode = ElementVNode | TextVNode;
+
+export type VNodeChild = VNode | null | undefined | false;
+
+export function text(value: string): TextVNode {
+  return { tag: '#text', text: value };
+}
+
+export function el(
+  tag: string,
+  attrs: VNodeAttrs | null,
+  children: VNodeChild[],
+): ElementVNode {
+  return {
+    tag,
+    attrs,
+    children: children.filter((c): c is VNode => Boolean(c)),
+  };
+}
+
+export function isText(node: VNode): node is TextVNode {
+  return node.tag === '#text';
+}
+
+export function isElement(node: VNode): node is ElementVNode {
+  return node.tag !== '#text';
+}
+
+function walk(node: VNode, visit: (n: VNode) => void): void {
+  visit(node);
+  if (isElement(node) && node.children) {
+    for (const child of node.children) walk(child, visit);
+  }
+}
+
+export function findByTestId(root: VNode, testid: string): ElementVNode | null {
+  let found: ElementVNode | null = null;
+  walk(root, (node) => {
+    if (found) return;
+    if (isElement(node) && node.attrs?.dataset?.testid === testid) {
+      found = node;
+    }
+  });
+  return found;
+}
+
+export function findAllByTestId(root: VNode, testid: string): ElementVNode[] {
+  const results: ElementVNode[] = [];
+  walk(root, (node) => {
+    if (isElement(node) && node.attrs?.dataset?.testid === testid) {
+      results.push(node);
+    }
+  });
+  return results;
+}
+
+export function findByTag(root: VNode, tag: string): ElementVNode | null {
+  let found: ElementVNode | null = null;
+  walk(root, (node) => {
+    if (found) return;
+    if (isElement(node) && node.tag === tag) {
+      found = node;
+    }
+  });
+  return found;
+}
+
+export function textContent(node: VNode): string {
+  if (isText(node)) return node.text;
+  if (!node.children) return '';
+  return node.children.map(textContent).join('');
+}

--- a/packages/floating-hint/tests/api.test.ts
+++ b/packages/floating-hint/tests/api.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createRendererApi } from '../src/renderer/api.js';
+
+interface DaemonBridge {
+  getChecklist: ReturnType<typeof vi.fn>;
+  startItem: ReturnType<typeof vi.fn>;
+  requestGuide: ReturnType<typeof vi.fn>;
+  requestVerify: ReturnType<typeof vi.fn>;
+  getRateLimit: ReturnType<typeof vi.fn>;
+  getConsents: ReturnType<typeof vi.fn>;
+  postConsent: ReturnType<typeof vi.fn>;
+  postClipboard: ReturnType<typeof vi.fn>;
+  runVerify: ReturnType<typeof vi.fn>;
+}
+
+function makeBridge(): DaemonBridge {
+  return {
+    getChecklist: vi.fn().mockResolvedValue({ items: [] }),
+    startItem: vi.fn().mockResolvedValue({ ok: true }),
+    requestGuide: vi.fn().mockResolvedValue({
+      call_id: 'vc',
+      cached: false,
+      latency_ms: 1,
+      result: { type: 'guide', message: 'm', confidence: 'high' },
+    }),
+    requestVerify: vi.fn().mockResolvedValue({
+      call_id: 'vc',
+      result: { type: 'verify', status: 'pass', reasoning: 'ok' },
+    }),
+    getRateLimit: vi.fn().mockResolvedValue({ state: 'normal' }),
+    getConsents: vi.fn().mockResolvedValue({}),
+    postConsent: vi.fn().mockResolvedValue({}),
+    postClipboard: vi.fn().mockResolvedValue({}),
+    runVerify: vi.fn().mockResolvedValue({}),
+  };
+}
+
+const original = (globalThis as { daemonClient?: unknown }).daemonClient;
+
+beforeEach(() => {
+  (globalThis as { daemonClient?: unknown }).daemonClient = undefined;
+});
+
+afterEach(() => {
+  (globalThis as { daemonClient?: unknown }).daemonClient = original;
+});
+
+describe('createRendererApi', () => {
+  it('proxies getChecklist() to the global daemonClient bridge', async () => {
+    const bridge = makeBridge();
+    (globalThis as { daemonClient?: DaemonBridge }).daemonClient = bridge;
+    const api = createRendererApi();
+    await api.getChecklist();
+    expect(bridge.getChecklist).toHaveBeenCalledTimes(1);
+  });
+
+  it('proxies requestGuide(input) preserving the input shape', async () => {
+    const bridge = makeBridge();
+    (globalThis as { daemonClient?: DaemonBridge }).daemonClient = bridge;
+    const api = createRendererApi();
+    await api.requestGuide({ item_id: 'a', step_id: 'b' });
+    expect(bridge.requestGuide).toHaveBeenCalledWith({
+      item_id: 'a',
+      step_id: 'b',
+    });
+  });
+
+  it('proxies requestVerify(input)', async () => {
+    const bridge = makeBridge();
+    (globalThis as { daemonClient?: DaemonBridge }).daemonClient = bridge;
+    const api = createRendererApi();
+    await api.requestVerify({ item_id: 'a', step_id: 'b' });
+    expect(bridge.requestVerify).toHaveBeenCalledWith({
+      item_id: 'a',
+      step_id: 'b',
+    });
+  });
+
+  it('proxies getRateLimit()', async () => {
+    const bridge = makeBridge();
+    (globalThis as { daemonClient?: DaemonBridge }).daemonClient = bridge;
+    const api = createRendererApi();
+    const out = await api.getRateLimit();
+    expect(out).toEqual({ state: 'normal' });
+  });
+
+  it('proxies getConsents()', async () => {
+    const bridge = makeBridge();
+    (globalThis as { daemonClient?: DaemonBridge }).daemonClient = bridge;
+    const api = createRendererApi();
+    await api.getConsents();
+    expect(bridge.getConsents).toHaveBeenCalled();
+  });
+
+  it('throws when window.daemonClient is missing', () => {
+    expect(() => createRendererApi()).toThrowError(/daemonClient/);
+  });
+
+  it('accepts an explicit bridge override (no global needed)', async () => {
+    const bridge = makeBridge();
+    const api = createRendererApi({ bridge });
+    await api.getChecklist();
+    expect(bridge.getChecklist).toHaveBeenCalled();
+  });
+});

--- a/packages/floating-hint/tests/components/action-buttons.test.ts
+++ b/packages/floating-hint/tests/components/action-buttons.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ActionButtons } from '../../src/renderer/components/ActionButtons.js';
+import { findByTestId, textContent } from '../../src/renderer/vnode.js';
+
+describe('ActionButtons', () => {
+  it('renders both buttons with the prescribed labels', () => {
+    const tree = ActionButtons({
+      mode: { kind: 'idle' },
+      onGuide: () => {},
+      onVerify: () => {},
+    });
+    const guide = findByTestId(tree, 'btn-guide');
+    const verify = findByTestId(tree, 'btn-verify');
+    expect(guide?.tag).toBe('button');
+    expect(verify?.tag).toBe('button');
+    expect(textContent(guide!)).toContain('안내 요청');
+    expect(textContent(verify!)).toContain('진행 확인');
+  });
+
+  it('clicking [안내 요청] invokes onGuide', () => {
+    const onGuide = vi.fn();
+    const tree = ActionButtons({
+      mode: { kind: 'idle' },
+      onGuide,
+      onVerify: () => {},
+    });
+    const guide = findByTestId(tree, 'btn-guide');
+    expect(guide?.attrs?.on?.click).toBeTypeOf('function');
+    guide?.attrs?.on?.click?.({});
+    expect(onGuide).toHaveBeenCalledOnce();
+  });
+
+  it('clicking [진행 확인] invokes onVerify', () => {
+    const onVerify = vi.fn();
+    const tree = ActionButtons({
+      mode: { kind: 'idle' },
+      onGuide: () => {},
+      onVerify,
+    });
+    const verify = findByTestId(tree, 'btn-verify');
+    verify?.attrs?.on?.click?.({});
+    expect(onVerify).toHaveBeenCalledOnce();
+  });
+
+  it('disables both buttons while loading', () => {
+    const tree = ActionButtons({
+      mode: { kind: 'loading', pending: 'guide' },
+      onGuide: () => {},
+      onVerify: () => {},
+    });
+    expect(findByTestId(tree, 'btn-guide')?.attrs?.disabled).toBe(true);
+    expect(findByTestId(tree, 'btn-verify')?.attrs?.disabled).toBe(true);
+  });
+
+  it('shows a spinner inside the active button while loading', () => {
+    const tree = ActionButtons({
+      mode: { kind: 'loading', pending: 'verify' },
+      onGuide: () => {},
+      onVerify: () => {},
+    });
+    expect(findByTestId(tree, 'spinner-verify')).not.toBeNull();
+    expect(findByTestId(tree, 'spinner-guide')).toBeNull();
+  });
+
+  it('disables both buttons when consent is blocked', () => {
+    const tree = ActionButtons({
+      mode: {
+        kind: 'consent-blocked',
+        reason: 'consent_required',
+        lastIntent: 'guide',
+      },
+      onGuide: () => {},
+      onVerify: () => {},
+    });
+    expect(findByTestId(tree, 'btn-guide')?.attrs?.disabled).toBe(true);
+    expect(findByTestId(tree, 'btn-verify')?.attrs?.disabled).toBe(true);
+  });
+});

--- a/packages/floating-hint/tests/components/consent-blocker.test.ts
+++ b/packages/floating-hint/tests/components/consent-blocker.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ConsentBlocker } from '../../src/renderer/components/ConsentBlocker.js';
+import { findByTestId, textContent } from '../../src/renderer/vnode.js';
+
+describe('ConsentBlocker', () => {
+  it('renders a settings entry button on 403 consent_required', () => {
+    const onSettings = vi.fn();
+    const tree = ConsentBlocker({
+      mode: {
+        kind: 'consent-blocked',
+        reason: 'consent_required',
+        lastIntent: 'guide',
+      },
+      onOpenSettings: onSettings,
+    });
+    const btn = findByTestId(tree!, 'btn-open-settings');
+    expect(btn).not.toBeNull();
+    btn?.attrs?.on?.click?.({});
+    expect(onSettings).toHaveBeenCalledOnce();
+  });
+
+  it('shows screen-recording-permission copy on 401', () => {
+    const tree = ConsentBlocker({
+      mode: {
+        kind: 'consent-blocked',
+        reason: 'screen_recording',
+        lastIntent: 'guide',
+      },
+      onOpenSettings: vi.fn(),
+    });
+    expect(textContent(tree!)).toContain('화면 기록');
+  });
+
+  it('shows anthropic-transmission copy on consent_required', () => {
+    const tree = ConsentBlocker({
+      mode: {
+        kind: 'consent-blocked',
+        reason: 'consent_required',
+        lastIntent: 'verify',
+      },
+      onOpenSettings: vi.fn(),
+    });
+    expect(textContent(tree!)).toContain('동의');
+  });
+
+  it('mentions running the CLI wizard again', () => {
+    const tree = ConsentBlocker({
+      mode: {
+        kind: 'consent-blocked',
+        reason: 'consent_required',
+        lastIntent: 'guide',
+      },
+      onOpenSettings: vi.fn(),
+    });
+    expect(textContent(tree!)).toMatch(/위저드|onboarding/);
+  });
+
+  it('returns null when not in consent-blocked mode', () => {
+    const tree = ConsentBlocker({
+      mode: { kind: 'idle' },
+      onOpenSettings: vi.fn(),
+    });
+    expect(tree).toBeNull();
+  });
+});

--- a/packages/floating-hint/tests/components/hint-window.test.ts
+++ b/packages/floating-hint/tests/components/hint-window.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from 'vitest';
+import { HintWindow } from '../../src/renderer/components/HintWindow.js';
+import type { AppState } from '../../src/renderer/state/machine.js';
+import { findByTestId, textContent } from '../../src/renderer/vnode.js';
+
+const baseState: AppState = {
+  mode: { kind: 'idle' },
+  context: {
+    itemId: 'install',
+    stepId: 's0',
+    stepIndex: 0,
+    totalSteps: 2,
+  },
+  stepIds: ['s0', 's1'],
+};
+
+const callbacks = {
+  onGuide: vi.fn(),
+  onVerify: vi.fn(),
+  onRetry: vi.fn(),
+  onOpenSettings: vi.fn(),
+  now: 0,
+};
+
+describe('HintWindow', () => {
+  it('renders progress badge + buttons + response panel in idle state', () => {
+    const tree = HintWindow({ state: baseState, ...callbacks });
+    expect(findByTestId(tree, 'progress-badge')).not.toBeNull();
+    expect(findByTestId(tree, 'btn-guide')).not.toBeNull();
+    expect(findByTestId(tree, 'btn-verify')).not.toBeNull();
+    expect(findByTestId(tree, 'response-panel')).not.toBeNull();
+  });
+
+  it('shows progress "단계 1/2"', () => {
+    const tree = HintWindow({ state: baseState, ...callbacks });
+    expect(textContent(findByTestId(tree, 'progress-badge')!)).toBe('단계 1/2');
+  });
+
+  it('renders RetryBanner when in error mode', () => {
+    const tree = HintWindow({
+      state: {
+        ...baseState,
+        mode: {
+          kind: 'error',
+          lastIntent: 'guide',
+          status: 503,
+          message: 'vision_api_timeout',
+        },
+      },
+      ...callbacks,
+    });
+    expect(findByTestId(tree, 'retry-banner')).not.toBeNull();
+  });
+
+  it('renders RatePausedBanner when in rate-paused mode', () => {
+    const tree = HintWindow({
+      state: {
+        ...baseState,
+        mode: { kind: 'rate-paused', resetAt: 1_000, lastIntent: 'guide' },
+      },
+      ...callbacks,
+      now: 0,
+    });
+    expect(findByTestId(tree, 'rate-paused-banner')).not.toBeNull();
+  });
+
+  it('renders ConsentBlocker when in consent-blocked mode', () => {
+    const tree = HintWindow({
+      state: {
+        ...baseState,
+        mode: {
+          kind: 'consent-blocked',
+          reason: 'consent_required',
+          lastIntent: 'guide',
+        },
+      },
+      ...callbacks,
+    });
+    expect(findByTestId(tree, 'consent-blocker')).not.toBeNull();
+  });
+
+  it('does not render banners when idle', () => {
+    const tree = HintWindow({ state: baseState, ...callbacks });
+    expect(findByTestId(tree, 'retry-banner')).toBeNull();
+    expect(findByTestId(tree, 'rate-paused-banner')).toBeNull();
+    expect(findByTestId(tree, 'consent-blocker')).toBeNull();
+  });
+
+  it('renders the response panel above other regions', () => {
+    const tree = HintWindow({
+      state: {
+        ...baseState,
+        mode: {
+          kind: 'showing-guide',
+          result: { type: 'guide', message: '클릭', confidence: 'high' },
+        },
+      },
+      ...callbacks,
+    });
+    expect(textContent(findByTestId(tree, 'response-message')!)).toBe('클릭');
+  });
+});

--- a/packages/floating-hint/tests/components/progress-badge.test.ts
+++ b/packages/floating-hint/tests/components/progress-badge.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { ProgressBadge } from '../../src/renderer/components/ProgressBadge.js';
+import { findByTestId, textContent } from '../../src/renderer/vnode.js';
+
+describe('ProgressBadge', () => {
+  it('renders "단계 N/M" when totalSteps > 0', () => {
+    const tree = ProgressBadge({ stepIndex: 1, totalSteps: 3 });
+    const node = findByTestId(tree, 'progress-badge');
+    expect(node).not.toBeNull();
+    expect(textContent(node!)).toBe('단계 2/3');
+  });
+
+  it('shows 1-based step index', () => {
+    const tree = ProgressBadge({ stepIndex: 0, totalSteps: 3 });
+    expect(textContent(findByTestId(tree, 'progress-badge')!)).toBe('단계 1/3');
+  });
+
+  it('hides itself when totalSteps is 0', () => {
+    const tree = ProgressBadge({ stepIndex: 0, totalSteps: 0 });
+    expect(tree.attrs?.hidden).toBe(true);
+  });
+});

--- a/packages/floating-hint/tests/components/rate-paused-banner.test.ts
+++ b/packages/floating-hint/tests/components/rate-paused-banner.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { RatePausedBanner } from '../../src/renderer/components/RatePausedBanner.js';
+import {
+  findByTestId,
+  textContent,
+} from '../../src/renderer/vnode.js';
+
+describe('RatePausedBanner', () => {
+  it('shows the reset countdown in mm:ss', () => {
+    const now = 1_000_000;
+    const resetAt = now + 90_500;
+    const tree = RatePausedBanner({
+      mode: {
+        kind: 'rate-paused',
+        resetAt,
+        lastIntent: 'guide',
+      },
+      now,
+    });
+    const countdown = findByTestId(tree!, 'rate-countdown');
+    expect(textContent(countdown!)).toBe('01:30');
+  });
+
+  it('clamps to 00:00 when reset_at is in the past', () => {
+    const now = 5_000;
+    const tree = RatePausedBanner({
+      mode: { kind: 'rate-paused', resetAt: 1_000, lastIntent: 'guide' },
+      now,
+    });
+    expect(textContent(findByTestId(tree!, 'rate-countdown')!)).toBe('00:00');
+  });
+
+  it('mentions the next-hour pause copy', () => {
+    const tree = RatePausedBanner({
+      mode: { kind: 'rate-paused', resetAt: 9_999_999, lastIntent: 'verify' },
+      now: 0,
+    });
+    expect(textContent(tree!)).toContain('정지');
+  });
+
+  it('returns null when not in rate-paused mode', () => {
+    const tree = RatePausedBanner({
+      mode: { kind: 'idle' },
+      now: 0,
+    });
+    expect(tree).toBeNull();
+  });
+});

--- a/packages/floating-hint/tests/components/response-panel.test.ts
+++ b/packages/floating-hint/tests/components/response-panel.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { ResponsePanel } from '../../src/renderer/components/ResponsePanel.js';
+import { findByTestId, textContent } from '../../src/renderer/vnode.js';
+
+describe('ResponsePanel', () => {
+  it('shows guide message + confidence label when in showing-guide mode', () => {
+    const tree = ResponsePanel({
+      mode: {
+        kind: 'showing-guide',
+        result: {
+          type: 'guide',
+          message: '잠금 아이콘을 클릭하세요',
+          confidence: 'high',
+        },
+      },
+    });
+    const message = findByTestId(tree, 'response-message');
+    const confidence = findByTestId(tree, 'response-confidence');
+    expect(textContent(message!)).toBe('잠금 아이콘을 클릭하세요');
+    expect(textContent(confidence!)).toContain('high');
+  });
+
+  it('shows pass result for verify pass', () => {
+    const tree = ResponsePanel({
+      mode: {
+        kind: 'showing-verify',
+        result: {
+          type: 'verify',
+          status: 'pass',
+          reasoning: '완료됨',
+        },
+      },
+    });
+    expect(findByTestId(tree, 'response-status')).not.toBeNull();
+    expect(textContent(findByTestId(tree, 'response-status')!)).toContain('pass');
+    expect(textContent(findByTestId(tree, 'response-message')!)).toContain('완료됨');
+  });
+
+  it('shows next_action_hint on verify fail', () => {
+    const tree = ResponsePanel({
+      mode: {
+        kind: 'showing-verify',
+        result: {
+          type: 'verify',
+          status: 'fail',
+          reasoning: '아직 안 됨',
+          next_action_hint: '잠금 아이콘 클릭',
+        },
+      },
+    });
+    expect(textContent(findByTestId(tree, 'response-hint')!)).toContain(
+      '잠금 아이콘 클릭',
+    );
+  });
+
+  it('renders an empty placeholder when idle', () => {
+    const tree = ResponsePanel({ mode: { kind: 'idle' } });
+    expect(findByTestId(tree, 'response-empty')).not.toBeNull();
+  });
+
+  it('renders a loading indicator when loading', () => {
+    const tree = ResponsePanel({
+      mode: { kind: 'loading', pending: 'guide' },
+    });
+    expect(findByTestId(tree, 'response-loading')).not.toBeNull();
+  });
+
+  it('marks the panel scrollable for long messages', () => {
+    const tree = ResponsePanel({
+      mode: {
+        kind: 'showing-guide',
+        result: {
+          type: 'guide',
+          message: 'a'.repeat(2000),
+          confidence: 'medium',
+        },
+      },
+    });
+    expect(tree.attrs?.dataset?.scrollable).toBe('true');
+  });
+});

--- a/packages/floating-hint/tests/components/retry-banner.test.ts
+++ b/packages/floating-hint/tests/components/retry-banner.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest';
+import { RetryBanner } from '../../src/renderer/components/RetryBanner.js';
+import { findByTestId, textContent } from '../../src/renderer/vnode.js';
+
+describe('RetryBanner', () => {
+  it('renders [🔄 재시도] button on 503 error', () => {
+    const onRetry = vi.fn();
+    const tree = RetryBanner({
+      mode: {
+        kind: 'error',
+        lastIntent: 'guide',
+        status: 503,
+        message: 'vision_api_timeout',
+      },
+      onRetry,
+    });
+    const btn = findByTestId(tree!, 'btn-retry');
+    expect(btn).not.toBeNull();
+    expect(textContent(btn!)).toContain('재시도');
+  });
+
+  it('clicking [재시도] invokes onRetry', () => {
+    const onRetry = vi.fn();
+    const tree = RetryBanner({
+      mode: {
+        kind: 'error',
+        lastIntent: 'guide',
+        status: 503,
+        message: 'timeout',
+      },
+      onRetry,
+    });
+    const btn = findByTestId(tree!, 'btn-retry');
+    btn?.attrs?.on?.click?.({});
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it('shows the error status code in the message', () => {
+    const tree = RetryBanner({
+      mode: {
+        kind: 'error',
+        lastIntent: 'verify',
+        status: 503,
+        message: 'vision_api_timeout',
+      },
+      onRetry: vi.fn(),
+    });
+    expect(textContent(tree!)).toContain('503');
+  });
+
+  it('returns null when not in error mode', () => {
+    const tree = RetryBanner({
+      mode: { kind: 'idle' },
+      onRetry: vi.fn(),
+    });
+    expect(tree).toBeNull();
+  });
+});

--- a/packages/floating-hint/tests/dom-mount.test.ts
+++ b/packages/floating-hint/tests/dom-mount.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mountVNode, applyVNode } from '../src/renderer/dom-mount.js';
+import { el, text } from '../src/renderer/vnode.js';
+import { createDomStub } from './helpers/dom-stub.js';
+
+describe('mountVNode', () => {
+  it('creates an element with text content', () => {
+    const dom = createDomStub();
+    const root = dom.createElement('div');
+    mountVNode(
+      el('p', { className: 'hello', dataset: { testid: 't' } }, [text('Hi')]),
+      root,
+      dom,
+    );
+    expect(root.children).toHaveLength(1);
+    const child = root.children[0]!;
+    expect(child.tag).toBe('p');
+    expect(child.attributes['class']).toBe('hello');
+    expect(child.attributes['data-testid']).toBe('t');
+    expect(child.textContent).toBe('Hi');
+  });
+
+  it('attaches click event handlers that fire on click()', () => {
+    const dom = createDomStub();
+    const root = dom.createElement('div');
+    const handler = vi.fn();
+    mountVNode(
+      el('button', { on: { click: handler } }, [text('Go')]),
+      root,
+      dom,
+    );
+    root.children[0]!.click();
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it('toggles disabled and hidden boolean attributes', () => {
+    const dom = createDomStub();
+    const root = dom.createElement('div');
+    mountVNode(
+      el('button', { disabled: true, hidden: true }, [text('No')]),
+      root,
+      dom,
+    );
+    const btn = root.children[0]!;
+    expect(btn.disabled).toBe(true);
+    expect(btn.hidden).toBe(true);
+  });
+
+  it('renders nested children', () => {
+    const dom = createDomStub();
+    const root = dom.createElement('div');
+    mountVNode(
+      el('section', null, [
+        el('p', null, [text('a')]),
+        el('p', null, [text('b')]),
+      ]),
+      root,
+      dom,
+    );
+    expect(root.children[0]!.children).toHaveLength(2);
+  });
+});
+
+describe('applyVNode (re-render)', () => {
+  it('replaces the rendered tree on subsequent calls', () => {
+    const dom = createDomStub();
+    const root = dom.createElement('div');
+    applyVNode(el('p', null, [text('first')]), root, dom);
+    expect(root.textContent).toBe('first');
+    applyVNode(el('p', null, [text('second')]), root, dom);
+    expect(root.textContent).toBe('second');
+    expect(root.children).toHaveLength(1);
+  });
+
+  it('handles a null vnode by clearing the root', () => {
+    const dom = createDomStub();
+    const root = dom.createElement('div');
+    applyVNode(el('p', null, [text('x')]), root, dom);
+    applyVNode(null, root, dom);
+    expect(root.children).toHaveLength(0);
+  });
+});

--- a/packages/floating-hint/tests/helpers/dom-stub.ts
+++ b/packages/floating-hint/tests/helpers/dom-stub.ts
@@ -1,0 +1,87 @@
+// Minimal DOM-like stub used by dom-mount tests. Avoids pulling in jsdom/happy-dom
+// which are outside the PRD §12 catalog (BOUNDARIES.md §3).
+
+export interface StubElement {
+  tag: string;
+  attributes: Record<string, string>;
+  children: StubElement[];
+  textContent: string;
+  disabled: boolean;
+  hidden: boolean;
+  listeners: Map<string, Array<(event: unknown) => void>>;
+  appendChild(child: StubElement): StubElement;
+  removeChild(child: StubElement): void;
+  replaceChildren(...nodes: StubElement[]): void;
+  setAttribute(name: string, value: string): void;
+  removeAttribute(name: string): void;
+  addEventListener(event: string, handler: (e: unknown) => void): void;
+  click(): void;
+  remove(): void;
+}
+
+export interface DomStub {
+  createElement(tag: string): StubElement;
+  createTextNode(text: string): StubElement;
+}
+
+export function createDomStub(): DomStub {
+  function makeElement(tag: string): StubElement {
+    const el: StubElement = {
+      tag,
+      attributes: {},
+      children: [],
+      textContent: '',
+      disabled: false,
+      hidden: false,
+      listeners: new Map(),
+      appendChild(child) {
+        this.children.push(child);
+        recomputeText(this);
+        return child;
+      },
+      removeChild(child) {
+        const idx = this.children.indexOf(child);
+        if (idx >= 0) this.children.splice(idx, 1);
+        recomputeText(this);
+      },
+      replaceChildren(...nodes) {
+        this.children = nodes.slice();
+        recomputeText(this);
+      },
+      setAttribute(name, value) {
+        this.attributes[name] = value;
+      },
+      removeAttribute(name) {
+        delete this.attributes[name];
+      },
+      addEventListener(event, handler) {
+        const arr = this.listeners.get(event) ?? [];
+        arr.push(handler);
+        this.listeners.set(event, arr);
+      },
+      click() {
+        const arr = this.listeners.get('click') ?? [];
+        for (const h of arr) h({ type: 'click' });
+      },
+      remove() {
+        // Simulate detach (no parent tracking for simplicity).
+      },
+    };
+    return el;
+  }
+
+  function recomputeText(el: StubElement): void {
+    el.textContent = el.children.map((c) => c.textContent).join('');
+  }
+
+  function makeText(content: string): StubElement {
+    const el = makeElement('#text');
+    el.textContent = content;
+    return el;
+  }
+
+  return {
+    createElement: (tag) => makeElement(tag),
+    createTextNode: (s) => makeText(s),
+  };
+}

--- a/packages/floating-hint/tests/state.test.ts
+++ b/packages/floating-hint/tests/state.test.ts
@@ -1,0 +1,355 @@
+import { describe, it, expect } from 'vitest';
+import {
+  initialState,
+  reduce,
+  type AppState,
+  type Event,
+} from '../src/renderer/state/machine.js';
+
+const baseContext = {
+  itemId: 'install-homebrew',
+  stepId: 'click-lock',
+  stepIndex: 1,
+  totalSteps: 3,
+};
+
+function withContext(state: AppState): AppState {
+  return { ...state, context: { ...baseContext } };
+}
+
+describe('initialState', () => {
+  it('starts in idle with no item/step', () => {
+    expect(initialState.mode).toEqual({ kind: 'idle' });
+    expect(initialState.context.itemId).toBeNull();
+    expect(initialState.context.stepId).toBeNull();
+  });
+});
+
+describe('reduce', () => {
+  it('transitions idle → loading on REQUEST_GUIDE', () => {
+    const start = withContext(initialState);
+    const next = reduce(start, { type: 'REQUEST_GUIDE' });
+    expect(next.mode).toEqual({ kind: 'loading', pending: 'guide' });
+    expect(next.context).toEqual(start.context);
+  });
+
+  it('transitions idle → loading on REQUEST_VERIFY', () => {
+    const next = reduce(withContext(initialState), { type: 'REQUEST_VERIFY' });
+    expect(next.mode).toEqual({ kind: 'loading', pending: 'verify' });
+  });
+
+  it('refuses REQUEST_GUIDE when no current item/step', () => {
+    const next = reduce(initialState, { type: 'REQUEST_GUIDE' });
+    expect(next.mode).toEqual({ kind: 'idle' });
+  });
+
+  it('transitions loading → showing-guide on GUIDE_SUCCESS', () => {
+    const start: AppState = {
+      ...withContext(initialState),
+      mode: { kind: 'loading', pending: 'guide' },
+    };
+    const event: Event = {
+      type: 'GUIDE_SUCCESS',
+      result: {
+        type: 'guide',
+        message: '잠금 아이콘을 클릭하세요',
+        confidence: 'high',
+      },
+    };
+    const next = reduce(start, event);
+    expect(next.mode).toEqual({
+      kind: 'showing-guide',
+      result: {
+        type: 'guide',
+        message: '잠금 아이콘을 클릭하세요',
+        confidence: 'high',
+      },
+    });
+  });
+
+  it('transitions loading → showing-verify on VERIFY_SUCCESS (fail)', () => {
+    const start: AppState = {
+      ...withContext(initialState),
+      mode: { kind: 'loading', pending: 'verify' },
+    };
+    const event: Event = {
+      type: 'VERIFY_SUCCESS',
+      result: {
+        type: 'verify',
+        status: 'fail',
+        reasoning: '아직 클릭 안 했음',
+        next_action_hint: '왼쪽 아래 잠금 아이콘 클릭',
+      },
+    };
+    const next = reduce(start, event);
+    expect(next.mode).toEqual({
+      kind: 'showing-verify',
+      result: event.result,
+    });
+    expect(next.context.stepIndex).toBe(1);
+  });
+
+  it('advances stepIndex on VERIFY_SUCCESS pass when next step exists', () => {
+    const start: AppState = {
+      ...withContext(initialState),
+      mode: { kind: 'loading', pending: 'verify' },
+      stepIds: ['s0', 's1', 's2'],
+    };
+    start.context = {
+      itemId: 'i',
+      stepId: 's1',
+      stepIndex: 1,
+      totalSteps: 3,
+    };
+    const next = reduce(start, {
+      type: 'VERIFY_SUCCESS',
+      result: { type: 'verify', status: 'pass', reasoning: 'ok' },
+    });
+    expect(next.context.stepIndex).toBe(2);
+    expect(next.context.stepId).toBe('s2');
+    expect(next.mode).toEqual({
+      kind: 'showing-verify',
+      result: { type: 'verify', status: 'pass', reasoning: 'ok' },
+    });
+  });
+
+  it('keeps stepIndex on VERIFY_SUCCESS pass when no next step', () => {
+    const start: AppState = {
+      ...withContext(initialState),
+      mode: { kind: 'loading', pending: 'verify' },
+      stepIds: ['s0', 's1'],
+    };
+    start.context = {
+      itemId: 'i',
+      stepId: 's1',
+      stepIndex: 1,
+      totalSteps: 2,
+    };
+    const next = reduce(start, {
+      type: 'VERIFY_SUCCESS',
+      result: { type: 'verify', status: 'pass', reasoning: 'done' },
+    });
+    expect(next.context.stepIndex).toBe(1);
+  });
+
+  it('transitions loading → error on ERROR 503', () => {
+    const start: AppState = {
+      ...withContext(initialState),
+      mode: { kind: 'loading', pending: 'guide' },
+    };
+    const next = reduce(start, {
+      type: 'ERROR',
+      status: 503,
+      body: { error: 'vision_api_timeout' },
+    });
+    expect(next.mode).toEqual({
+      kind: 'error',
+      lastIntent: 'guide',
+      status: 503,
+      message: 'vision_api_timeout',
+    });
+  });
+
+  it('transitions loading → rate-paused on ERROR 429 paused', () => {
+    const start: AppState = {
+      ...withContext(initialState),
+      mode: { kind: 'loading', pending: 'verify' },
+    };
+    const next = reduce(start, {
+      type: 'ERROR',
+      status: 429,
+      body: {
+        error: 'rate_limit_exceeded',
+        state: 'paused',
+        reset_at: 1_700_000_000,
+      },
+    });
+    expect(next.mode).toEqual({
+      kind: 'rate-paused',
+      resetAt: 1_700_000_000,
+      lastIntent: 'verify',
+    });
+  });
+
+  it('transitions loading → error on ERROR 429 throttled (not paused)', () => {
+    const start: AppState = {
+      ...withContext(initialState),
+      mode: { kind: 'loading', pending: 'guide' },
+    };
+    const next = reduce(start, {
+      type: 'ERROR',
+      status: 429,
+      body: { error: 'rate_limit_exceeded', state: 'alert' },
+    });
+    expect(next.mode.kind).toBe('error');
+    if (next.mode.kind === 'error') {
+      expect(next.mode.status).toBe(429);
+    }
+  });
+
+  it('transitions loading → consent-blocked on ERROR 403', () => {
+    const start: AppState = {
+      ...withContext(initialState),
+      mode: { kind: 'loading', pending: 'guide' },
+    };
+    const next = reduce(start, {
+      type: 'ERROR',
+      status: 403,
+      body: { error: 'consent_required' },
+    });
+    expect(next.mode).toEqual({
+      kind: 'consent-blocked',
+      reason: 'consent_required',
+      lastIntent: 'guide',
+    });
+  });
+
+  it('transitions loading → consent-blocked on ERROR 401', () => {
+    const start: AppState = {
+      ...withContext(initialState),
+      mode: { kind: 'loading', pending: 'guide' },
+    };
+    const next = reduce(start, {
+      type: 'ERROR',
+      status: 401,
+      body: { error: 'screen_recording_permission_required' },
+    });
+    expect(next.mode).toEqual({
+      kind: 'consent-blocked',
+      reason: 'screen_recording',
+      lastIntent: 'guide',
+    });
+  });
+
+  it('falls back to generic error on unknown status', () => {
+    const start: AppState = {
+      ...withContext(initialState),
+      mode: { kind: 'loading', pending: 'guide' },
+    };
+    const next = reduce(start, {
+      type: 'ERROR',
+      status: 500,
+      body: null,
+    });
+    expect(next.mode).toEqual({
+      kind: 'error',
+      lastIntent: 'guide',
+      status: 500,
+      message: 'unknown_error',
+    });
+  });
+
+  it('RETRY from error returns to loading with last intent', () => {
+    const start: AppState = {
+      ...withContext(initialState),
+      mode: {
+        kind: 'error',
+        lastIntent: 'verify',
+        status: 503,
+        message: 'vision_api_timeout',
+      },
+    };
+    const next = reduce(start, { type: 'RETRY' });
+    expect(next.mode).toEqual({ kind: 'loading', pending: 'verify' });
+  });
+
+  it('RETRY from rate-paused returns to loading with last intent', () => {
+    const start: AppState = {
+      ...withContext(initialState),
+      mode: {
+        kind: 'rate-paused',
+        resetAt: 0,
+        lastIntent: 'guide',
+      },
+    };
+    const next = reduce(start, { type: 'RETRY' });
+    expect(next.mode).toEqual({ kind: 'loading', pending: 'guide' });
+  });
+
+  it('RETRY from idle is a no-op', () => {
+    const next = reduce(initialState, { type: 'RETRY' });
+    expect(next).toBe(initialState);
+  });
+
+  it('RESOLVE_CONSENT moves consent-blocked → idle', () => {
+    const start: AppState = {
+      ...withContext(initialState),
+      mode: {
+        kind: 'consent-blocked',
+        reason: 'consent_required',
+        lastIntent: 'guide',
+      },
+    };
+    const next = reduce(start, { type: 'RESOLVE_CONSENT' });
+    expect(next.mode).toEqual({ kind: 'idle' });
+  });
+
+  it('SET_CONTEXT updates the current item/step pointer', () => {
+    const next = reduce(initialState, {
+      type: 'SET_CONTEXT',
+      context: {
+        itemId: 'install-git',
+        stepId: 'configure-name',
+        stepIndex: 0,
+        totalSteps: 2,
+      },
+      stepIds: ['configure-name', 'configure-email'],
+    });
+    expect(next.context).toEqual({
+      itemId: 'install-git',
+      stepId: 'configure-name',
+      stepIndex: 0,
+      totalSteps: 2,
+    });
+    expect(next.stepIds).toEqual(['configure-name', 'configure-email']);
+  });
+
+  it('SET_RATE_LIMIT updates rate state without changing mode', () => {
+    const next = reduce(withContext(initialState), {
+      type: 'SET_RATE_LIMIT',
+      rateLimit: { state: 'alert', current_hour_calls: 110 },
+    });
+    expect(next.rateLimit).toEqual({ state: 'alert', current_hour_calls: 110 });
+    expect(next.mode).toEqual({ kind: 'idle' });
+  });
+
+  it('SET_CONSENTS updates consent map', () => {
+    const next = reduce(initialState, {
+      type: 'SET_CONSENTS',
+      consents: { screen_recording: true, anthropic_transmission: false },
+    });
+    expect(next.consents).toEqual({
+      screen_recording: true,
+      anthropic_transmission: false,
+    });
+  });
+
+  it('REQUEST_GUIDE while loading is rejected', () => {
+    const start: AppState = {
+      ...withContext(initialState),
+      mode: { kind: 'loading', pending: 'guide' },
+    };
+    const next = reduce(start, { type: 'REQUEST_GUIDE' });
+    expect(next).toBe(start);
+  });
+
+  it('REQUEST_GUIDE from showing-guide allowed (re-fetch)', () => {
+    const start: AppState = {
+      ...withContext(initialState),
+      mode: {
+        kind: 'showing-guide',
+        result: { type: 'guide', message: 'old', confidence: 'low' },
+      },
+    };
+    const next = reduce(start, { type: 'REQUEST_GUIDE' });
+    expect(next.mode).toEqual({ kind: 'loading', pending: 'guide' });
+  });
+
+  it('GUIDE_SUCCESS while not loading is ignored', () => {
+    const next = reduce(withContext(initialState), {
+      type: 'GUIDE_SUCCESS',
+      result: { type: 'guide', message: 'x', confidence: 'low' },
+    });
+    expect(next.mode).toEqual({ kind: 'idle' });
+  });
+});

--- a/packages/floating-hint/tests/store.test.ts
+++ b/packages/floating-hint/tests/store.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createStore } from '../src/renderer/state/store.js';
+import type { AppState } from '../src/renderer/state/machine.js';
+
+describe('createStore', () => {
+  it('exposes initial state via getState()', () => {
+    const store = createStore();
+    const s = store.getState();
+    expect(s.mode).toEqual({ kind: 'idle' });
+    expect(s.context.itemId).toBeNull();
+  });
+
+  it('notifies subscribers on dispatch', () => {
+    const store = createStore();
+    const seen: AppState[] = [];
+    const unsub = store.subscribe((s) => seen.push(s));
+    store.dispatch({
+      type: 'SET_CONTEXT',
+      context: { itemId: 'a', stepId: 'b', stepIndex: 0, totalSteps: 1 },
+      stepIds: ['b'],
+    });
+    expect(seen).toHaveLength(1);
+    expect(seen[0]?.context.itemId).toBe('a');
+    unsub();
+    store.dispatch({ type: 'REQUEST_GUIDE' });
+    expect(seen).toHaveLength(1);
+  });
+
+  it('does not notify subscribers when state is unchanged', () => {
+    const store = createStore();
+    const sub = vi.fn();
+    store.subscribe(sub);
+    store.dispatch({ type: 'RETRY' });
+    expect(sub).not.toHaveBeenCalled();
+  });
+
+  it('multiple subscribers each receive updates independently', () => {
+    const store = createStore();
+    const a = vi.fn();
+    const b = vi.fn();
+    store.subscribe(a);
+    const unsubB = store.subscribe(b);
+    store.dispatch({
+      type: 'SET_CONSENTS',
+      consents: { screen_recording: true, anthropic_transmission: true },
+    });
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+    unsubB();
+    store.dispatch({
+      type: 'SET_RATE_LIMIT',
+      rateLimit: { state: 'normal' },
+    });
+    expect(a).toHaveBeenCalledTimes(2);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+
+  it('startChecklistPoll fetches /api/checklist every interval', async () => {
+    vi.useFakeTimers();
+    try {
+      const items = [
+        {
+          id: 'install',
+          title: 't',
+          estimated_minutes: 1,
+          ai_coaching: {
+            overall_goal: 'g',
+            steps: [
+              { id: 's0', intent: 'i0', success_criteria: 'sc0' },
+              { id: 's1', intent: 'i1', success_criteria: 'sc1' },
+            ],
+          },
+        },
+      ];
+      const getChecklist = vi.fn().mockResolvedValue({
+        items: items.map((i) => ({
+          item_id: i.id,
+          title: i.title,
+          status: 'in_progress',
+          current_step: 's0',
+          started_at: 1,
+          completed_at: null,
+          attempt_count: 0,
+        })),
+      });
+      const store = createStore({
+        api: {
+          getChecklist,
+          requestGuide: vi.fn(),
+          requestVerify: vi.fn(),
+          getRateLimit: vi.fn().mockResolvedValue({ state: 'normal' }),
+          getConsents: vi.fn().mockResolvedValue({}),
+        },
+        checklist: items,
+        pollIntervalMs: 5_000,
+      });
+      store.startChecklistPoll();
+      await vi.advanceTimersByTimeAsync(0); // initial tick
+      expect(getChecklist).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(getChecklist).toHaveBeenCalledTimes(2);
+      // Resulting state reflects current item/step pulled from checklist + state
+      const s = store.getState();
+      expect(s.context.itemId).toBe('install');
+      expect(s.context.stepId).toBe('s0');
+      expect(s.context.stepIndex).toBe(0);
+      expect(s.context.totalSteps).toBe(2);
+      expect(s.stepIds).toEqual(['s0', 's1']);
+      store.stopChecklistPoll();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('requestGuide() dispatches REQUEST_GUIDE then GUIDE_SUCCESS on 200', async () => {
+    const requestGuide = vi.fn().mockResolvedValue({
+      call_id: 'vc_1',
+      cached: false,
+      latency_ms: 100,
+      result: { type: 'guide', message: 'click', confidence: 'high' },
+    });
+    const store = createStore({
+      api: {
+        getChecklist: vi.fn(),
+        requestGuide,
+        requestVerify: vi.fn(),
+        getRateLimit: vi.fn(),
+        getConsents: vi.fn(),
+      },
+    });
+    store.dispatch({
+      type: 'SET_CONTEXT',
+      context: { itemId: 'i', stepId: 's', stepIndex: 0, totalSteps: 1 },
+      stepIds: ['s'],
+    });
+    await store.requestGuide();
+    expect(requestGuide).toHaveBeenCalledWith({ item_id: 'i', step_id: 's' });
+    expect(store.getState().mode).toEqual({
+      kind: 'showing-guide',
+      result: { type: 'guide', message: 'click', confidence: 'high' },
+    });
+  });
+
+  it('requestGuide() dispatches ERROR when api throws DaemonHttpError 503', async () => {
+    const err = new (class extends Error {
+      status = 503;
+      body = { error: 'vision_api_timeout' };
+      constructor() {
+        super('boom');
+        this.name = 'DaemonHttpError';
+      }
+    })();
+    const store = createStore({
+      api: {
+        getChecklist: vi.fn(),
+        requestGuide: vi.fn().mockRejectedValue(err),
+        requestVerify: vi.fn(),
+        getRateLimit: vi.fn(),
+        getConsents: vi.fn(),
+      },
+    });
+    store.dispatch({
+      type: 'SET_CONTEXT',
+      context: { itemId: 'i', stepId: 's', stepIndex: 0, totalSteps: 1 },
+      stepIds: ['s'],
+    });
+    await store.requestGuide();
+    expect(store.getState().mode).toEqual({
+      kind: 'error',
+      lastIntent: 'guide',
+      status: 503,
+      message: 'vision_api_timeout',
+    });
+  });
+
+  it('requestGuide() dispatches generic 500 ERROR when api throws unknown', async () => {
+    const store = createStore({
+      api: {
+        getChecklist: vi.fn(),
+        requestGuide: vi.fn().mockRejectedValue(new Error('network')),
+        requestVerify: vi.fn(),
+        getRateLimit: vi.fn(),
+        getConsents: vi.fn(),
+      },
+    });
+    store.dispatch({
+      type: 'SET_CONTEXT',
+      context: { itemId: 'i', stepId: 's', stepIndex: 0, totalSteps: 1 },
+      stepIds: ['s'],
+    });
+    await store.requestGuide();
+    expect(store.getState().mode.kind).toBe('error');
+  });
+
+  it('requestVerify() dispatches REQUEST_VERIFY then VERIFY_SUCCESS', async () => {
+    const requestVerify = vi.fn().mockResolvedValue({
+      call_id: 'vc_2',
+      result: {
+        type: 'verify',
+        status: 'fail',
+        reasoning: 'not yet',
+        next_action_hint: 'try again',
+      },
+    });
+    const store = createStore({
+      api: {
+        getChecklist: vi.fn(),
+        requestGuide: vi.fn(),
+        requestVerify,
+        getRateLimit: vi.fn(),
+        getConsents: vi.fn(),
+      },
+    });
+    store.dispatch({
+      type: 'SET_CONTEXT',
+      context: { itemId: 'i', stepId: 's', stepIndex: 0, totalSteps: 1 },
+      stepIds: ['s'],
+    });
+    await store.requestVerify();
+    expect(requestVerify).toHaveBeenCalledWith({ item_id: 'i', step_id: 's' });
+    const m = store.getState().mode;
+    expect(m.kind).toBe('showing-verify');
+  });
+
+  it('retry() re-runs the last failing intent', async () => {
+    const requestGuide = vi
+      .fn()
+      .mockRejectedValueOnce(
+        Object.assign(new Error('boom'), {
+          name: 'DaemonHttpError',
+          status: 503,
+          body: { error: 'vision_api_timeout' },
+        }),
+      )
+      .mockResolvedValueOnce({
+        call_id: 'vc',
+        cached: false,
+        latency_ms: 50,
+        result: { type: 'guide', message: 'ok', confidence: 'medium' },
+      });
+    const store = createStore({
+      api: {
+        getChecklist: vi.fn(),
+        requestGuide,
+        requestVerify: vi.fn(),
+        getRateLimit: vi.fn(),
+        getConsents: vi.fn(),
+      },
+    });
+    store.dispatch({
+      type: 'SET_CONTEXT',
+      context: { itemId: 'i', stepId: 's', stepIndex: 0, totalSteps: 1 },
+      stepIds: ['s'],
+    });
+    await store.requestGuide();
+    expect(store.getState().mode.kind).toBe('error');
+    await store.retry();
+    expect(requestGuide).toHaveBeenCalledTimes(2);
+    expect(store.getState().mode).toEqual({
+      kind: 'showing-guide',
+      result: { type: 'guide', message: 'ok', confidence: 'medium' },
+    });
+  });
+
+  it('retry() with no last intent is a no-op', async () => {
+    const requestGuide = vi.fn();
+    const store = createStore({
+      api: {
+        getChecklist: vi.fn(),
+        requestGuide,
+        requestVerify: vi.fn(),
+        getRateLimit: vi.fn(),
+        getConsents: vi.fn(),
+      },
+    });
+    await store.retry();
+    expect(requestGuide).not.toHaveBeenCalled();
+  });
+});

--- a/packages/floating-hint/tests/vnode.test.ts
+++ b/packages/floating-hint/tests/vnode.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import {
+  el,
+  text,
+  findByTestId,
+  findAllByTestId,
+  findByTag,
+  type VNode,
+} from '../src/renderer/vnode.js';
+
+describe('el()', () => {
+  it('creates a vnode with tag, attrs, and children', () => {
+    const node = el('button', { className: 'btn', dataset: { testid: 'go' } }, [
+      text('Go'),
+    ]);
+    expect(node.tag).toBe('button');
+    expect(node.attrs?.className).toBe('btn');
+    expect(node.attrs?.dataset?.testid).toBe('go');
+    expect(node.children).toHaveLength(1);
+    expect(node.children?.[0]).toEqual({ tag: '#text', text: 'Go' });
+  });
+
+  it('flattens nested falsy children (null/undefined/false)', () => {
+    const node = el('div', null, [
+      text('a'),
+      null,
+      undefined,
+      false,
+      text('b'),
+    ]);
+    expect(node.children).toHaveLength(2);
+  });
+
+  it('attaches event listeners via on:event', () => {
+    const onClick = (): void => {};
+    const node = el('button', { on: { click: onClick } }, []);
+    expect(node.attrs?.on?.click).toBe(onClick);
+  });
+});
+
+describe('findByTestId', () => {
+  const tree: VNode = el('div', null, [
+    el('span', { dataset: { testid: 'a' } }, [text('A')]),
+    el('div', null, [
+      el('button', { dataset: { testid: 'b' } }, [text('B')]),
+    ]),
+  ]);
+
+  it('finds the first descendant with matching testid', () => {
+    const found = findByTestId(tree, 'a');
+    expect(found?.tag).toBe('span');
+  });
+
+  it('finds nested descendants', () => {
+    const found = findByTestId(tree, 'b');
+    expect(found?.tag).toBe('button');
+  });
+
+  it('returns null when missing', () => {
+    expect(findByTestId(tree, 'nope')).toBeNull();
+  });
+});
+
+describe('findAllByTestId', () => {
+  it('finds all matching descendants', () => {
+    const tree: VNode = el('div', null, [
+      el('span', { dataset: { testid: 'item' } }, []),
+      el('span', { dataset: { testid: 'item' } }, []),
+      el('span', { dataset: { testid: 'other' } }, []),
+    ]);
+    const matches = findAllByTestId(tree, 'item');
+    expect(matches).toHaveLength(2);
+  });
+});
+
+describe('findByTag', () => {
+  it('finds the first descendant with the given tag', () => {
+    const tree: VNode = el('div', null, [
+      el('p', null, [text('hi')]),
+      el('button', null, [text('go')]),
+    ]);
+    expect(findByTag(tree, 'button')?.tag).toBe('button');
+  });
+});
+
+describe('text()', () => {
+  it('produces a #text vnode', () => {
+    expect(text('hello')).toEqual({ tag: '#text', text: 'hello' });
+  });
+});

--- a/packages/floating-hint/vitest.config.ts
+++ b/packages/floating-hint/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
       exclude: [
         'src/main/index.ts',
         'src/preload/index.ts',
+        'src/preload/bridge.ts',
         'src/renderer/index.ts',
       ],
       thresholds: {


### PR DESCRIPTION
# Review — spec-015-fh-ui-buttons

- **Reviewer**: Claude (code reviewer agent, 읽기 전용)
- **Branch**: `feature/spec-015-fh-ui-buttons` (HEAD `a7b4e46`)
- **Spec**: [`specs/spec-015-fh-ui-buttons.md`](../specs/spec-015-fh-ui-buttons.md)
- **PRD 권위본**: `docs/PRD-MVP-SLIM.md` v0.10
- **검증 범위**: `git show HEAD` (commit `a7b4e46` — spec-015 commit only). 그 외 main..HEAD 커밋(spec-002~014)은 별도 spec에서 이미 검토됨.
- **Diff 규모**: 30 파일, +2628/-12 (모두 `packages/floating-hint/` 내부)

---

## 요약 판정

| 항목 | 판정 |
|------|------|
| 1. AC 정합성 | **PASS_WITH_WARN** |
| 2. PRD 정합성 | **PASS** |
| 3. 데이터 모델 정합성 (PRD §8) | **PASS** (N/A — SQLite 미사용 영역) |
| 4. API 계약 정합성 (PRD §9) | **PASS** |
| 5. 보안 점검 | **PASS** |
| 6. 코드 품질 | **WARN** |
| 7. BOUNDARIES.md 준수 | **PASS** |
| 8. 의존성 체크 (PRD §12) | **PASS** |

**최종 판정**: 모든 항목 PASS, FAIL 없음. 두 개 항목에 WARN 존재 → **PASS_WITH_WARN**.

---

## 1. AC 정합성 — PASS_WITH_WARN

spec-015의 13개 체크박스를 코드 위치와 함께 매핑한다.

| AC | 위치 | 결과 |
|----|------|------|
| F-P5PP-02 두 버튼 가시성 + POST 라우팅 | `src/renderer/components/ActionButtons.ts:50-74` (버튼 렌더), `src/main/daemon-client.ts:83-84` (`/api/vision/{guide,verify}` POST), `src/renderer/state/store.ts:181-209` (호출 wiring) | ✅ |
| F-P5PP-03 응답 message + 긴 텍스트 스크롤 | `src/renderer/components/ResponsePanel.ts:79-127` (`SCROLL_THRESHOLD = 200`, `dataset.scrollable`) | ✅ |
| F-P5PP-05 503 시 재시도 버튼 + 재전송 | `src/renderer/components/RetryBanner.ts:9-38`, `src/renderer/state/store.ts:225-235` (`retry()` re-runs lastIntent) | ✅ |
| F-P5PP-06 단계 N/M 미니 표시 | `src/renderer/components/ProgressBadge.ts:8-26` (`단계 {current}/{totalSteps}`) | ✅ |
| AC-VIS-06 (UI 측) 503 → RetryBanner 즉시 표시 | `state/machine.ts:104-128` `classifyError` (503은 generic error mode), `HintWindow.ts:21-24` (banner 우선순위 RetryBanner 최상단) | ✅ |
| 429-paused → RatePausedBanner + 1초 카운트다운 | `state/machine.ts:115-121` (429 + state==='paused' → rate-paused), `components/RatePausedBanner.ts:18-44` (mm:ss 포맷), `renderer/index.ts:51-53` (1s 재렌더 tick) | ✅ |
| 403 consent_required → ConsentBlocker + 설정 진입 버튼 | `state/machine.ts:112-114`, `components/ConsentBlocker.ts:9-46` (CLI 위저드 재실행 안내 카피 + `[설정 열기]` 버튼) | ✅ (단, 아래 WARN 참조) |
| verify pass → 자동 step 진행, fail → next_action_hint 표시 | `state/machine.ts:151-171` (pass 시 stepIndex 증가, stepId 갱신), `components/ResponsePanel.ts:67-77` (hint 렌더) | ✅ (단, 아래 WARN 참조) |
| 로딩 중 버튼 disabled + 스피너 | `components/ActionButtons.ts:10-12, 50-72` (loading일 때 둘 다 disabled, 활성 intent 쪽에 spinner) | ✅ |
| `pnpm test` 통과 | 116/116 PASS (실측, 아래 §실행 결과) | ✅ |
| `pnpm build` 통과 | shared 빌드 후 floating-hint 빌드 PASS | ✅ |
| `pnpm lint` 에러 0 | tsc 에러 0 (shared 빌드 후) | ✅ |
| 커버리지 ≥ 80% | lines 97.4% / branches 84.67% / functions 98.68% | ✅ |

### WARN 1: 설정 진입 버튼이 stub
- 위치: `src/renderer/index.ts:42-44`
  ```ts
  onOpenSettings: () => {
    // Phase 2 hook — for now nudge the user via the response panel.
  },
  ```
- AC 본문은 "설정 진입 버튼 (CLI 위저드 재실행 안내)"이다. ConsentBlocker 카피에 "`onboarding` CLI 위저드를 다시 실행해 동의를 갱신해주세요"가 박혀 있어서 안내 자체는 충족되지만, 버튼 클릭 시 동작이 빈 함수다. 사용자에게 표면화되는 효과가 0이다.
- 권장: 최소한 Electron `shell.openExternal` 또는 `dialog.showMessageBox`로 위저드 명령을 안내하거나, 버튼을 제거하고 카피만 남기는 편이 일관성 있다. 현재는 클릭 가능한 dead button이다.

### WARN 2: item 간 자동 진행 미구현
- AC 본문은 "verify 응답이 pass면 자동으로 다음 **step/item**으로 컨텍스트 갱신". 코드(`state/machine.ts:155-165`)는 같은 item 내 step만 advance한다. 마지막 step에서 pass가 나오면 stepIndex가 그대로 유지되어 다음 item으로 넘어가지 않는다.
- 일부 우회: 5초마다 `/api/checklist` poll (`store.ts:159-172`)이 daemon 측 진행 상태를 가져와 `SET_CONTEXT`로 갱신한다. daemon이 pass 시 자동으로 다음 item을 in_progress로 만든다면 결과적으로는 동작한다.
- 그러나 spec 본문은 클라이언트가 직접 갱신하도록 읽힌다. daemon 동작이 그렇게 갖춰졌는지는 spec-015 범위 밖이지만, 의존 검증이 spec에 명시되어 있지 않다.
- 권장: 다음 spec(또는 본 spec 후속 PR)에서 (a) daemon이 verify pass 시 다음 item 시작 처리하는 계약을 문서화, 또는 (b) 클라이언트 reducer가 stepIds 끝에 도달하면 `POST /api/items/:nextItemId/start`를 호출하도록 한다.

---

## 2. PRD 정합성 — PASS

- PRD §6.2 C (Floating Hint Window) 의도와 일치: always-on-top + IPC + AI 응답 표시.
- PRD §7.6 F-P5PP-02 ~ F-P5PP-06 모두 코드로 구현됨 (위 §1 표 참조).
- PRD §10 AC-VIS-06 UI 측 충족.
- spec 외 영역 침범 없음 (§7 참조).

---

## 3. 데이터 모델 정합성 (PRD §8) — PASS (N/A)

- spec-015은 SQLite 스키마, 데이터 보존 정책, 캡처 이미지 처리에 손대지 않는다.
- floating-hint는 메모리 상의 클라이언트 상태(`AppState`)만 관리하며 디스크 영속화 없음.
- 캡처 이미지는 daemon 영역. 이 spec에서는 응답의 텍스트 메타데이터(`message`, `confidence`, `reasoning`, `next_action_hint`)만 다룬다.

---

## 4. API 계약 정합성 (PRD §9) — PASS

`packages/floating-hint/src/main/daemon-client.ts` 가 호출하는 라우트(스펙 014에서 선언, 본 spec 015에서는 사용만):

| 라우트 | 메서드 | 위치 | PRD §9 |
|--------|-------|------|--------|
| `/api/checklist` | GET | `daemon-client.ts:80` | §9.1.1 ✓ |
| `/api/items/:itemId/start` | POST | `daemon-client.ts:81-82` | §9.1.2 ✓ |
| `/api/vision/guide` | POST | `daemon-client.ts:83` | §9.1.3 ✓ |
| `/api/vision/verify` | POST | `daemon-client.ts:84` | §9.1.4 ✓ |
| `/api/vision/rate-limit` | GET | `daemon-client.ts:85` | §9.1.5 ✓ |
| `/api/consents` | GET/POST | `daemon-client.ts:86-87` | §9.1.6 ✓ |
| `/api/clipboard` | POST | `daemon-client.ts:88` | §9.1.7 ✓ |
| `/api/verify/run` | POST | `daemon-client.ts:89` | §9.1.8 ✓ |

요청/응답 필드:
- `VisionStepInput { item_id, step_id }` ↔ PRD §9.1.3/9.1.4 Request 일치.
- 응답 필드 (`call_id`, `cached`, `latency_ms`, `result.message`, `result.highlight_region`, `result.confidence`, `result.status`, `result.reasoning`, `result.next_action_hint`)를 클라이언트가 PRD 필드명 그대로 읽음 (`store.ts:17-27`, `ResponsePanel.ts:79-96`).
- 에러 코드 매핑: 401 → screen_recording, 403 → consent_required, 429 + state==='paused' → rate-paused, 그 외 → generic error (`state/machine.ts:104-128`). PRD §9.1.3 에러 코드와 일치.

Breaking change 없음. 라우트/필드/스테이터스 의미 모두 보존.

---

## 5. 보안 점검 — PASS

- **시크릿 하드코딩**: ANTHROPIC_API_KEY 등은 floating-hint 어디에도 등장하지 않음 (grep 검증). 이 spec은 daemon HTTP 클라이언트 wrapper이므로 키 자체는 daemon이 관리.
- **SQL 인젝션**: 본 spec에 SQL 사용 없음 (SQLite는 daemon).
- **캡처 이미지 파기**: 본 spec 코드는 raw 이미지/base64를 절대 다루지 않음. `result.message`, `result.reasoning` 같은 텍스트 응답만 store에 저장. PRD §8.2 보존 정책 위반 가능성 0.
- **로그 누설**: pino 로깅은 daemon. floating-hint 측 console 로그 거의 없음 (renderer/index.ts에 `bootstrap()` 외 로그 없음 — 검증).
- **XSS 위험**: VNode 트리에서 텍스트는 `text(...)` 노드로 명시 분리되고 dom-mount에서 `createTextNode` 호출(`dom-mount.ts:68`). HTML 문자열 직접 삽입 경로 없음. AI message 텍스트도 `el('p', ..., [text(message)])` 구조라 자동 escape됨.
- **외부 origin 호출**: daemon-client는 `http://localhost:7777` 하드코딩(BOUNDARIES §5 표에 의하면 사내 비공개 URL이 아니라 로컬 호스트 → 허용).
- **민감 입력 노출**: ConsentBlocker 카피에 PII 없음.

---

## 6. 코드 품질 — WARN

### 함수 50줄 미만 규칙 위반

| 함수 | 파일 | 줄 수 | 비고 |
|------|------|-------|------|
| `reduce` | `state/machine.ts:130-196` | 67줄 | switch-case reducer; 각 case는 작지만 외곽이 50줄 초과 |
| `createStore` | `state/store.ts:92-252` | 161줄 | factory closure; 내부 helper들(`syncChecklist`, `performGuide`, `performVerify`, `requestGuide`, `requestVerify`, `retry`)을 포함 |
| `applyAttrs` | `renderer/dom-mount.ts:23-63` | 41줄 | 50 미만이지만 분기가 많음 (관성적 양호) |

- `reduce`는 reducer 패턴 관례상 단일 함수가 자연스럽다. 케이스를 별도 함수로 분리하면 가독성이 오히려 떨어진다.
- `createStore`는 closure 변수 공유를 위해 한 함수 안에 모인 것. inner 함수들은 모두 ≤30줄로 작다. 다만 외곽 함수의 총량이 161줄이라 본 spec 기준 50줄 룰을 분명히 초과한다.
- 권장: `createStore`를 명시적 클래스로 리팩터하거나 thunks(`performGuide`, `performVerify`, `retry`)를 외부 함수 + state DI로 분리. 본 spec 내에서 즉시 차단할 정도는 아니라고 판단해 WARN.

### 그 외 품질 관측 (지적사항 아님, 메모)
- 모든 컴포넌트는 `ElementVNode` 트리만 반환하는 순수 함수 → jsdom/happy-dom 없이 vitest로 단위 테스트 가능. 좋은 설계.
- 테스트 커버리지: lines 97.4% / branches 84.67% / functions 98.68%. 80% 임계 모두 통과.
- 미커버 라인은 모두 방어적 early-return 가드 (`store.ts:207-208, 233-234`, `machine.ts:153-154`). 합리적.

---

## 7. BOUNDARIES.md 준수 — PASS

`git show HEAD --stat` 검사 결과 spec-015 commit은 다음만 변경:
- `packages/floating-hint/src/preload/{bridge,index}.ts` (preload bridge 인터페이스 분리)
- `packages/floating-hint/src/renderer/**` (신규 components, state, api, dom-mount, vnode)
- `packages/floating-hint/tests/**` (신규 테스트)
- `packages/floating-hint/vitest.config.ts` (`bridge.ts` coverage 제외 추가)

- 다른 패키지(daemon, shared) 미수정.
- 루트 `package.json`, `pnpm-workspace.yaml`, `tsconfig.base.json` 미수정.
- `docs/`, `BOUNDARIES.md`, `spec-template.md`, `specs/spec-NNN-*` 미수정.

§1 (Read-Only), §2 (spec 외 패키지), §4 (API 계약 protect) 모두 준수.

---

## 8. 의존성 체크 (PRD §12) — PASS

- spec-015 commit은 `packages/floating-hint/package.json`을 변경하지 않았다 (`git diff HEAD~1 HEAD -- packages/floating-hint/package.json` 결과 비어있음).
- 따라서 본 spec에서 신규 의존성 추가 0.
- 기존 deps (spec-014에서 도입된 `@types/node`, `@vitest/coverage-v8`, `electron`, `typescript`, `vitest`, `@onboarding/shared`)는 PRD §12 카탈로그 또는 그 토착 부속(`@vitest/coverage-v8`은 vitest 공식 coverage adapter)이며, 본 spec 책임 범위 밖.
- spec 본문 §"신규 의존성" 결정과 일치: React/zustand 미도입, vanilla VNode + 자체 dom-mount로 구현.

---

## 실행 결과 (검증 명령)

```
$ pnpm install        # /Users/tao/.../wt-015-fh-ui-buttons-review (root)
... 436 packages installed ...

$ pnpm -r build
packages/shared build: Done
packages/daemon build: Done
packages/floating-hint build: Done

$ cd packages/floating-hint && pnpm lint    # tsc -p tsconfig.json
(no errors)

$ cd packages/floating-hint && pnpm test    # vitest run --coverage
 Test Files  15 passed (15)
      Tests  116 passed (116)
 Coverage:
  All files          | 97.4% lines | 84.67% branch | 98.68% func
   renderer/components| 100% / 100% / 100%
   renderer/state     | 95.13% / 72.97% / 100%
    machine.ts        | 98.29% / 85.41% / 100%   (uncovered: 153-154)
    store.ts          | 92.98% / 63.49% / 100%   (uncovered: 207-208, 233-234)
   main/daemon-client.ts | 100% / 100% / 100%
```

빌드는 의존 패키지(`@onboarding/shared`)가 먼저 컴파일된 상태에서만 통과한다. `pnpm -r build` 또는 root `pnpm build`로 워크스페이스 전체를 빌드하면 정상 동작. 단독 패키지에서 `pnpm lint`만 돌리면 `@onboarding/shared` dist가 없어 TS2307이 난다 — 이는 워크스페이스 빌드 순서 운영 이슈로, spec-015 결함 아님.

---

## 권장 후속 조치 (FAIL 아님, 리뷰어 의견)

1. **WARN 1** (Phase 2 stub): `index.ts:42-44`의 `onOpenSettings` 빈 콜백을 최소 placeholder(예: shell.openExternal로 위저드 안내 페이지 열기)로 바꾸거나, ConsentBlocker에서 버튼을 제거하고 카피만 남긴다.
2. **WARN 2** (item 간 진행): daemon이 verify pass 시 다음 item을 자동 in_progress 처리하는지 검증하는 통합 테스트를 별도 spec(예: spec-017 e2e)에서 명시한다. 또는 reducer가 stepIds 끝에 도달했을 때 명시적으로 next-item 호출을 보내도록 보강.
3. **품질 WARN**: `createStore`가 161줄로 50-line 규칙을 초과한다. 향후 리팩터 spec에서 thunks를 외부 함수 + 의존성 주입으로 분리할 것을 권장. 본 spec 통과를 막지는 않음.

---

## 완료 신호

WARN 두 개 + 품질 WARN 한 개. FAIL 없음.

<promise>SPEC_015_FH_UI_BUTTONS_REVIEW_PASS_WITH_WARN</promise>
