### PR TITLE
[Ralph] spec-016-fh-highlight-overlay

### DIFF
--- a/packages/floating-hint/scripts/copy-renderer.mjs
+++ b/packages/floating-hint/scripts/copy-renderer.mjs
@@ -8,7 +8,10 @@ import { fileURLToPath } from 'node:url';
 const here = dirname(fileURLToPath(import.meta.url));
 const pkgRoot = resolve(here, '..');
 
-const assets = [['src/renderer/index.html', 'dist/renderer/index.html']];
+const assets = [
+  ['src/renderer/index.html', 'dist/renderer/index.html'],
+  ['src/renderer/overlay/index.html', 'dist/renderer/overlay/index.html'],
+];
 
 for (const [from, to] of assets) {
   const src = resolve(pkgRoot, from);

--- a/packages/floating-hint/src/main/index.ts
+++ b/packages/floating-hint/src/main/index.ts
@@ -1,15 +1,28 @@
-import { app, BrowserWindow, screen } from 'electron';
+import { app, BrowserWindow, ipcMain, screen } from 'electron';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   assertSupportedPlatform,
   buildBrowserWindowOptions,
 } from './window-options.js';
+import {
+  createOverlayWindow,
+  registerOverlayIpc,
+  type OverlayBrowserWindowLike,
+} from './overlay-window.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const PRELOAD_PATH = path.join(__dirname, '..', 'preload', 'index.js');
 const RENDERER_HTML_PATH = path.join(__dirname, '..', 'renderer', 'index.html');
+const OVERLAY_PRELOAD_PATH = path.join(__dirname, '..', 'preload', 'overlay.js');
+const OVERLAY_HTML_PATH = path.join(
+  __dirname,
+  '..',
+  'renderer',
+  'overlay',
+  'index.html',
+);
 
 function createMainWindow(): BrowserWindow {
   const primary = screen.getPrimaryDisplay();
@@ -23,7 +36,17 @@ function createMainWindow(): BrowserWindow {
   return win;
 }
 
+function createOverlay(): OverlayBrowserWindowLike {
+  const primary = screen.getPrimaryDisplay();
+  return createOverlayWindow(BrowserWindow as never, {
+    workArea: primary.workArea,
+    preloadPath: OVERLAY_PRELOAD_PATH,
+    htmlPath: OVERLAY_HTML_PATH,
+  });
+}
+
 let mainWindow: BrowserWindow | null = null;
+let overlayWindow: OverlayBrowserWindowLike | null = null;
 
 function bootstrap(): void {
   assertSupportedPlatform(
@@ -33,9 +56,25 @@ function bootstrap(): void {
 
   void app.whenReady().then(() => {
     mainWindow = createMainWindow();
+    overlayWindow = createOverlay();
+    registerOverlayIpc(
+      ipcMain,
+      () => overlayWindow,
+      () => {
+        const display = screen.getPrimaryDisplay();
+        return {
+          width: display.workArea.width,
+          height: display.workArea.height,
+          scaleFactor: display.scaleFactor,
+        };
+      },
+    );
     app.on('activate', () => {
       if (!mainWindow || mainWindow.isDestroyed()) {
         mainWindow = createMainWindow();
+      }
+      if (!overlayWindow || overlayWindow.isDestroyed()) {
+        overlayWindow = createOverlay();
       }
     });
   });

--- a/packages/floating-hint/src/main/overlay-window.ts
+++ b/packages/floating-hint/src/main/overlay-window.ts
@@ -1,0 +1,135 @@
+// Overlay window — the full-viewport, click-through, transparent BrowserWindow
+// that draws the red highlight box (PRD F-P5PP-04, AC-VIS-09).
+//
+// Two responsibilities split for testability:
+//
+//   buildOverlayWindowOptions / createOverlayWindow
+//     pure / parameterised so tests can assert flags without touching Electron.
+//
+//   registerOverlayIpc
+//     translates `overlay:show`/`overlay:hide` IPC messages from the hint
+//     window's renderer into `overlay:render`/`overlay:clear` messages on the
+//     overlay's webContents, doing the vision-px → CSS-px conversion in the
+//     middle so the renderer doesn't need to re-implement the transform.
+
+import type { BrowserWindowConstructorOptions, Rectangle } from 'electron';
+import type { HighlightRegion } from '@onboarding/shared';
+import {
+  visionRegionToCss,
+  type DisplayMetrics,
+} from '../renderer/overlay/coords.js';
+
+export type WorkArea = Pick<Rectangle, 'x' | 'y' | 'width' | 'height'>;
+
+export interface OverlayBrowserWindowLike {
+  setAlwaysOnTop(top: boolean, level?: string): void;
+  setIgnoreMouseEvents(
+    ignore: boolean,
+    options?: { forward?: boolean },
+  ): void;
+  setVisibleOnAllWorkspaces?(
+    visible: boolean,
+    options?: { visibleOnFullScreen?: boolean },
+  ): void;
+  loadFile(path: string): Promise<void> | unknown;
+  webContents: { send(channel: string, ...args: unknown[]): void };
+  show(): void;
+  hide(): void;
+  isDestroyed(): boolean;
+}
+
+export type OverlayBrowserWindowCtor = new (
+  options: BrowserWindowConstructorOptions,
+) => OverlayBrowserWindowLike;
+
+export interface OverlayWindowOptions {
+  workArea: WorkArea;
+  preloadPath: string;
+  htmlPath: string;
+}
+
+export function buildOverlayWindowOptions(
+  workArea: WorkArea,
+  preloadPath: string,
+): BrowserWindowConstructorOptions {
+  return {
+    x: workArea.x,
+    y: workArea.y,
+    width: workArea.width,
+    height: workArea.height,
+    transparent: true,
+    backgroundColor: '#00000000',
+    frame: false,
+    alwaysOnTop: true,
+    focusable: false,
+    hasShadow: false,
+    resizable: false,
+    movable: false,
+    minimizable: false,
+    maximizable: false,
+    skipTaskbar: true,
+    show: false,
+    webPreferences: {
+      preload: preloadPath,
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+    },
+  };
+}
+
+export function createOverlayWindow(
+  BrowserWindow: OverlayBrowserWindowCtor,
+  options: OverlayWindowOptions,
+): OverlayBrowserWindowLike {
+  const win = new BrowserWindow(
+    buildOverlayWindowOptions(options.workArea, options.preloadPath),
+  );
+  // 'screen-saver' floats above normal floating windows so the overlay sits
+  // on top of system panels, the hint window, and full-screen apps.
+  win.setAlwaysOnTop(true, 'screen-saver');
+  // Click-through: we forward mouse events to the apps below so the user can
+  // keep clicking/typing into System Settings, Slack, etc. (AC-VIS-09).
+  win.setIgnoreMouseEvents(true, { forward: true });
+  if (typeof win.setVisibleOnAllWorkspaces === 'function') {
+    win.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
+  }
+  void win.loadFile(options.htmlPath);
+  return win;
+}
+
+export interface IpcMainLike {
+  on(
+    channel: string,
+    handler: (event: unknown, ...args: unknown[]) => void,
+  ): void;
+  removeAllListeners(channel: string): void;
+}
+
+export function registerOverlayIpc(
+  ipcMain: IpcMainLike,
+  getOverlay: () => OverlayBrowserWindowLike | null,
+  getDisplay: () => DisplayMetrics,
+): void {
+  ipcMain.removeAllListeners('overlay:show');
+  ipcMain.removeAllListeners('overlay:hide');
+
+  ipcMain.on('overlay:show', (_event, region: unknown) => {
+    const overlay = getOverlay();
+    if (!overlay || overlay.isDestroyed()) return;
+    const rect = visionRegionToCss(
+      region as HighlightRegion | null | undefined,
+      getDisplay(),
+    );
+    if (!rect) return;
+    overlay.webContents.send('overlay:render', rect);
+    overlay.show();
+  });
+
+  ipcMain.on('overlay:hide', () => {
+    const overlay = getOverlay();
+    if (!overlay || overlay.isDestroyed()) return;
+    overlay.webContents.send('overlay:clear');
+    overlay.hide();
+  });
+}

--- a/packages/floating-hint/src/preload/index.ts
+++ b/packages/floating-hint/src/preload/index.ts
@@ -1,4 +1,5 @@
-import { contextBridge } from 'electron';
+import { contextBridge, ipcRenderer } from 'electron';
+import type { HighlightRegion } from '@onboarding/shared';
 import {
   createDaemonClient,
   type ClipboardInput,
@@ -26,3 +27,15 @@ const exposed: DaemonClientBridge = {
 };
 
 contextBridge.exposeInMainWorld('daemonClient', exposed);
+
+export interface OverlayController {
+  show(region: HighlightRegion): void;
+  hide(): void;
+}
+
+const overlayController: OverlayController = {
+  show: (region) => ipcRenderer.send('overlay:show', region),
+  hide: () => ipcRenderer.send('overlay:hide'),
+};
+
+contextBridge.exposeInMainWorld('overlayController', overlayController);

--- a/packages/floating-hint/src/preload/overlay.ts
+++ b/packages/floating-hint/src/preload/overlay.ts
@@ -1,0 +1,30 @@
+// Preload for the overlay window. Exposes a tiny bridge for the overlay
+// renderer to subscribe to `overlay:render` and `overlay:clear` events that
+// main forwards via webContents.send().
+
+import { contextBridge, ipcRenderer } from 'electron';
+import type { CssRect } from '../renderer/overlay/coords.js';
+
+export interface OverlayBridge {
+  onRender(cb: (rect: CssRect) => void): () => void;
+  onClear(cb: () => void): () => void;
+}
+
+const bridge: OverlayBridge = {
+  onRender: (cb) => {
+    const handler = (_event: unknown, rect: CssRect): void => cb(rect);
+    ipcRenderer.on('overlay:render', handler);
+    return () => {
+      ipcRenderer.removeListener('overlay:render', handler);
+    };
+  },
+  onClear: (cb) => {
+    const handler = (): void => cb();
+    ipcRenderer.on('overlay:clear', handler);
+    return () => {
+      ipcRenderer.removeListener('overlay:clear', handler);
+    };
+  },
+};
+
+contextBridge.exposeInMainWorld('overlayBridge', bridge);

--- a/packages/floating-hint/src/renderer/api.ts
+++ b/packages/floating-hint/src/renderer/api.ts
@@ -1,6 +1,7 @@
 import type { DaemonClientBridge } from '../preload/bridge.js';
 import type {
   ChecklistResponse,
+  OverlayClient,
   RendererApi,
   VisionGuideResponse,
   VisionVerifyResponse,
@@ -38,4 +39,9 @@ export function createRendererApi(
     getRateLimit: () => bridge.getRateLimit() as Promise<RateLimitInfo>,
     getConsents: () => bridge.getConsents(),
   };
+}
+
+export function resolveOverlayClient(): OverlayClient | undefined {
+  const global = globalThis as { overlayController?: OverlayClient };
+  return global.overlayController;
 }

--- a/packages/floating-hint/src/renderer/index.ts
+++ b/packages/floating-hint/src/renderer/index.ts
@@ -6,7 +6,7 @@
 
 import { HintWindow } from './components/HintWindow.js';
 import { applyVNode, type DomLike } from './dom-mount.js';
-import { createRendererApi } from './api.js';
+import { createRendererApi, resolveOverlayClient } from './api.js';
 import { createStore } from './state/store.js';
 
 const RATE_TICK_MS = 1_000;
@@ -15,7 +15,8 @@ function bootstrap(): void {
   const root = document.getElementById('app');
   if (!root) return;
   const api = createRendererApi();
-  const store = createStore({ api });
+  const overlay = resolveOverlayClient();
+  const store = createStore({ api, overlay });
   const dom: DomLike = {
     createElement: (tag) =>
       document.createElement(tag) as unknown as ReturnType<DomLike['createElement']>,

--- a/packages/floating-hint/src/renderer/overlay/coords.ts
+++ b/packages/floating-hint/src/renderer/overlay/coords.ts
@@ -1,0 +1,68 @@
+// Coordinate transform for the highlight-region overlay.
+//
+// Vision pipeline:
+//   1. Daemon captures the screen (physical px = display.width × scaleFactor).
+//   2. sharp resizes it so the long edge is `VISION_LONG_EDGE_PX` (1568) — the
+//      Anthropic-recommended size that keeps OCR quality high while staying
+//      under the API's pixel budget.
+//   3. Claude Vision returns `highlight_region` coordinates in that resized
+//      image space.
+//
+// The overlay window covers the work area in CSS pixels (Electron positions
+// child elements in CSS px). To draw the box on the right spot we have to
+// undo step 2 (upscale to physical) and then convert physical → CSS. Both
+// corrections matter on Retina (PRD §10 AC-VIS-09 and spec-016 AC).
+
+import type { HighlightRegion } from '@onboarding/shared';
+
+export const VISION_LONG_EDGE_PX = 1568;
+
+export interface DisplayMetrics {
+  /** Work-area width in CSS pixels (e.g. `screen.getPrimaryDisplay().workArea.width`). */
+  width: number;
+  /** Work-area height in CSS pixels. */
+  height: number;
+  /** Physical-to-CSS ratio (`screen.getPrimaryDisplay().scaleFactor`). 2 on Retina. */
+  scaleFactor: number;
+}
+
+export interface CssRect {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+export function isValidRegion(value: unknown): value is HighlightRegion {
+  if (value === null || value === undefined) return false;
+  if (typeof value !== 'object') return false;
+  const r = value as Record<string, unknown>;
+  const fields = [r.x, r.y, r.width, r.height];
+  if (!fields.every((f) => typeof f === 'number' && Number.isFinite(f))) {
+    return false;
+  }
+  if ((r.x as number) < 0 || (r.y as number) < 0) return false;
+  if ((r.width as number) <= 0 || (r.height as number) <= 0) return false;
+  return true;
+}
+
+export function visionRegionToCss(
+  region: HighlightRegion | null | undefined,
+  display: DisplayMetrics,
+): CssRect | null {
+  if (!isValidRegion(region)) return null;
+  const physicalLongEdge =
+    Math.max(display.width, display.height) * display.scaleFactor;
+  const upscale =
+    physicalLongEdge > VISION_LONG_EDGE_PX
+      ? physicalLongEdge / VISION_LONG_EDGE_PX
+      : 1;
+  // ratio = (vision → physical) × (physical → CSS) = upscale / scaleFactor.
+  const ratio = upscale / display.scaleFactor;
+  return {
+    left: region.x * ratio,
+    top: region.y * ratio,
+    width: region.width * ratio,
+    height: region.height * ratio,
+  };
+}

--- a/packages/floating-hint/src/renderer/overlay/index.html
+++ b/packages/floating-hint/src/renderer/overlay/index.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'"
+    />
+    <title>Onboarding Overlay</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        width: 100%;
+        height: 100%;
+        background: transparent;
+        overflow: hidden;
+        pointer-events: none;
+      }
+
+      #overlay-box {
+        position: absolute;
+        box-sizing: border-box;
+        border: 3px solid #ff3b30;
+        border-radius: 4px;
+        box-shadow: 0 0 12px rgba(255, 59, 48, 0.4);
+        opacity: 0;
+        transform: scale(0.95);
+        transition:
+          opacity 200ms ease-out,
+          transform 200ms ease-out;
+        pointer-events: none;
+        will-change: transform, opacity;
+      }
+
+      #overlay-box.visible {
+        opacity: 1;
+        transform: scale(1);
+      }
+    </style>
+  </head>
+  <body>
+    <div id="overlay-box" hidden></div>
+    <script type="module" src="./index.js"></script>
+  </body>
+</html>

--- a/packages/floating-hint/src/renderer/overlay/index.ts
+++ b/packages/floating-hint/src/renderer/overlay/index.ts
@@ -1,0 +1,61 @@
+// Overlay renderer entry — runs inside the transparent click-through window.
+// Subscribes to `overlay:render` / `overlay:clear` events forwarded from main
+// (see preload/overlay.ts) and toggles a single absolutely-positioned div.
+//
+// Excluded from coverage: this module touches `document` and `window` and is
+// only meaningfully exercised inside an Electron renderer process.
+
+import type { CssRect } from './coords.js';
+
+interface OverlayBridge {
+  onRender(cb: (rect: CssRect) => void): () => void;
+  onClear(cb: () => void): () => void;
+}
+
+const FADE_OUT_MS = 4000;
+let timer: ReturnType<typeof setTimeout> | null = null;
+
+function getBox(): HTMLElement | null {
+  return document.getElementById('overlay-box');
+}
+
+function applyRect(box: HTMLElement, rect: CssRect): void {
+  box.style.left = `${rect.left}px`;
+  box.style.top = `${rect.top}px`;
+  box.style.width = `${rect.width}px`;
+  box.style.height = `${rect.height}px`;
+}
+
+function showRect(rect: CssRect): void {
+  const box = getBox();
+  if (!box) return;
+  applyRect(box, rect);
+  box.hidden = false;
+  // Force reflow so the .visible transition replays on a fresh region.
+  void box.offsetWidth;
+  box.classList.add('visible');
+  if (timer !== null) clearTimeout(timer);
+  timer = setTimeout(() => {
+    clearOverlay();
+  }, FADE_OUT_MS);
+}
+
+function clearOverlay(): void {
+  const box = getBox();
+  if (!box) return;
+  box.classList.remove('visible');
+  if (timer !== null) {
+    clearTimeout(timer);
+    timer = null;
+  }
+}
+
+function bootstrap(): void {
+  const bridge = (globalThis as { overlayBridge?: OverlayBridge })
+    .overlayBridge;
+  if (!bridge) return;
+  bridge.onRender((rect) => showRect(rect));
+  bridge.onClear(() => clearOverlay());
+}
+
+bootstrap();

--- a/packages/floating-hint/src/renderer/state/store.ts
+++ b/packages/floating-hint/src/renderer/state/store.ts
@@ -1,5 +1,6 @@
 import type {
   ChecklistItem,
+  HighlightRegion,
   ItemState,
   VisionGuideResult,
   VisionVerifyResult,
@@ -38,10 +39,16 @@ export interface RendererApi {
   getConsents(): Promise<unknown>;
 }
 
+export interface OverlayClient {
+  show(region: HighlightRegion): void;
+  hide(): void;
+}
+
 export interface CreateStoreOptions {
   api?: RendererApi;
   checklist?: ChecklistItem[];
   pollIntervalMs?: number;
+  overlay?: OverlayClient;
 }
 
 export interface Store {
@@ -95,6 +102,7 @@ export function createStore(options: CreateStoreOptions = {}): Store {
   const checklist = options.checklist ?? [];
   const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
   const api = options.api;
+  const overlay = options.overlay;
   let pollHandle: ReturnType<typeof setInterval> | null = null;
 
   function setState(next: AppState): void {
@@ -178,6 +186,15 @@ export function createStore(options: CreateStoreOptions = {}): Store {
     return { type: 'ERROR', status: 500, body: null };
   }
 
+  function applyGuideOverlay(result: VisionGuideResult): void {
+    if (!overlay) return;
+    if (result.highlight_region) {
+      overlay.show(result.highlight_region);
+    } else {
+      overlay.hide();
+    }
+  }
+
   async function performGuide(): Promise<void> {
     if (!api) return;
     const ctx = state.context;
@@ -187,8 +204,10 @@ export function createStore(options: CreateStoreOptions = {}): Store {
         item_id: ctx.itemId,
         step_id: ctx.stepId,
       });
+      applyGuideOverlay(res.result);
       dispatch({ type: 'GUIDE_SUCCESS', result: res.result });
     } catch (err) {
+      overlay?.hide();
       dispatch(errorEvent(err));
     }
   }
@@ -217,6 +236,7 @@ export function createStore(options: CreateStoreOptions = {}): Store {
 
   async function requestVerify(): Promise<void> {
     if (!state.context.itemId || !state.context.stepId) return;
+    overlay?.hide();
     dispatch({ type: 'REQUEST_VERIFY' });
     if (state.mode.kind !== 'loading') return;
     await performVerify();

--- a/packages/floating-hint/tests/main.smoke.test.ts
+++ b/packages/floating-hint/tests/main.smoke.test.ts
@@ -6,8 +6,9 @@ const browserWindowMock = vi.fn().mockImplementation(() => ({
   setIgnoreMouseEvents: vi.fn(),
   loadFile: vi.fn().mockResolvedValue(undefined),
   show: vi.fn(),
+  hide: vi.fn(),
   isDestroyed: () => false,
-  webContents: { on: vi.fn() },
+  webContents: { on: vi.fn(), send: vi.fn() },
   on: vi.fn(),
 }));
 
@@ -17,12 +18,19 @@ const appMock = {
   quit: vi.fn(),
 };
 
+const ipcMainMock = {
+  on: vi.fn(),
+  removeAllListeners: vi.fn(),
+};
+
 vi.mock('electron', () => ({
   app: appMock,
   BrowserWindow: browserWindowMock,
+  ipcMain: ipcMainMock,
   screen: {
     getPrimaryDisplay: () => ({
       workArea: { x: 0, y: 25, width: 1440, height: 875 },
+      scaleFactor: 2,
     }),
   },
   contextBridge: { exposeInMainWorld: vi.fn() },
@@ -45,10 +53,12 @@ afterAll(() => {
 });
 
 describe('main process smoke', () => {
-  it('boots the Electron app and creates the floating-hint BrowserWindow', async () => {
+  it('boots the Electron app and creates both the hint and overlay BrowserWindows', async () => {
     browserWindowMock.mockClear();
     appMock.whenReady.mockClear();
     appMock.on.mockClear();
+    ipcMainMock.on.mockClear();
+    ipcMainMock.removeAllListeners.mockClear();
 
     await import('../src/main/index.js');
     // Allow whenReady().then(...) microtasks to run.
@@ -56,23 +66,58 @@ describe('main process smoke', () => {
     await new Promise((resolve) => setImmediate(resolve));
 
     expect(appMock.whenReady).toHaveBeenCalled();
-    expect(browserWindowMock).toHaveBeenCalledTimes(1);
+    expect(browserWindowMock).toHaveBeenCalledTimes(2);
 
-    const opts = browserWindowMock.mock.calls[0]?.[0] as Record<string, unknown>;
-    expect(opts).toBeTruthy();
-    expect(opts.alwaysOnTop).toBe(true);
-    expect(opts.frame).toBe(false);
-    expect(opts.transparent).toBe(true);
-    expect(opts.backgroundColor).toBe('#00000000');
-    expect(opts.focusable).toBe(false);
-    expect(opts.width).toBe(360);
-    expect(opts.height).toBe(200);
+    const hintOpts = browserWindowMock.mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(hintOpts).toBeTruthy();
+    expect(hintOpts.alwaysOnTop).toBe(true);
+    expect(hintOpts.frame).toBe(false);
+    expect(hintOpts.transparent).toBe(true);
+    expect(hintOpts.backgroundColor).toBe('#00000000');
+    expect(hintOpts.focusable).toBe(false);
+    expect(hintOpts.width).toBe(360);
+    expect(hintOpts.height).toBe(200);
 
-    const winInstance = browserWindowMock.mock.results[0]?.value as {
+    const overlayOpts = browserWindowMock.mock.calls[1]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(overlayOpts).toBeTruthy();
+    expect(overlayOpts.transparent).toBe(true);
+    expect(overlayOpts.focusable).toBe(false);
+    expect(overlayOpts.hasShadow).toBe(false);
+    expect(overlayOpts.width).toBe(1440);
+    expect(overlayOpts.height).toBe(875);
+    expect(overlayOpts.show).toBe(false);
+
+    const hintWin = browserWindowMock.mock.results[0]?.value as {
       setAlwaysOnTop: ReturnType<typeof vi.fn>;
       loadFile: ReturnType<typeof vi.fn>;
     };
-    expect(winInstance.setAlwaysOnTop).toHaveBeenCalledWith(true, 'floating');
-    expect(winInstance.loadFile).toHaveBeenCalled();
+    expect(hintWin.setAlwaysOnTop).toHaveBeenCalledWith(true, 'floating');
+    expect(hintWin.loadFile).toHaveBeenCalled();
+
+    const overlayWin = browserWindowMock.mock.results[1]?.value as {
+      setAlwaysOnTop: ReturnType<typeof vi.fn>;
+      setIgnoreMouseEvents: ReturnType<typeof vi.fn>;
+      loadFile: ReturnType<typeof vi.fn>;
+    };
+    expect(overlayWin.setAlwaysOnTop).toHaveBeenCalledWith(true, 'screen-saver');
+    expect(overlayWin.setIgnoreMouseEvents).toHaveBeenCalledWith(true, {
+      forward: true,
+    });
+    expect(overlayWin.loadFile).toHaveBeenCalled();
+
+    expect(ipcMainMock.on).toHaveBeenCalledWith(
+      'overlay:show',
+      expect.any(Function),
+    );
+    expect(ipcMainMock.on).toHaveBeenCalledWith(
+      'overlay:hide',
+      expect.any(Function),
+    );
   });
 });

--- a/packages/floating-hint/tests/overlay/coords.test.ts
+++ b/packages/floating-hint/tests/overlay/coords.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest';
+import {
+  VISION_LONG_EDGE_PX,
+  isValidRegion,
+  visionRegionToCss,
+} from '../../src/renderer/overlay/coords.js';
+
+describe('VISION_LONG_EDGE_PX', () => {
+  it('matches the Anthropic recommended long-edge resize (1568px)', () => {
+    expect(VISION_LONG_EDGE_PX).toBe(1568);
+  });
+});
+
+describe('isValidRegion', () => {
+  it('accepts a positive box at the origin', () => {
+    expect(isValidRegion({ x: 0, y: 0, width: 32, height: 32 })).toBe(true);
+  });
+
+  it('rejects null / undefined', () => {
+    expect(isValidRegion(null)).toBe(false);
+    expect(isValidRegion(undefined)).toBe(false);
+  });
+
+  it('rejects non-objects', () => {
+    expect(isValidRegion('not a region')).toBe(false);
+    expect(isValidRegion(42)).toBe(false);
+  });
+
+  it('rejects missing or non-numeric fields', () => {
+    expect(isValidRegion({ x: 0, y: 0, width: 10 })).toBe(false);
+    expect(isValidRegion({ x: '0', y: 0, width: 10, height: 10 })).toBe(false);
+  });
+
+  it('rejects negative origin', () => {
+    expect(isValidRegion({ x: -1, y: 0, width: 10, height: 10 })).toBe(false);
+    expect(isValidRegion({ x: 0, y: -1, width: 10, height: 10 })).toBe(false);
+  });
+
+  it('rejects zero or negative dimensions', () => {
+    expect(isValidRegion({ x: 0, y: 0, width: 0, height: 10 })).toBe(false);
+    expect(isValidRegion({ x: 0, y: 0, width: 10, height: 0 })).toBe(false);
+    expect(isValidRegion({ x: 0, y: 0, width: -5, height: 10 })).toBe(false);
+  });
+
+  it('rejects non-finite values (NaN, Infinity)', () => {
+    expect(isValidRegion({ x: NaN, y: 0, width: 10, height: 10 })).toBe(false);
+    expect(isValidRegion({ x: 0, y: 0, width: Infinity, height: 10 })).toBe(false);
+  });
+});
+
+describe('visionRegionToCss', () => {
+  // Spec: capture is sharp-resized to long-edge 1568px before sending to Vision.
+  // Display info comes from Electron's screen.getPrimaryDisplay() (CSS work
+  // area + scaleFactor). Output is in CSS px so the renderer can position the
+  // box with `left: ...px`.
+
+  it('1568-space center maps to physical 2880x1800 Retina center (≤5px error)', () => {
+    // 14" Retina: 1440x900 CSS @ scaleFactor 2 → physical 2880x1800.
+    // sharp resize 2880 → 1568, so vision sees a 1568x980 image.
+    // Box centered on vision (784, 490) — i.e. vision top-left (768, 474) —
+    // should land centered on CSS (720, 450) ± 5 px.
+    const result = visionRegionToCss(
+      { x: 768, y: 474, width: 32, height: 32 },
+      { width: 1440, height: 900, scaleFactor: 2 },
+    );
+    expect(result).not.toBeNull();
+    if (!result) return;
+    const centerX = result.left + result.width / 2;
+    const centerY = result.top + result.height / 2;
+    expect(Math.abs(centerX - 720)).toBeLessThanOrEqual(5);
+    expect(Math.abs(centerY - 450)).toBeLessThanOrEqual(5);
+  });
+
+  it('vision (0,0) maps to display (0,0) regardless of scale', () => {
+    const result = visionRegionToCss(
+      { x: 0, y: 0, width: 32, height: 32 },
+      { width: 1440, height: 900, scaleFactor: 2 },
+    );
+    expect(result).not.toBeNull();
+    if (!result) return;
+    expect(result.left).toBeCloseTo(0, 1);
+    expect(result.top).toBeCloseTo(0, 1);
+  });
+
+  it('full vision space (1568x980) covers the full 1440x900 CSS display', () => {
+    const result = visionRegionToCss(
+      { x: 0, y: 0, width: 1568, height: 980 },
+      { width: 1440, height: 900, scaleFactor: 2 },
+    );
+    expect(result).not.toBeNull();
+    if (!result) return;
+    expect(Math.abs(result.width - 1440)).toBeLessThanOrEqual(5);
+    expect(Math.abs(result.height - 900)).toBeLessThanOrEqual(5);
+  });
+
+  it('non-Retina 1920x1080 with scaleFactor 1 upscales by 1920/1568', () => {
+    const result = visionRegionToCss(
+      { x: 0, y: 0, width: 1568, height: 882 }, // long-edge resize keeps 16:9
+      { width: 1920, height: 1080, scaleFactor: 1 },
+    );
+    expect(result).not.toBeNull();
+    if (!result) return;
+    expect(Math.abs(result.width - 1920)).toBeLessThanOrEqual(5);
+  });
+
+  it('display whose long-edge is below 1568 is not upscaled', () => {
+    // 1280x800 @ scaleFactor 1 → physical long-edge 1280 < 1568.
+    // sharp would skip the resize, so vision coords already equal physical px.
+    const result = visionRegionToCss(
+      { x: 100, y: 100, width: 50, height: 50 },
+      { width: 1280, height: 800, scaleFactor: 1 },
+    );
+    expect(result).not.toBeNull();
+    if (!result) return;
+    expect(result.left).toBeCloseTo(100, 1);
+    expect(result.top).toBeCloseTo(100, 1);
+    expect(result.width).toBeCloseTo(50, 1);
+    expect(result.height).toBeCloseTo(50, 1);
+  });
+
+  it('returns null for null / invalid regions', () => {
+    expect(
+      visionRegionToCss(null, { width: 1440, height: 900, scaleFactor: 2 }),
+    ).toBeNull();
+    expect(
+      visionRegionToCss(undefined, {
+        width: 1440,
+        height: 900,
+        scaleFactor: 2,
+      }),
+    ).toBeNull();
+    expect(
+      visionRegionToCss(
+        { x: -1, y: 0, width: 10, height: 10 },
+        { width: 1440, height: 900, scaleFactor: 2 },
+      ),
+    ).toBeNull();
+    expect(
+      visionRegionToCss(
+        { x: 0, y: 0, width: 0, height: 10 },
+        { width: 1440, height: 900, scaleFactor: 2 },
+      ),
+    ).toBeNull();
+  });
+
+  it('handles portrait-oriented displays (long-edge is height)', () => {
+    // 900x1440 portrait Retina → physical 1800x2880, long-edge 2880.
+    // Box centered at vision (490, 784) — top-left (474, 768) — should land
+    // centered at CSS (450, 720).
+    const result = visionRegionToCss(
+      { x: 474, y: 768, width: 32, height: 32 },
+      { width: 900, height: 1440, scaleFactor: 2 },
+    );
+    expect(result).not.toBeNull();
+    if (!result) return;
+    const centerY = result.top + result.height / 2;
+    expect(Math.abs(centerY - 720)).toBeLessThanOrEqual(5);
+  });
+
+  it('preserves region shape — width/height ratio is unchanged', () => {
+    const result = visionRegionToCss(
+      { x: 100, y: 100, width: 60, height: 30 },
+      { width: 1440, height: 900, scaleFactor: 2 },
+    );
+    expect(result).not.toBeNull();
+    if (!result) return;
+    expect(result.width / result.height).toBeCloseTo(2, 2);
+  });
+});

--- a/packages/floating-hint/tests/overlay/window.test.ts
+++ b/packages/floating-hint/tests/overlay/window.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  buildOverlayWindowOptions,
+  createOverlayWindow,
+  registerOverlayIpc,
+  type OverlayBrowserWindowLike,
+} from '../../src/main/overlay-window.js';
+
+describe('buildOverlayWindowOptions', () => {
+  const workArea = { x: 0, y: 0, width: 1440, height: 900 };
+  const opts = buildOverlayWindowOptions(workArea, '/path/to/overlay-preload.js');
+
+  it('produces a transparent / always-on-top / focusable=false options bag', () => {
+    expect(opts.transparent).toBe(true);
+    expect(opts.frame).toBe(false);
+    expect(opts.alwaysOnTop).toBe(true);
+    expect(opts.focusable).toBe(false);
+    expect(opts.hasShadow).toBe(false);
+  });
+
+  it('covers the entire work area (full-viewport) and starts hidden', () => {
+    expect(opts.x).toBe(0);
+    expect(opts.y).toBe(0);
+    expect(opts.width).toBe(1440);
+    expect(opts.height).toBe(900);
+    expect(opts.show).toBe(false);
+  });
+
+  it('disables window decorations and taskbar entry', () => {
+    expect(opts.resizable).toBe(false);
+    expect(opts.movable).toBe(false);
+    expect(opts.minimizable).toBe(false);
+    expect(opts.maximizable).toBe(false);
+    expect(opts.skipTaskbar).toBe(true);
+  });
+
+  it('locks down the renderer (contextIsolation, sandbox, no nodeIntegration)', () => {
+    expect(opts.webPreferences?.contextIsolation).toBe(true);
+    expect(opts.webPreferences?.nodeIntegration).toBe(false);
+    expect(opts.webPreferences?.sandbox).toBe(true);
+    expect(opts.webPreferences?.preload).toBe('/path/to/overlay-preload.js');
+  });
+
+  it('respects a non-zero work area origin (e.g. menu bar offset)', () => {
+    const o = buildOverlayWindowOptions(
+      { x: 0, y: 25, width: 1440, height: 875 },
+      '/p.js',
+    );
+    expect(o.y).toBe(25);
+    expect(o.height).toBe(875);
+  });
+});
+
+describe('createOverlayWindow', () => {
+  function mockInstance(): {
+    win: OverlayBrowserWindowLike;
+    setAlwaysOnTop: ReturnType<typeof vi.fn>;
+    setIgnoreMouseEvents: ReturnType<typeof vi.fn>;
+    setVisibleOnAllWorkspaces: ReturnType<typeof vi.fn>;
+    loadFile: ReturnType<typeof vi.fn>;
+  } {
+    const setAlwaysOnTop = vi.fn();
+    const setIgnoreMouseEvents = vi.fn();
+    const setVisibleOnAllWorkspaces = vi.fn();
+    const loadFile = vi.fn().mockResolvedValue(undefined);
+    const win: OverlayBrowserWindowLike = {
+      setAlwaysOnTop,
+      setIgnoreMouseEvents,
+      setVisibleOnAllWorkspaces,
+      loadFile,
+      show: vi.fn(),
+      hide: vi.fn(),
+      isDestroyed: vi.fn().mockReturnValue(false),
+      webContents: { send: vi.fn() },
+    };
+    return { win, setAlwaysOnTop, setIgnoreMouseEvents, setVisibleOnAllWorkspaces, loadFile };
+  }
+
+  it('uses BrowserWindow constructor with the overlay options', () => {
+    const inst = mockInstance();
+    const ctor = vi.fn().mockReturnValue(inst.win);
+    createOverlayWindow(ctor as never, {
+      workArea: { x: 0, y: 0, width: 1440, height: 900 },
+      preloadPath: '/p.js',
+      htmlPath: '/h.html',
+    });
+    expect(ctor).toHaveBeenCalledTimes(1);
+    const opts = ctor.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(opts.transparent).toBe(true);
+    expect(opts.focusable).toBe(false);
+  });
+
+  it('sets always-on-top with screen-saver level (above floating windows)', () => {
+    const inst = mockInstance();
+    const ctor = vi.fn().mockReturnValue(inst.win);
+    createOverlayWindow(ctor as never, {
+      workArea: { x: 0, y: 0, width: 1440, height: 900 },
+      preloadPath: '/p.js',
+      htmlPath: '/h.html',
+    });
+    expect(inst.setAlwaysOnTop).toHaveBeenCalledWith(true, 'screen-saver');
+  });
+
+  it('enables click-through with setIgnoreMouseEvents(true, {forward:true})', () => {
+    const inst = mockInstance();
+    const ctor = vi.fn().mockReturnValue(inst.win);
+    createOverlayWindow(ctor as never, {
+      workArea: { x: 0, y: 0, width: 1440, height: 900 },
+      preloadPath: '/p.js',
+      htmlPath: '/h.html',
+    });
+    expect(inst.setIgnoreMouseEvents).toHaveBeenCalledWith(true, {
+      forward: true,
+    });
+  });
+
+  it('makes the window visible across spaces / fullscreen', () => {
+    const inst = mockInstance();
+    const ctor = vi.fn().mockReturnValue(inst.win);
+    createOverlayWindow(ctor as never, {
+      workArea: { x: 0, y: 0, width: 1440, height: 900 },
+      preloadPath: '/p.js',
+      htmlPath: '/h.html',
+    });
+    expect(inst.setVisibleOnAllWorkspaces).toHaveBeenCalledWith(true, {
+      visibleOnFullScreen: true,
+    });
+  });
+
+  it('loads the overlay HTML file', () => {
+    const inst = mockInstance();
+    const ctor = vi.fn().mockReturnValue(inst.win);
+    createOverlayWindow(ctor as never, {
+      workArea: { x: 0, y: 0, width: 1440, height: 900 },
+      preloadPath: '/p.js',
+      htmlPath: '/abs/overlay.html',
+    });
+    expect(inst.loadFile).toHaveBeenCalledWith('/abs/overlay.html');
+  });
+});
+
+describe('registerOverlayIpc', () => {
+  function makeIpc(): {
+    on: ReturnType<typeof vi.fn>;
+    removeAllListeners: ReturnType<typeof vi.fn>;
+    fire: (channel: string, ...args: unknown[]) => void;
+  } {
+    const handlers = new Map<
+      string,
+      (event: unknown, ...args: unknown[]) => void
+    >();
+    return {
+      on: vi.fn((ch: string, h: (event: unknown, ...args: unknown[]) => void) => {
+        handlers.set(ch, h);
+      }),
+      removeAllListeners: vi.fn((ch: string) => {
+        handlers.delete(ch);
+      }),
+      fire: (ch: string, ...args: unknown[]) => {
+        const h = handlers.get(ch);
+        if (h) h({}, ...args);
+      },
+    };
+  }
+
+  function makeWindow(): OverlayBrowserWindowLike & {
+    webContents: { send: ReturnType<typeof vi.fn> };
+    show: ReturnType<typeof vi.fn>;
+    hide: ReturnType<typeof vi.fn>;
+    isDestroyed: ReturnType<typeof vi.fn>;
+  } {
+    return {
+      setAlwaysOnTop: vi.fn(),
+      setIgnoreMouseEvents: vi.fn(),
+      setVisibleOnAllWorkspaces: vi.fn(),
+      loadFile: vi.fn(),
+      webContents: { send: vi.fn() },
+      show: vi.fn(),
+      hide: vi.fn(),
+      isDestroyed: vi.fn().mockReturnValue(false),
+    };
+  }
+
+  const display = { width: 1440, height: 900, scaleFactor: 2 };
+
+  it('registers handlers for overlay:show and overlay:hide', () => {
+    const ipc = makeIpc();
+    const win = makeWindow();
+    registerOverlayIpc(ipc, () => win, () => display);
+    expect(ipc.removeAllListeners).toHaveBeenCalledWith('overlay:show');
+    expect(ipc.removeAllListeners).toHaveBeenCalledWith('overlay:hide');
+    expect(ipc.on).toHaveBeenCalledWith('overlay:show', expect.any(Function));
+    expect(ipc.on).toHaveBeenCalledWith('overlay:hide', expect.any(Function));
+  });
+
+  it('overlay:show transforms vision coords into CSS rect and shows the window', () => {
+    const ipc = makeIpc();
+    const win = makeWindow();
+    registerOverlayIpc(ipc, () => win, () => display);
+    // Box centered on vision (784, 490) — top-left (768, 474) — should land
+    // near the centre of a 1440x900 CSS Retina display.
+    ipc.fire('overlay:show', { x: 768, y: 474, width: 32, height: 32 });
+    expect(win.webContents.send).toHaveBeenCalledTimes(1);
+    const [channel, payload] = win.webContents.send.mock.calls[0] as [
+      string,
+      { left: number; top: number; width: number; height: number },
+    ];
+    expect(channel).toBe('overlay:render');
+    const cx = payload.left + payload.width / 2;
+    const cy = payload.top + payload.height / 2;
+    expect(Math.abs(cx - 720)).toBeLessThanOrEqual(5);
+    expect(Math.abs(cy - 450)).toBeLessThanOrEqual(5);
+    expect(win.show).toHaveBeenCalledTimes(1);
+  });
+
+  it('overlay:show is a no-op for invalid (negative / zero) regions', () => {
+    const ipc = makeIpc();
+    const win = makeWindow();
+    registerOverlayIpc(ipc, () => win, () => display);
+    ipc.fire('overlay:show', { x: -1, y: 0, width: 10, height: 10 });
+    ipc.fire('overlay:show', { x: 0, y: 0, width: 0, height: 0 });
+    ipc.fire('overlay:show', null);
+    expect(win.webContents.send).not.toHaveBeenCalled();
+    expect(win.show).not.toHaveBeenCalled();
+  });
+
+  it('overlay:show is a no-op when the overlay window is destroyed', () => {
+    const ipc = makeIpc();
+    const win = makeWindow();
+    win.isDestroyed.mockReturnValue(true);
+    registerOverlayIpc(ipc, () => win, () => display);
+    ipc.fire('overlay:show', { x: 0, y: 0, width: 10, height: 10 });
+    expect(win.webContents.send).not.toHaveBeenCalled();
+    expect(win.show).not.toHaveBeenCalled();
+  });
+
+  it('overlay:show is a no-op when getOverlay() returns null', () => {
+    const ipc = makeIpc();
+    registerOverlayIpc(ipc, () => null, () => display);
+    expect(() =>
+      ipc.fire('overlay:show', { x: 0, y: 0, width: 10, height: 10 }),
+    ).not.toThrow();
+  });
+
+  it('overlay:hide sends overlay:clear and hides the window', () => {
+    const ipc = makeIpc();
+    const win = makeWindow();
+    registerOverlayIpc(ipc, () => win, () => display);
+    ipc.fire('overlay:hide');
+    expect(win.webContents.send).toHaveBeenCalledWith('overlay:clear');
+    expect(win.hide).toHaveBeenCalledTimes(1);
+  });
+
+  it('overlay:hide is a no-op when overlay is missing/destroyed', () => {
+    const ipc = makeIpc();
+    const win = makeWindow();
+    win.isDestroyed.mockReturnValue(true);
+    registerOverlayIpc(ipc, () => win, () => display);
+    ipc.fire('overlay:hide');
+    expect(win.webContents.send).not.toHaveBeenCalled();
+    expect(win.hide).not.toHaveBeenCalled();
+  });
+
+  it('uses the latest display info on each show (re-evaluates the getter)', () => {
+    const ipc = makeIpc();
+    const win = makeWindow();
+    let scale = 1;
+    registerOverlayIpc(ipc, () => win, () => ({
+      width: 1920,
+      height: 1080,
+      scaleFactor: scale,
+    }));
+    ipc.fire('overlay:show', { x: 0, y: 0, width: 1568, height: 882 });
+    const first = win.webContents.send.mock.calls[0]?.[1] as { width: number };
+    expect(Math.round(first.width)).toBeCloseTo(1920, 0);
+    scale = 2;
+    win.webContents.send.mockClear();
+    ipc.fire('overlay:show', { x: 0, y: 0, width: 1568, height: 882 });
+    const second = win.webContents.send.mock.calls[0]?.[1] as { width: number };
+    // physical 3840x2160 → CSS 1920x1080, but upscale 3840/1568 = 2.4490; CSS
+    // = vision * upscale / scale = vision * 1.2245. So 1568*1.2245 ≈ 1920.
+    expect(Math.round(second.width)).toBeCloseTo(1920, 0);
+  });
+});

--- a/packages/floating-hint/tests/store-overlay.test.ts
+++ b/packages/floating-hint/tests/store-overlay.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createStore } from '../src/renderer/state/store.js';
+import type { RendererApi } from '../src/renderer/state/store.js';
+
+function makeContext() {
+  return {
+    type: 'SET_CONTEXT' as const,
+    context: { itemId: 'i', stepId: 's', stepIndex: 0, totalSteps: 1 },
+    stepIds: ['s'],
+  };
+}
+
+function baseApi(over: Partial<RendererApi> = {}): RendererApi {
+  return {
+    getChecklist: vi.fn().mockResolvedValue({ items: [] }),
+    requestGuide: vi.fn(),
+    requestVerify: vi.fn(),
+    getRateLimit: vi.fn().mockResolvedValue({ state: 'normal' }),
+    getConsents: vi.fn().mockResolvedValue({}),
+    ...over,
+  };
+}
+
+describe('createStore — overlay integration', () => {
+  it('calls overlay.show(region) when guide returns with highlight_region', async () => {
+    const overlay = { show: vi.fn(), hide: vi.fn() };
+    const api = baseApi({
+      requestGuide: vi.fn().mockResolvedValue({
+        call_id: 'vc',
+        result: {
+          type: 'guide',
+          message: 'click the icon',
+          highlight_region: { x: 24, y: 480, width: 32, height: 32 },
+          confidence: 'high',
+        },
+      }),
+    });
+    const store = createStore({ api, overlay });
+    store.dispatch(makeContext());
+    await store.requestGuide();
+    expect(overlay.show).toHaveBeenCalledTimes(1);
+    expect(overlay.show).toHaveBeenCalledWith({
+      x: 24,
+      y: 480,
+      width: 32,
+      height: 32,
+    });
+    expect(overlay.hide).not.toHaveBeenCalled();
+  });
+
+  it('calls overlay.hide when guide returns without highlight_region', async () => {
+    const overlay = { show: vi.fn(), hide: vi.fn() };
+    const api = baseApi({
+      requestGuide: vi.fn().mockResolvedValue({
+        call_id: 'vc',
+        result: {
+          type: 'guide',
+          message: 'no specific spot',
+          confidence: 'medium',
+        },
+      }),
+    });
+    const store = createStore({ api, overlay });
+    store.dispatch(makeContext());
+    await store.requestGuide();
+    expect(overlay.show).not.toHaveBeenCalled();
+    expect(overlay.hide).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the overlay before issuing a verify request', async () => {
+    const overlay = { show: vi.fn(), hide: vi.fn() };
+    const api = baseApi({
+      requestVerify: vi.fn().mockResolvedValue({
+        call_id: 'vc',
+        result: { type: 'verify', status: 'fail', reasoning: 'not yet' },
+      }),
+    });
+    const store = createStore({ api, overlay });
+    store.dispatch(makeContext());
+    await store.requestVerify();
+    expect(overlay.hide).toHaveBeenCalled();
+  });
+
+  it('hides the overlay when guide errors out', async () => {
+    const overlay = { show: vi.fn(), hide: vi.fn() };
+    const err = Object.assign(new Error('boom'), {
+      name: 'DaemonHttpError',
+      status: 503,
+      body: { error: 'vision_api_timeout' },
+    });
+    const api = baseApi({
+      requestGuide: vi.fn().mockRejectedValue(err),
+    });
+    const store = createStore({ api, overlay });
+    store.dispatch(makeContext());
+    await store.requestGuide();
+    expect(overlay.show).not.toHaveBeenCalled();
+    expect(overlay.hide).toHaveBeenCalled();
+  });
+
+  it('works without an overlay client (overlay is optional)', async () => {
+    const api = baseApi({
+      requestGuide: vi.fn().mockResolvedValue({
+        call_id: 'vc',
+        result: {
+          type: 'guide',
+          message: 'click',
+          highlight_region: { x: 1, y: 2, width: 3, height: 4 },
+          confidence: 'high',
+        },
+      }),
+    });
+    const store = createStore({ api });
+    store.dispatch(makeContext());
+    await expect(store.requestGuide()).resolves.toBeUndefined();
+    expect(store.getState().mode.kind).toBe('showing-guide');
+  });
+
+  it('hides the overlay when retry leaves error state and re-enters guide flow', async () => {
+    const overlay = { show: vi.fn(), hide: vi.fn() };
+    const requestGuide = vi
+      .fn()
+      .mockRejectedValueOnce(
+        Object.assign(new Error('boom'), {
+          name: 'DaemonHttpError',
+          status: 503,
+          body: { error: 'vision_api_timeout' },
+        }),
+      )
+      .mockResolvedValueOnce({
+        call_id: 'vc',
+        result: {
+          type: 'guide',
+          message: 'now click here',
+          highlight_region: { x: 5, y: 6, width: 7, height: 8 },
+          confidence: 'high',
+        },
+      });
+    const store = createStore({ api: baseApi({ requestGuide }), overlay });
+    store.dispatch(makeContext());
+    await store.requestGuide();
+    expect(overlay.hide).toHaveBeenCalledTimes(1);
+    overlay.hide.mockClear();
+    overlay.show.mockClear();
+    await store.retry();
+    expect(overlay.show).toHaveBeenCalledWith({
+      x: 5,
+      y: 6,
+      width: 7,
+      height: 8,
+    });
+  });
+});

--- a/packages/floating-hint/vitest.config.ts
+++ b/packages/floating-hint/vitest.config.ts
@@ -11,7 +11,9 @@ export default defineConfig({
         'src/main/index.ts',
         'src/preload/index.ts',
         'src/preload/bridge.ts',
+        'src/preload/overlay.ts',
         'src/renderer/index.ts',
+        'src/renderer/overlay/index.ts',
       ],
       thresholds: {
         lines: 80,


### PR DESCRIPTION
# Code Review — spec-016-fh-highlight-overlay

- **Spec**: [specs/spec-016-fh-highlight-overlay.md](../specs/spec-016-fh-highlight-overlay.md)
- **PRD**: docs/PRD-MVP-SLIM.md (v0.10)
- **브랜치 / 커밋**: `feature/spec-016-fh-highlight-overlay` @ `3caa434`
- **검토 범위**: `git diff main...HEAD` 중 `3caa434` 커밋의 변경분 (16 files, +1096 / −20)
- **검토일**: 2026-05-01
- **검토자**: code-reviewer agent

## 종합 판정

| 항목 | 판정 |
|------|------|
| 1. AC 정합성 | **PASS (with WARN)** |
| 2. PRD 정합성 | **PASS** |
| 3. 데이터 모델 정합성 | **PASS** (해당 없음) |
| 4. API 계약 정합성 | **PASS** (해당 없음) |
| 5. 보안 점검 | **PASS** |
| 6. 코드 품질 | **PASS** |
| 7. BOUNDARIES.md 준수 | **PASS** |
| 8. 의존성 체크 | **PASS** |

**최종**: WARN만 1건. FAIL 없음.

---

## 1. AC 정합성 (PRD §10) — PASS (with WARN)

spec의 Acceptance Criteria 11개 항목 점검.

| AC | 충족 코드 | 결과 |
|----|----------|------|
| F-P5PP-04 (highlight_region → 빨간 박스) | `src/main/overlay-window.ts:117-127`(IPC handler) + `src/renderer/overlay/index.html:23-35`(스타일) + `src/renderer/overlay/index.ts:29-41`(rendering) | PASS |
| AC-VIS-09 (오버레이 비간섭) | `src/main/overlay-window.ts:64`(`focusable:false`) + `:93`(`setIgnoreMouseEvents(true,{forward:true})`) | PASS |
| 좌표 환산(≤5px) — sharp 리사이즈 비율 + scaleFactor | `src/renderer/overlay/coords.ts:49-68`(visionRegionToCss). `tests/overlay/coords.test.ts:57-104`에서 14" Retina 중심점·full-space·portrait·non-Retina·low-DPI no-upscale 케이스 모두 ≤5px 검증 | PASS |
| 음수/0/null 안전장치 | `src/renderer/overlay/coords.ts:36-47`(isValidRegion) + IPC handler가 `visionRegionToCss` null 결과 시 no-op (`overlay-window.ts:124`) | PASS |
| 4초 자동 fade-out, 새 응답 도착 시 즉시 갱신 | `src/renderer/overlay/index.ts:15`(`FADE_OUT_MS = 4000`), `:34`(force reflow `void box.offsetWidth` → transition replay), `:37-40`(timer 리셋) | PASS |
| 다중 모니터 → primary display만 | `src/main/index.ts:40,64`(`screen.getPrimaryDisplay()`) | PASS |
| `pnpm test` 통과 | 18 files / 156 tests pass — `pnpm --filter @onboarding/floating-hint test` | PASS |
| `pnpm build` 통과 | tsc + copy-renderer.mjs 모두 정상 | PASS |
| `pnpm lint` 에러 0 | tsc -p tsconfig.json 에러 0 | PASS |
| 테스트 커버리지 ≥ 80% | **97.41% lines / 97.59% funcs / 86.75% branches** (overlay/coords.ts: 100%, main/overlay-window.ts: 100%) | PASS |
| BOUNDARIES.md 준수 | §7 참조 | PASS |
| 신규 의존성 없음 | §8 참조 | PASS |

### WARN-1: "다음 step 진입 시 overlay:hide" 부분 미구현
spec 본문(`출력` 섹션)에 다음 요구가 있다.
> store.ts 갱신 — guide 응답에 region 포함되면 자동 `overlay:show` 호출, **다음 step 진입 또는 verify 호출 시 `overlay:hide`**

구현 상태(`src/renderer/state/store.ts`):
- `requestVerify()` 진입 시 `overlay?.hide()` ✓ (line 239)
- guide 응답에 region 없음 / guide 에러 → `overlay.hide()` ✓ (lines 193-195, 210)
- **`SET_CONTEXT`로 stepId가 바뀔 때 overlay.hide() 호출 없음** ✗

영향: 사용자가 step을 완료해 진행률이 다음 step으로 넘어가도, 4초 자동 페이드아웃까지 이전 박스가 화면에 남는다.

완화 요인:
- 4초 fade-out (`FADE_OUT_MS = 4000`)이 자연스럽게 처리
- spec AC 항목(체크리스트)에는 명시되지 않음 — 본문 출력 명세에만 등장
- 다음 guide 호출 시 새 region으로 즉시 갱신됨

권장 조치(non-blocking): `store.ts`의 `dispatch(SET_CONTEXT)` 직후 stepId가 바뀌면 `overlay?.hide()` 호출. ~3 라인 추가.

---

## 2. PRD 정합성 — PASS

- **PRD §6.1 아키텍처**(빨간 박스 오버레이) — 별도 transparent BrowserWindow로 구현. ✓
- **PRD §7.6 F-P5PP-04**(별도 투명 윈도우) — `overlay-window.ts`로 hint window와 별도 분리. ✓
- **PRD §10 AC-VIS-09**(Hint Window 비간섭) — `focusable:false` + `setIgnoreMouseEvents(true,{forward:true})`. ✓
- **PRD §9.1.3**(`highlight_region` 응답) — shared의 `HighlightRegion` 타입을 그대로 소비, 임의 변경 없음. ✓
- spec 외 영역 침범 없음 (§7 BOUNDARIES 참조).

---

## 3. 데이터 모델 정합성 (PRD §8) — PASS (해당 없음)

이 spec은 SQLite 스키마를 다루지 않는다. `git show 3caa434 --stat`상 `packages/daemon/src/db/`·migrations 어떤 파일도 변경되지 않았다. 임의 신규 타입 도입도 없으며, `HighlightRegion`은 shared에 spec-001에서 이미 정의된 것을 import만 한다.

---

## 4. API 계약 정합성 (PRD §9) — PASS (해당 없음)

Daemon HTTP API(§9.1)는 변경되지 않았다. 추가된 IPC 채널 `overlay:show / overlay:hide / overlay:render / overlay:clear`는 floating-hint 패키지 내부 main↔renderer 통신으로, PRD §9 보호 대상(localhost:7777 라우트)이 아니다. Breaking change 없음.

---

## 5. 보안 점검 — PASS

- **시크릿 하드코딩**: 없음. 변경 파일에서 `sk-`, `secret`, API 키, 이메일, 사내 URL 등 어떤 평문 자격증명도 발견되지 않음.
- **SQL 인젝션**: 해당 없음(DB 미사용 spec).
- **캡처 이미지 파기 (PRD §8.2)**: 해당 없음 — overlay는 좌표(`HighlightRegion`)만 IPC로 받고, raw image / base64를 다루지 않는다. AC-VIS-07 대상 코드는 daemon에 격리되어 있어 본 spec 영향 외.
- **Renderer 격리**(추가 보안 점검):
  - `buildOverlayWindowOptions`: `contextIsolation:true`, `nodeIntegration:false`, `sandbox:true` — 안전한 설정 (`overlay-window.ts:72-77`).
  - 오버레이 HTML CSP: `default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'` — 외부 스크립트 차단, inline style만 허용 (`overlay/index.html:7`).
  - preload `overlay.ts`: `contextBridge.exposeInMainWorld`로 `overlayBridge`만 노출, ipcRenderer 직접 노출 없음.
  - `overlayController` (preload/index.ts:36-39): `ipcRenderer.send`만 사용. `ipcRenderer.on`은 미노출 — 권한 분리 적절.

---

## 6. 코드 품질 — PASS

### 함수 길이 (50줄 미만)
| 함수 | 줄 수 |
|------|-------|
| `buildOverlayWindowOptions` | 29 |
| `createOverlayWindow` | 19 |
| `registerOverlayIpc` | 27 |
| `isValidRegion` | 12 |
| `visionRegionToCss` | 20 |
| overlay/index.ts `showRect` | 13 |
| main/index.ts `bootstrap` | 37 |

모두 50줄 이내.

### 테스트 커버리지 (≥80%)
실측치(`vitest run --coverage`):

```
All files          |   97.41 |    86.75 |   97.59 |   97.41
 main              |     100 |      100 |      95 |     100
  overlay-window.ts |     100 |      100 |     100 |     100
 renderer/overlay  |     100 |      100 |     100 |     100
  coords.ts        |     100 |      100 |     100 |     100
```

신규 모듈(coords, overlay-window) 모두 100%. vitest.config.ts는 IPC 부트스트랩 모듈(`overlay/index.ts`, `preload/overlay.ts`)을 coverage exclude했는데 이는 합리적이다(`document`/`window`/Electron 의존, smoke test로 별도 보장).

### 그 외
- 모듈 분리(pure transform / window factory / IPC bridge) 명확.
- 주석은 WHY 위주(WHY 좌표 두 번 보정해야 하는지, WHY screen-saver 레벨인지)로 적절. 잡소리 없음.
- 테스트가 spec의 모든 핵심 시나리오(중심점, 풀 스페이스, portrait, no-upscale, invalid region, IPC no-op 경로)를 커버.

---

## 7. BOUNDARIES.md 준수 — PASS

- **§1 Read-only 파일**: PRD, BOUNDARIES, spec-template, archive, .git, 다른 spec 파일 — 어느 것도 수정 안 됨. ✓
- **§2 spec 외 패키지 경로**: 변경된 16개 파일 모두 `packages/floating-hint/` 내부. shared / daemon / cli / 루트 워크스페이스 무손. ✓
- **§3 신규 외부 의존성**: §8 참조.
- **§4 API 계약**: §4 참조 — 변경 없음.
- **§5 시크릿**: §5 참조 — 평문 시크릿 없음.

---

## 8. 의존성 체크 — PASS

`git show 3caa434 -- packages/floating-hint/package.json` → 출력 없음(변경 없음).
`git show 3caa434 -- package.json pnpm-lock.yaml pnpm-workspace.yaml` → 출력 없음.

신규 의존성 0건. PRD §12 화이트리스트와 완전 일치.

---

## 부록 A — 검증 명령 / 결과

```bash
# 모두 worktree root에서 실행
pnpm install                                     # OK
pnpm --filter @onboarding/shared build           # OK (lint/build 선결 조건)
pnpm --filter @onboarding/floating-hint lint     # exit 0
pnpm --filter @onboarding/floating-hint build    # exit 0, dist/renderer/overlay/index.html 생성
pnpm --filter @onboarding/floating-hint test     # 18 files, 156/156 pass, 97.41% lines
```

## 부록 B — 권장 후속 조치 (non-blocking)

1. **WARN-1 보완**: `store.ts`에서 `SET_CONTEXT`가 stepId를 변경했을 때 `overlay?.hide()` 호출. 4초 fade-out과 중복돼도 무해.
2. (관찰) Phase 2 비범위 항목으로 명시되어 있어 별도 조치 불필요하지만, 다중 모니터 시 캡처 모니터 추적은 추후 개선 여지.

---

<promise>SPEC_016_FH_HIGHLIGHT_OVERLAY_REVIEW_PASS_WITH_WARN</promise>
